### PR TITLE
fix: reject camelCase scheduledAt in batch email validation

### DIFF
--- a/src/commands/emails/batch.ts
+++ b/src/commands/emails/batch.ts
@@ -130,10 +130,10 @@ export const batchCommand = new Command('batch')
           { json: globalOpts.json },
         );
       }
-      if ('scheduled_at' in email) {
+      if ('scheduled_at' in email || 'scheduledAt' in email) {
         outputError(
           {
-            message: `Email at index ${i} contains "scheduled_at", which is not supported in batch sends.`,
+            message: `Email at index ${i} contains scheduling, which is not supported in batch sends.`,
             code: 'batch_error',
           },
           { json: globalOpts.json },

--- a/tests/commands/emails/batch.test.ts
+++ b/tests/commands/emails/batch.test.ts
@@ -7,6 +7,7 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
   test,
   vi,
@@ -248,7 +249,27 @@ describe('batch command', () => {
     );
 
     const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
-    expect(output).toContain('scheduled_at');
+    expect(output).toContain('scheduling');
+    expect(output).toContain('batch_error');
+  });
+
+  it('rejects entries with camelCase scheduledAt', async () => {
+    setNonInteractive();
+    errorSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    exitSpy = mockExitThrow();
+
+    const emails = [
+      { ...VALID_EMAILS[0], scheduledAt: '2026-01-01T00:00:00Z' },
+    ];
+    const file = await writeTmpJson(emails);
+    const { batchCommand } = await import('../../../src/commands/emails/batch');
+    await expectExit1(() =>
+      batchCommand.parseAsync(['--file', file], { from: 'user' }),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('scheduling');
+    expect(output).toContain('batch_error');
   });
 
   test('warns but continues when array length exceeds 100', async () => {


### PR DESCRIPTION

## Summary by cubic
Reject scheduling fields in batch email payloads by blocking both `scheduled_at` and `scheduledAt` before calling the API. Returns a local `batch_error` with a clear, unified message, aligning with BU-662.

- **Bug Fixes**
  - Validate and reject `scheduled_at` and `scheduledAt` in batch sends with a single “scheduling … not supported” error and `batch_error`.
  - Added regression test for camelCase and updated existing test to match the unified message.

<sup>Written for commit bb34a5c3324276ecc715fcc3432862afbebaa787. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

