### PR TITLE
chore: standardize lint command

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "dev:watch": "tsx --watch src/cli.ts",
     "build": "esbuild src/cli.ts --bundle --platform=node --format=cjs --minify --outfile=dist/cli.cjs",
     "build:bin": "pnpm build && pkg dist/cli.cjs --compress Brotli --target node24 --output dist/resend",
-    "lint": "biome check",
-    "format": "biome format --write",
+    "lint": "biome check .",
+    "lint:fix": "biome check --write .",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:e2e": "vitest run --config vitest.config.e2e.ts"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardized lint scripts to use `biome` consistently and make the target explicit. `lint` runs `biome check .`, new `lint:fix` runs `biome check --write .`, and the old `format` script was removed.

<sup>Written for commit c6bd7ae657bf08119c03b702d35879a3f4f20623. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

