### PR TITLE
feat: add open command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,11 +9,11 @@ import { contactsCommand } from './commands/contacts/index';
 import { doctorCommand } from './commands/doctor';
 import { domainsCommand } from './commands/domains/index';
 import { emailsCommand } from './commands/emails/index';
+import { openCommand } from './commands/open';
 import { segmentsCommand } from './commands/segments/index';
 import { teamsCommand } from './commands/teams/index';
 import { topicsCommand } from './commands/topics/index';
 import { webhooksCommand } from './commands/webhooks/index';
-import { openCommand } from './commands/open';
 import { whoamiCommand } from './commands/whoami';
 import { PACKAGE_NAME, VERSION } from './lib/version';
 

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -13,12 +13,12 @@ export const openCommand = new Command('open')
   .action(async () => {
     const url = 'https://resend.com/emails';
     const { platform } = process;
-    const cmd =
+    const args =
       platform === 'darwin'
-        ? 'open'
+        ? ['open', url]
         : platform === 'win32'
-          ? 'start'
-          : 'xdg-open';
+          ? ['cmd', '/c', 'start', url]
+          : ['xdg-open', url];
 
-    Bun.spawn([cmd, url], { stdio: ['ignore', 'ignore', 'ignore'] });
+    Bun.spawn(args, { stdio: ['ignore', 'ignore', 'ignore'] });
   });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an `open` command that launches https://resend.com/emails in your default browser on macOS, Windows, and Linux, with help text and a Windows `start` fix.

<sup>Written for commit e893bac490fbc7f0451f8f6a5944c62cc6406a8d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

