### PR TITLE
fix: add Intel macOS (x64) binary runtime validation to release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,9 @@ jobs:
           - os: macos-latest
             target: node24-macos-arm64
             binary: dist/resend
+          - os: macos-latest
+            target: node24-macos-x64
+            binary: dist/resend
           - os: ubuntu-latest
             target: node24-linux-x64
             binary: dist/resend
@@ -100,6 +103,13 @@ jobs:
         run: |
           pnpm exec pkg dist/cli.cjs --compress Brotli --target node24-macos-arm64 --output dist/resend-darwin-arm64
           pnpm exec pkg dist/cli.cjs --compress Brotli --target node24-macos-x64   --output dist/resend-darwin-x64
+      - name: Verify binaries run
+        run: |
+          chmod +x dist/resend-darwin-arm64 dist/resend-darwin-x64
+          dist/resend-darwin-arm64 --version
+          dist/resend-darwin-arm64 --help
+          dist/resend-darwin-x64 --version
+          dist/resend-darwin-x64 --help
       - name: Verify signatures
         run: |
           codesign -v dist/resend-darwin-arm64


### PR DESCRIPTION

## Summary by cubic
Add runtime validation for the Intel macOS (x64) binary in the release pipeline to avoid shipping an untested build. Addresses BU-647 by executing `--version` and `--help` on the x64 artifact before signing and release.

- **Bug Fixes**
  - Added `node24-macos-x64` to the `test-binary` matrix (runs via Rosetta 2 on `macos-latest`).
  - In `build-macos`, added a step to run `dist/resend-darwin-{arm64,x64}` with `--version` and `--help` before signing/packaging.

<sup>Written for commit 245a5b441a736560dfd20dcc544d3e9f0b1ce4ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

