### PR TITLE
feat: whoami: updated whoami to show the path to the config if that is what is being used

### DIFF
--- a/src/commands/whoami.ts
+++ b/src/commands/whoami.ts
@@ -71,7 +71,7 @@ Shows which profile is active and where the API key comes from.`,
     }
 
     const profile = resolved.profile ?? resolveProfileName(profileFlag);
-    const credentialsPath = join(getConfigDir(), 'credentials.json');
+    const configPath = join(getConfigDir(), 'credentials.json');
 
     if (globalOpts.json || !isInteractive()) {
       outputResult(
@@ -80,9 +80,7 @@ Shows which profile is active and where the API key comes from.`,
           profile,
           api_key: maskKey(resolved.key),
           source: resolved.source,
-          ...(resolved.source === 'config'
-            ? { config_path: credentialsPath }
-            : {}),
+          config_path: configPath,
         },
         { json: globalOpts.json },
       );
@@ -101,12 +99,7 @@ Shows which profile is active and where the API key comes from.`,
     console.log('');
     console.log(`  Profile: ${profile}`);
     console.log(`  API Key: ${maskKey(resolved.key)}`);
-    console.log(
-      `  Source:  ${resolved.source === 'config' ? 'config file' : resolved.source === 'env' ? 'environment variable' : 'flag'}`,
-    );
-    if (resolved.source === 'config') {
-      console.log(`  Config:  ${credentialsPath}`);
-    }
     console.log(`  Source:  ${sourceLabel}`);
+    console.log(`  Config:  ${configPath}`);
     console.log('');
   });

--- a/tests/commands/whoami.test.ts
+++ b/tests/commands/whoami.test.ts
@@ -97,6 +97,7 @@ describe('whoami command', () => {
     const parsed = JSON.parse(output);
     expect(parsed.authenticated).toBe(true);
     expect(parsed.source).toBe('env');
+    expect(parsed.config_path).toBe(join(tmpDir, 'resend', 'credentials.json'));
   });
 
   test('shows authenticated for keychain user (async resolve)', async () => {
@@ -137,5 +138,6 @@ describe('whoami command', () => {
     expect(parsed.authenticated).toBe(true);
     expect(parsed.api_key).toBe('re_...key1');
     expect(parsed.source).toBe('secure_storage');
+    expect(parsed.config_path).toBe(join(tmpDir, 'resend', 'credentials.json'));
   });
 });


### PR DESCRIPTION
## Summary
I wanted a way to know where my config/api keys were stored other than on login/logout. So I added a new output to `whoami` to show the config path if we are using a config.

Example
```
$ pnpm dev whoami --json

> resend-cli@1.4.1 dev /mnt/shared_drive/DEVDIR/resend-cli
> tsx src/cli.ts whoami --json

{
  "authenticated": true,
  "profile": "default",
  "api_key": "re_...JMBH",
  "source": "config",
  "config_path": "/home/kevkevin/.config/resend/credentials.json"
}
```

With no `--json`
```
$ pnpm dev whoami

> resend-cli@1.4.1 dev /mnt/shared_drive/DEVDIR/resend-cli
> tsx src/cli.ts whoami


  Profile: default
  API Key: re_...JMBH
  Source:  config file
  Config:  /home/kevkevin/.config/resend/credentials.json
  ```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated `whoami` to always show the full path to `credentials.json` in both JSON and standard output. This makes it easy to find where profile data is stored across all key sources.

- **New Features**
  - Always includes `config_path` in JSON and a "Config:" line in interactive output, pointing to the credentials file from `getConfigDir`.

- **Bug Fixes**
  - Removed duplicate "Source:" line in interactive output.

<sup>Written for commit 30849b6a3efa416386e22aa85e5cf702c532100b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

