### PR TITLE
fix: pin actions/setup-node to immutable SHA in test-credential-backends

### DIFF
--- a/.github/workflows/test-credential-backends.yml
+++ b/.github/workflows/test-credential-backends.yml
@@ -5,6 +5,7 @@ on:
       - src/lib/credential-backends/**
       - .github/workflows/test-credential-backends.yml
   workflow_dispatch:
+permissions: {}
 jobs:
   # ── Windows ──────────────────────────────────────────────
   win-passwordvault:
@@ -223,7 +224,7 @@ jobs:
               exit 1
             fi
           '
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24
       - name: Test Node.js spawn + stdin with secret-tool
@@ -295,7 +296,7 @@ jobs:
           else
             echo "Verify deleted: OK"
           fi
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24
       - name: Test Node.js execFile with security command


### PR DESCRIPTION

## Summary by cubic
Pin `actions/setup-node` in the `test-credential-backends` workflow from the mutable `@v6` tag to the immutable SHA `@53b83947a5a98c8d113130e565377fae1a50d02f` (v6.3.0), and set workflow `permissions: {}` to restrict `GITHUB_TOKEN` by default. This hardens CI against supply-chain changes and aligns with BU-625.

<sup>Written for commit ace4f62b05ec0469587f57d6825e8a8304d4a86e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

