### PR TITLE
feat: remove private repo reference

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,12 +64,6 @@ jobs:
             ```pwsh
             irm https://resend.com/install.ps1 | iex
             ```
-
-            **GitHub CLI** _(use while repo is private)_
-            ```sh
-            gh release download --repo resend/resend-cli --pattern "resend-darwin-arm64.tar.gz"
-            tar -xzf resend-darwin-arm64.tar.gz && sudo mv resend /usr/local/bin/ && rm resend-darwin-arm64.tar.gz
-            ```
           files: |
             dist/resend-darwin-arm64.tar.gz
             dist/resend-darwin-x64.tar.gz


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the private-repo GitHub CLI download instructions from `.github/workflows/release.yml`, leaving only the standard installer path to simplify the release step and avoid confusion.

<sup>Written for commit 3e561961b9d881cb271fc8dcbfaecaeda02546f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

