### PR TITLE
fix: pin npx verification to expected package version

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -35,10 +35,18 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
       - uses: actions/setup-node@v6
         with:
           node-version: 24
       - name: Verify npx resend-cli
         run: |
-          npx resend-cli --version
-          npx resend-cli --help
+          EXPECTED_VERSION=$(node -p "require('./package.json').version")
+          ACTUAL_VERSION=$(npx --yes resend-cli@"$EXPECTED_VERSION" --version)
+          if [ "$ACTUAL_VERSION" != "$EXPECTED_VERSION" ]; then
+            echo "::error::Version mismatch: expected $EXPECTED_VERSION, got $ACTUAL_VERSION"
+            exit 1
+          fi
+          npx --yes resend-cli@"$EXPECTED_VERSION" --help >/dev/null


### PR DESCRIPTION

## Summary by cubic
Pins `npx` verification in the post-release workflow to the just-released `resend-cli` version (BU-645) to prevent false-green checks when npm serves an older package. The job checks out the release commit, reads the version from `package.json`, runs `npx --yes resend-cli@$EXPECTED_VERSION`, and fails if the `--version` output doesn’t match.

<sup>Written for commit 96d8b39af6dafbe2c97769c3a247edb8c32d24b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

