### PR TITLE
fix: pin release version in post-release installer verification

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -13,24 +13,37 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install via install.sh
-        run: curl -fsSL https://raw.githubusercontent.com/resend/resend-cli/${{ github.event.workflow_run.head_sha }}/install.sh | bash
-      - name: Verify binary
+        run: curl -fsSL https://raw.githubusercontent.com/resend/resend-cli/${{ github.event.workflow_run.head_sha }}/install.sh | bash -s -- "${{ github.event.workflow_run.head_branch }}"
+      - name: Verify binary version matches release tag
         run: |
-          "$HOME/.resend/bin/resend" --version
+          expected="${{ github.event.workflow_run.head_branch }}"
+          expected="${expected#v}"
+          actual=$("$HOME/.resend/bin/resend" --version)
           "$HOME/.resend/bin/resend" --help
+          if [ "$actual" != "$expected" ]; then
+            echo "::error::Version mismatch: expected ${expected}, got ${actual}"
+            exit 1
+          fi
   verify-install-windows:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: windows-latest
     steps:
       - name: Install via install.ps1
         shell: pwsh
-        run: irm https://raw.githubusercontent.com/resend/resend-cli/${{ github.event.workflow_run.head_sha }}/install.ps1 | iex
-      - name: Verify binary
+        run: |
+          $env:RESEND_VERSION = '${{ github.event.workflow_run.head_branch }}'
+          irm https://raw.githubusercontent.com/resend/resend-cli/${{ github.event.workflow_run.head_sha }}/install.ps1 | iex
+      - name: Verify binary version matches release tag
         shell: pwsh
         run: |
+          $expected = '${{ github.event.workflow_run.head_branch }}'.TrimStart('v')
           $exe = "$env:USERPROFILE\.resend\bin\resend.exe"
-          & $exe --version
+          $actual = (& $exe --version).Trim()
           & $exe --help
+          if ($actual -ne $expected) {
+            Write-Error "Version mismatch: expected $expected, got $actual"
+            exit 1
+          }
   verify-npx:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest


### PR DESCRIPTION

## Summary by cubic
Pin the release version in post-release installer verification so the workflow installs and checks the exact tag that triggered the release. Fixes false positives for prereleases and back-to-back releases; resolves BU-648.

- **Bug Fixes**
  - Pass the triggering tag (`${{ github.event.workflow_run.head_branch }}`) to `install.sh` and set `RESEND_VERSION` before running `install.ps1` to fetch versioned assets.
  - Add version assertions: compare the installed `resend` version to the expected tag (trim leading `v`) and fail on mismatch.

<sup>Written for commit a9bd256866acd2745b39c120d0f1f875a7db062c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

