### PR TITLE
fix: make telemetry optional in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,17 +8,7 @@ concurrency:
   group: release
   cancel-in-progress: false
 jobs:
-  preflight:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Verify PostHog key is configured
-        run: |
-          if [ -z "${{ secrets.POSTHOG_PUBLIC_KEY }}" ]; then
-            echo "::error::POSTHOG_PUBLIC_KEY secret is not set"
-            exit 1
-          fi
   test-binary:
-    needs: preflight
     strategy:
       fail-fast: false
       matrix:
@@ -53,7 +43,6 @@ jobs:
           ${{ matrix.binary }} --version
           ${{ matrix.binary }} --help
   test-binary-linux-arm64:
-    needs: preflight
     runs-on: blacksmith-2vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v6

--- a/scripts/verify-bundle.mjs
+++ b/scripts/verify-bundle.mjs
@@ -1,10 +1,9 @@
 import { readFileSync } from 'node:fs';
 
 const bundle = readFileSync('dist/cli.cjs', 'utf8');
+const key = process.env.POSTHOG_PUBLIC_KEY ?? '';
 
-if (!bundle.includes('phc_')) {
-  console.error(
-    'Error: POSTHOG_PUBLIC_KEY not found in bundle — add it to .env',
-  );
+if (key && !bundle.includes(key)) {
+  console.error('Error: configured POSTHOG_PUBLIC_KEY was not found in bundle');
   process.exit(1);
 }


### PR DESCRIPTION

## Summary by cubic
Make telemetry optional in the release pipeline so builds don’t fail when `POSTHOG_PUBLIC_KEY` is missing. Aligns CI with runtime behavior and unblocks releases (BU-618).

- **Bug Fixes**
  - Removed the `preflight` job and its `needs` from `.github/workflows/release.yml`; the build still receives `POSTHOG_PUBLIC_KEY` when set.
  - Updated `scripts/verify-bundle.mjs` to validate the exact key only when it’s configured; skips the check when telemetry is disabled.

<sup>Written for commit 16b3c00918d1d7260f3b21abdcdbdc2207c1cf80. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

