### PR TITLE
feat: add rm alias to all delete commands

### DIFF
--- a/src/commands/api-keys/delete.ts
+++ b/src/commands/api-keys/delete.ts
@@ -4,6 +4,7 @@ import type { GlobalOpts } from '../../lib/client';
 import { buildHelpText } from '../../lib/help-text';
 
 export const deleteApiKeyCommand = new Command('delete')
+  .alias('rm')
   .description(
     'Delete an API key — any services using it will immediately lose access',
   )

--- a/src/commands/broadcasts/delete.ts
+++ b/src/commands/broadcasts/delete.ts
@@ -4,6 +4,7 @@ import type { GlobalOpts } from '../../lib/client';
 import { buildHelpText } from '../../lib/help-text';
 
 export const deleteBroadcastCommand = new Command('delete')
+  .alias('rm')
   .description(
     'Delete a broadcast — draft broadcasts are removed; scheduled broadcasts are cancelled before delivery',
   )

--- a/src/commands/contact-properties/delete.ts
+++ b/src/commands/contact-properties/delete.ts
@@ -4,6 +4,7 @@ import type { GlobalOpts } from '../../lib/client';
 import { buildHelpText } from '../../lib/help-text';
 
 export const deleteContactPropertyCommand = new Command('delete')
+  .alias('rm')
   .description('Delete a contact property definition')
   .argument('<id>', 'Contact property UUID')
   .option(

--- a/src/commands/contacts/delete.ts
+++ b/src/commands/contacts/delete.ts
@@ -4,6 +4,7 @@ import type { GlobalOpts } from '../../lib/client';
 import { buildHelpText } from '../../lib/help-text';
 
 export const deleteContactCommand = new Command('delete')
+  .alias('rm')
   .description('Delete a contact')
   .argument(
     '<id>',

--- a/src/commands/domains/delete.ts
+++ b/src/commands/domains/delete.ts
@@ -4,6 +4,7 @@ import type { GlobalOpts } from '../../lib/client';
 import { buildHelpText } from '../../lib/help-text';
 
 export const deleteDomainCommand = new Command('delete')
+  .alias('rm')
   .description('Delete a domain')
   .argument('<id>', 'Domain ID')
   .option('--yes', 'Skip confirmation prompt')

--- a/src/commands/segments/delete.ts
+++ b/src/commands/segments/delete.ts
@@ -4,6 +4,7 @@ import type { GlobalOpts } from '../../lib/client';
 import { buildHelpText } from '../../lib/help-text';
 
 export const deleteSegmentCommand = new Command('delete')
+  .alias('rm')
   .description('Delete a segment')
   .argument('<id>', 'Segment UUID')
   .option(

--- a/src/commands/topics/delete.ts
+++ b/src/commands/topics/delete.ts
@@ -4,6 +4,7 @@ import type { GlobalOpts } from '../../lib/client';
 import { buildHelpText } from '../../lib/help-text';
 
 export const deleteTopicCommand = new Command('delete')
+  .alias('rm')
   .description('Delete a topic')
   .argument('<id>', 'Topic UUID')
   .option(

--- a/src/commands/webhooks/delete.ts
+++ b/src/commands/webhooks/delete.ts
@@ -4,6 +4,7 @@ import type { GlobalOpts } from '../../lib/client';
 import { buildHelpText } from '../../lib/help-text';
 
 export const deleteWebhookCommand = new Command('delete')
+  .alias('rm')
   .description('Delete a webhook endpoint and stop all event deliveries to it')
   .argument('<id>', 'Webhook UUID')
   .option(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added rm alias to all delete commands to match Unix conventions and speed up CLI usage. Applies to API keys, broadcasts, contact properties, contacts, domains, segments, topics, and webhooks.

<sup>Written for commit 4a8463f20ee2c5a16fa253f3b23a0eb809fb339f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

