### PR TITLE
fix: preserve --var values as strings instead of auto-coercing to numbers

### DIFF
--- a/src/commands/emails/send.ts
+++ b/src/commands/emails/send.ts
@@ -183,8 +183,7 @@ export const sendCommand = new Command('send')
             }
             const key = v.slice(0, eq);
             const raw = v.slice(eq + 1);
-            const num = Number(raw);
-            return [key, raw !== '' && !Number.isNaN(num) ? num : raw];
+            return [key, raw];
           }),
         )
       : undefined;

--- a/tests/commands/emails/send.test.ts
+++ b/tests/commands/emails/send.test.ts
@@ -895,7 +895,65 @@ describe('send command', () => {
     const callArgs = mockSend.mock.calls[0][0] as Record<string, unknown>;
     expect(callArgs.template).toEqual({
       id: 'tmpl_123',
-      variables: { name: 'John', count: 42 },
+      variables: { name: 'John', count: '42' },
+    });
+  });
+
+  test('preserves leading zeros in --var values', async () => {
+    spies = setupOutputSpies();
+
+    const { sendCommand } = await import('../../../src/commands/emails/send');
+    await sendCommand.parseAsync(
+      ['--template', 'tmpl_123', '--to', 'b@test.com', '--var', 'otp=012345'],
+      { from: 'user' },
+    );
+
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    const callArgs = mockSend.mock.calls[0][0] as Record<string, unknown>;
+    expect(callArgs.template).toEqual({
+      id: 'tmpl_123',
+      variables: { otp: '012345' },
+    });
+  });
+
+  test('preserves large numeric strings beyond MAX_SAFE_INTEGER in --var values', async () => {
+    spies = setupOutputSpies();
+
+    const { sendCommand } = await import('../../../src/commands/emails/send');
+    await sendCommand.parseAsync(
+      [
+        '--template',
+        'tmpl_123',
+        '--to',
+        'b@test.com',
+        '--var',
+        'account_id=9007199254740993',
+      ],
+      { from: 'user' },
+    );
+
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    const callArgs = mockSend.mock.calls[0][0] as Record<string, unknown>;
+    expect(callArgs.template).toEqual({
+      id: 'tmpl_123',
+      variables: { account_id: '9007199254740993' },
+    });
+  });
+
+  test('preserves scientific notation strings in --var values', async () => {
+    spies = setupOutputSpies();
+
+    const { sendCommand } = await import('../../../src/commands/emails/send');
+    await sendCommand.parseAsync(
+      ['--template', 'tmpl_123', '--to', 'b@test.com', '--var', 'code=1e3'],
+      { from: 'user' },
+    );
+
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    const callArgs = mockSend.mock.calls[0][0] as Record<string, unknown>;
+    expect(callArgs.template).toEqual({
+      id: 'tmpl_123',
+      variables: { code: '1e3' },
     });
   });
 


### PR DESCRIPTION

## Summary by cubic
Preserves `--var` values as strings in the `emails send` command to stop numeric auto-coercion that corrupted IDs and OTPs. Fixes BU-624 and aligns CLI parsing with template variable types.

- **Bug Fixes**
  - Always pass `--var` values as strings; removed Number() coercion.
  - Protects leading zeros, large IDs beyond Number.MAX_SAFE_INTEGER, and scientific notation strings.
  - Updated tests to expect strings and added edge cases.

<sup>Written for commit 7fb58224aac7b08e620a6cbf7bb3bdc6c724ca0e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

