### PR TITLE
fix: detach update notifier from command completion chain

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -184,7 +184,7 @@ program
       });
     }
 
-    return checkForUpdates().catch(() => {});
+    void checkForUpdates().catch(() => {});
   })
   .catch((err) => {
     outputError({


### PR DESCRIPTION

## Summary by cubic
Prevents the CLI from hanging after successful commands by running the update check in the background. The notifier no longer blocks process exit, addressing BU-641.

- **Bug Fixes**
  - Detach update check from the `program.parseAsync()` chain by using `void checkForUpdates().catch(() => {})`, so it’s fire-and-forget but still prints notices when available.

<sup>Written for commit 7edb01ff5b27f180b6f6d705e86b4a1a8ce12942. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

