### PR TITLE
feat: add email list command

### DIFF
--- a/src/commands/emails/index.ts
+++ b/src/commands/emails/index.ts
@@ -1,6 +1,7 @@
 import { Command } from '@commander-js/extra-typings';
 import { buildHelpText } from '../../lib/help-text';
 import { batchCommand } from './batch';
+import { listEmailsCommand } from './list';
 import { receivingCommand } from './receiving/index';
 import { sendCommand } from './send';
 
@@ -10,6 +11,7 @@ export const emailsCommand = new Command('emails')
     'after',
     buildHelpText({
       examples: [
+        'resend emails list',
         'resend emails send --from you@domain.com --to user@example.com --subject "Hello" --text "Hi"',
         'resend emails batch --file ./emails.json',
         'resend emails receiving list',
@@ -19,6 +21,7 @@ export const emailsCommand = new Command('emails')
       ],
     }),
   )
+  .addCommand(listEmailsCommand, { isDefault: true })
   .addCommand(sendCommand)
   .addCommand(batchCommand)
   .addCommand(receivingCommand);

--- a/src/commands/emails/list.ts
+++ b/src/commands/emails/list.ts
@@ -1,0 +1,84 @@
+import { Command } from '@commander-js/extra-typings';
+import { runList } from '../../lib/actions';
+import type { GlobalOpts } from '../../lib/client';
+import { buildHelpText } from '../../lib/help-text';
+import {
+  buildPaginationOpts,
+  parseLimitOpt,
+  printPaginationHint,
+} from '../../lib/pagination';
+import { renderTable } from '../../lib/table';
+
+type SentEmail = {
+  id: string;
+  to: string[];
+  from: string;
+  created_at: string;
+  subject: string;
+  last_event: string | null;
+  scheduled_at: string | null;
+};
+
+function renderSentEmailsTable(emails: SentEmail[]): string {
+  const rows = emails.map((e) => {
+    const to = e.to.join(', ');
+    const toStr = to.length > 40 ? `${to.slice(0, 37)}...` : to;
+    const subject =
+      e.subject.length > 50 ? `${e.subject.slice(0, 47)}...` : e.subject;
+    return [e.from, toStr, subject, e.last_event ?? '—', e.created_at, e.id];
+  });
+  return renderTable(
+    ['From', 'To', 'Subject', 'Status', 'Created', 'ID'],
+    rows,
+    '(no sent emails)',
+  );
+}
+
+export const listEmailsCommand = new Command('list')
+  .alias('ls')
+  .description(
+    'List sent emails — returns summary (use "get <id>" for full details)',
+  )
+  .option('--limit <n>', 'Maximum number of emails to return (1-100)', '10')
+  .option(
+    '--after <cursor>',
+    'Cursor for forward pagination — list items after this ID',
+  )
+  .option(
+    '--before <cursor>',
+    'Cursor for backward pagination — list items before this ID',
+  )
+  .addHelpText(
+    'after',
+    buildHelpText({
+      context: `Lists emails sent by your team. For emails received by your domain, use: resend emails receiving list`,
+      output: `  {"object":"list","has_more":false,"data":[{"id":"...","to":["..."],"from":"...","subject":"...","created_at":"...","last_event":"delivered|opened|...","scheduled_at":null}]}`,
+      errorCodes: ['auth_error', 'invalid_limit', 'list_error'],
+      examples: [
+        'resend emails list',
+        'resend emails list --limit 5',
+        'resend emails list --after <email-id> --limit 10',
+        'resend emails list --json',
+      ],
+    }),
+  )
+  .action(async (opts, cmd) => {
+    const globalOpts = cmd.optsWithGlobals() as GlobalOpts;
+    const limit = parseLimitOpt(opts.limit, globalOpts);
+    const paginationOpts = buildPaginationOpts(limit, opts.after, opts.before);
+    await runList(
+      {
+        spinner: {
+          loading: 'Fetching sent emails...',
+          success: 'Sent emails fetched',
+          fail: 'Failed to list emails',
+        },
+        sdkCall: (resend) => resend.emails.list(paginationOpts),
+        onInteractive: (list) => {
+          console.log(renderSentEmailsTable(list.data));
+          printPaginationHint(list);
+        },
+      },
+      globalOpts,
+    );
+  });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a new `emails list` command to the CLI to view sent emails with pagination and a clean table output. Also sets `list` as the default `emails` subcommand.

- **New Features**
  - Adds `emails list` (alias `ls`) to fetch sent emails; shows From, To, Subject, Status, Created, and ID.
  - Supports `--limit`, `--after`, and `--before`; prints pagination hints.
  - Respects `--json` for raw output; otherwise renders a truncated table for readability.
  - Updates `emails` help examples and makes `list` the default subcommand.

<sup>Written for commit 11d05b713f448095c8e17aff859126c81b64267c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

