### PR TITLE
fix: inject telemetry staging key into smoke CI builds

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -19,6 +19,8 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Build Node bundle
         run: pnpm build
+        env:
+          POSTHOG_PUBLIC_KEY: ${{ secrets.POSTHOG_STAGING_KEY }}
       - name: Build pkg binary
         run: pnpm exec pkg dist/cli.cjs --compress Brotli --target node24-linux-x64 --output dist/resend
       - name: Smoke test Node bundle
@@ -29,3 +31,23 @@ jobs:
         run: |
           ./dist/resend --version
           ./dist/resend --help
+      - name: Verify telemetry spawn (Node bundle)
+        run: |
+          rm -f /tmp/resend-telemetry-*.json
+          node dist/cli.cjs --api-key re_fake whoami || true
+          sleep 1
+          if ! ls /tmp/resend-telemetry-*.json 1>/dev/null 2>&1; then
+            echo "::error::Telemetry temp file was never created — trackCommand did not fire"
+            exit 1
+          fi
+          echo "Telemetry spawn OK — temp file created"
+      - name: Verify telemetry spawn (pkg binary)
+        run: |
+          rm -f /tmp/resend-telemetry-*.json
+          ./dist/resend --api-key re_fake whoami || true
+          sleep 1
+          if ! ls /tmp/resend-telemetry-*.json 1>/dev/null 2>&1; then
+            echo "::error::Telemetry temp file was never created — trackCommand did not fire"
+            exit 1
+          fi
+          echo "Telemetry spawn OK — temp file created"

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -33,21 +33,19 @@ jobs:
           ./dist/resend --help
       - name: Verify telemetry spawn (Node bundle)
         run: |
-          rm -f /tmp/resend-telemetry-*.json
+          rm -f "$HOME/.config/resend/telemetry-id"
           node dist/cli.cjs --api-key re_fake whoami || true
-          sleep 1
-          if ! ls /tmp/resend-telemetry-*.json 1>/dev/null 2>&1; then
-            echo "::error::Telemetry temp file was never created — trackCommand did not fire"
+          if [ ! -f "$HOME/.config/resend/telemetry-id" ]; then
+            echo "::error::telemetry-id was never created — trackCommand did not fire"
             exit 1
           fi
-          echo "Telemetry spawn OK — temp file created"
+          echo "Telemetry spawn OK — telemetry-id created by Node bundle"
       - name: Verify telemetry spawn (pkg binary)
         run: |
-          rm -f /tmp/resend-telemetry-*.json
+          rm -f "$HOME/.config/resend/telemetry-id"
           ./dist/resend --api-key re_fake whoami || true
-          sleep 1
-          if ! ls /tmp/resend-telemetry-*.json 1>/dev/null 2>&1; then
-            echo "::error::Telemetry temp file was never created — trackCommand did not fire"
+          if [ ! -f "$HOME/.config/resend/telemetry-id" ]; then
+            echo "::error::telemetry-id was never created — trackCommand did not fire"
             exit 1
           fi
-          echo "Telemetry spawn OK — temp file created"
+          echo "Telemetry spawn OK — telemetry-id created by pkg binary"


### PR DESCRIPTION

## Summary by cubic
Enable telemetry in smoke CI builds and add checks that the telemetry spawn path runs for both the Node bundle and the `pkg` binary. Aligns smoke with release builds to catch telemetry regressions early (Linear BU-626).

- **Bug Fixes**
  - Inject `POSTHOG_STAGING_KEY` as `POSTHOG_PUBLIC_KEY` during `pnpm build` in `.github/workflows/smoke.yml`.
  - Add two checks that clear `/tmp`, run `whoami` with a fake API key, and assert a telemetry temp file was created for both the Node bundle and the `pkg` binary (events go to staging).

<sup>Written for commit b14e632cbfac203b8c1040dfcc6d2f82b2ada2f4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

