### PR TITLE
fix: clean up telemetry temp files on flush failure

### DIFF
--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -192,6 +192,9 @@ export async function flushFromFile(filePath: string): Promise<void> {
     closeSync(fd);
   }
 
-  await flushPayload(payload);
-  unlinkSync(resolved);
+  try {
+    await flushPayload(payload);
+  } finally {
+    unlinkSync(resolved);
+  }
 }

--- a/tests/lib/telemetry.test.ts
+++ b/tests/lib/telemetry.test.ts
@@ -449,12 +449,12 @@ describe('flushFromFile', () => {
     }
   });
 
-  it('preserves file when flush fails', async () => {
+  it('deletes file even when flush fails', async () => {
     fetchSpy.mockResolvedValue({ ok: false, status: 500 } as Response);
     const payload = JSON.stringify({ event: 'test' });
     writeFileSync(tmpFile, payload);
 
     await expect(flushFromFile(tmpFile)).rejects.toThrow();
-    expect(existsSync(tmpFile)).toBe(true);
+    expect(existsSync(tmpFile)).toBe(false);
   });
 });


### PR DESCRIPTION

## Summary by cubic
Always delete telemetry temp files after any flush attempt to prevent leaks, even when the network request fails.

- **Bug Fixes**
  - Wrap `flushPayload()` in `try/finally` in `flushFromFile()` so `unlinkSync()` always runs.
  - Update test to assert the temp file is deleted on failed flush.

<sup>Written for commit ef3dd3940c2f77136177e36fa575f04d2f4d8cd8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

