### PR TITLE
fix: validate batch entries before react-email HTML injection

### DIFF
--- a/src/commands/emails/batch.ts
+++ b/src/commands/emails/batch.ts
@@ -102,13 +102,6 @@ export const batchCommand = new Command('batch')
       );
     }
 
-    if (opts.reactEmail) {
-      const reactHtml = await buildReactEmailHtml(opts.reactEmail, globalOpts);
-      for (const email of emails) {
-        (email as Record<string, unknown>).html = reactHtml;
-      }
-    }
-
     for (let i = 0; i < emails.length; i++) {
       const email = emails[i];
       if (email === null || typeof email !== 'object' || Array.isArray(email)) {
@@ -138,6 +131,13 @@ export const batchCommand = new Command('batch')
           },
           { json: globalOpts.json },
         );
+      }
+    }
+
+    if (opts.reactEmail) {
+      const reactHtml = await buildReactEmailHtml(opts.reactEmail, globalOpts);
+      for (const email of emails) {
+        (email as Record<string, unknown>).html = reactHtml;
       }
     }
 

--- a/tests/commands/emails/batch.test.ts
+++ b/tests/commands/emails/batch.test.ts
@@ -435,6 +435,46 @@ describe('batch command', () => {
     }
   });
 
+  test('errors with invalid_format when an entry is null with --react-email', async () => {
+    setNonInteractive();
+    errorSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    exitSpy = mockExitThrow();
+
+    const file = await writeTmpJson([null]);
+    const { batchCommand } = await import('../../../src/commands/emails/batch');
+    await expectExit1(() =>
+      batchCommand.parseAsync(
+        ['--file', file, '--react-email', './emails/welcome.tsx'],
+        { from: 'user' },
+      ),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('invalid_format');
+    expect(output).toContain('Email at index 0 must be a JSON object.');
+    expect(mockBuildReactEmailHtml).not.toHaveBeenCalled();
+  });
+
+  test('errors with invalid_format when an entry is a string with --react-email', async () => {
+    setNonInteractive();
+    errorSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    exitSpy = mockExitThrow();
+
+    const file = await writeTmpJson(['oops']);
+    const { batchCommand } = await import('../../../src/commands/emails/batch');
+    await expectExit1(() =>
+      batchCommand.parseAsync(
+        ['--file', file, '--react-email', './emails/welcome.tsx'],
+        { from: 'user' },
+      ),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('invalid_format');
+    expect(output).toContain('Email at index 0 must be a JSON object.');
+    expect(mockBuildReactEmailHtml).not.toHaveBeenCalled();
+  });
+
   test('errors with batch_error when SDK returns an error', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'log').mockImplementation(() => {});


### PR DESCRIPTION

## Summary by cubic
Validate batch entries before injecting React Email HTML so malformed items return `invalid_format` instead of `unexpected_error`. Fixes BU-612 for `emails batch --react-email` when entries are non-objects.

- **Bug Fixes**
  - Validate each batch entry is a JSON object before setting `.html`; inject React HTML only after validation.
  - Add regression tests for `null` and string entries with `--react-email` to verify `invalid_format` and that `buildReactEmailHtml` is never called.

<sup>Written for commit e3bebae9ecd44059c9d8a0db6bd69f55c87c4ecc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

