### PR TITLE
fix(release): add install instructions to release body and bump version to 0.2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,24 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
+          body: |
+            ## Install
+
+            **macOS / Linux**
+            ```sh
+            curl -fsSL https://resend.com/install.sh | bash
+            ```
+
+            **Windows (PowerShell)**
+            ```pwsh
+            irm https://resend.com/install.ps1 | iex
+            ```
+
+            **GitHub CLI** _(use while repo is private)_
+            ```sh
+            gh release download --repo resend/resend-cli --pattern "resend-darwin-arm64.tar.gz"
+            tar -xzf resend-darwin-arm64.tar.gz && sudo mv resend /usr/local/bin/ && rm resend-darwin-arm64.tar.gz
+            ```
           files: |
             dist/resend-darwin-arm64.tar.gz
             dist/resend-darwin-x64.tar.gz

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@resend/cli",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Resend CLI — email for developers",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

- Adds a `body:` to the `Create GitHub Release` step in `release.yml` so every future release automatically includes install instructions — no more manually patching the release page after the fact
- Shows two install options: `resend.com/install.sh` (intended long-term) and `gh release download` (works now while the repo is private)
- Bumps `package.json` version from `0.1.0` → `0.2.0` so `resend --version` reports the correct version (the CLI reads its version directly from `package.json` via `src/lib/version.ts`)

## Test plan

- [ ] Merge and push a new tag — confirm the GitHub release page shows the Install section automatically
- [ ] Run `gh release download v0.2.0 --repo resend/resend-cli --pattern "resend-darwin-arm64.tar.gz"` and verify the binary installs and reports `0.2.0`
- [ ] Once `resend.com/install.sh` is live, verify `curl -fsSL https://resend.com/install.sh | bash` works end to end