### PR TITLE
docs: Fixed dev script usage in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Use this when you want to change the CLI and run your build locally.
 Use the dev script:
 
 ```bash
-pnpm dev -- --version
+pnpm dev --version
 ```
 
 Or run the built JS bundle:


### PR DESCRIPTION
## Summary
I was just starting up to use the CLI and noticed that this command didn't work for me

```
 pnpm dev -- --version

> resend-cli@1.4.1 dev /mnt/shared_drive/DEVDIR/resend-cli
> tsx src/cli.ts -- --version

error: unknown command '--version'
 ELIFECYCLE  Command failed with exit code 1.
```

But this did work fine

```
pnpm dev --version

> resend-cli@1.4.1 dev /mnt/shared_drive/DEVDIR/resend-cli
> tsx src/cli.ts --version

resend-cli v1.4.1
```

---

Feel free to close if unneeded

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix README dev script example to pass flags correctly: use `pnpm dev --version` instead of `pnpm dev -- --version`. Prevents the "unknown command --version" error when checking the CLI version during local development.

<sup>Written for commit 15e473fd272a9159577f91255444caa26a25d23f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

