### PR TITLE
feat: configure user agent

### DIFF
--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -1,6 +1,7 @@
 import { Resend } from 'resend';
 import { resolveApiKey } from './config';
 import { errorMessage, outputError } from './output';
+import { VERSION } from './version';
 
 export type GlobalOpts = {
   apiKey?: string;
@@ -8,6 +9,8 @@ export type GlobalOpts = {
   quiet?: boolean;
   team?: string;
 };
+
+process.env.RESEND_USER_AGENT = `resend-cli:${VERSION}`;
 
 export function createClient(flagValue?: string, teamName?: string): Resend {
   const resolved = resolveApiKey(flagValue, teamName);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Configure a custom user agent for all Resend API requests from the CLI using the current CLI version. This improves request attribution and debugging on the server side.

- **New Features**
  - Sets process.env.RESEND_USER_AGENT to "resend-cli:${VERSION}" during client setup so the Resend SDK sends a versioned user agent.

<sup>Written for commit 309e766f649a2fea5925728c14b69c24080e5fbf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

