### PR TITLE
chore: remove duplicated success message

### DIFF
--- a/src/commands/api-keys/create.ts
+++ b/src/commands/api-keys/create.ts
@@ -100,8 +100,7 @@ Permissions:
             ...(opts.domainId && { domain_id: opts.domainId }),
           }),
         onInteractive: (d) => {
-          console.log('\nAPI key created!\n');
-          console.log(`  Name:    ${name}`);
+          console.log(`\n  Name:    ${name}`);
           console.log(`  ID:      ${d.id}`);
           console.log(`  Token:   ${d.token}`);
           console.log(


### PR DESCRIPTION
<img width="442" height="129" alt="image" src="https://github.com/user-attachments/assets/3efdc71d-931a-43cc-be72-f91245620524" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the duplicate "API key created!" message in the `api-keys create` command to prevent redundant logs and keep the success output clean. The Name/ID/Token details remain unchanged.

<sup>Written for commit 229c35945027c919d3814daddae33f41442387e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

