### PR TITLE
chore: update install and release instructions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,19 +223,24 @@ jobs:
           body: |
             ## Install
 
-            **macOS / Linux**
+            **cURL**
             ```sh
             curl -fsSL https://resend.com/install.sh | bash
             ```
 
-            **Windows (PowerShell)**
-            ```pwsh
-            irm https://resend.com/install.ps1 | iex
+            **Node.js**
+            ```sh
+            npm install -g resend-cli
             ```
 
-            **npx**
+            **Homebrew (macOS / Linux)**
             ```sh
-            npx resend-cli
+            brew install resend/cli/resend
+            ```
+
+            **PowerShell (Windows)**
+            ```sh
+            irm https://resend.com/install.ps1 | iex
             ```
           files: |
             dist/resend-darwin-arm64.tar.gz

--- a/README.md
+++ b/README.md
@@ -15,31 +15,31 @@ Built for humans, AI agents, and CI/CD pipelines.
 
 ## Install
 
-### Homebrew (macOS)
+### cURL
 
-```bash
-brew install resend/cli/resend
+```sh
+curl -fsSL https://resend.com/install.sh | bash
 ```
 
-### Shell script (macOS and Linux)
+### Node.js
 
-```bash
-curl -fsSL https://resend.com/install.sh | bash
+```sh
+npm install -g resend-cli
+```
+
+### Homebrew (macOS / Linux)
+
+```sh
+brew install resend/cli/resend
 ```
 
 ### PowerShell (Windows)
 
-```powershell
+```sh
 irm https://resend.com/install.ps1 | iex
 ```
 
 Or download the `.exe` directly from the [GitHub releases page](https://github.com/resend/resend-cli/releases/latest).
-
-### npx
-
-```bash
-npx resend-cli
-```
 
 ## Local development
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardized and simplified CLI install instructions across the README and GitHub release notes to make setup clearer and consistent.

- **Refactors**
  - Made cURL the primary install path.
  - Added `npm install -g resend-cli` option.
  - Clarified Homebrew support as macOS/Linux and kept PowerShell for Windows.
  - Removed the `npx` path.
  - Synced wording and code blocks between README and release body.

<sup>Written for commit 759706d5f6427939aaf94f00859bd17e298481f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

