### PR TITLE
fix: suppress update banner in machine mode (--json / --quiet)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -184,7 +184,10 @@ program
       });
     }
 
-    return checkForUpdates().catch(() => {});
+    const globals = program.opts();
+    return checkForUpdates({
+      json: Boolean(globals.json || globals.quiet),
+    }).catch(() => {});
   })
   .catch((err) => {
     outputError({

--- a/src/lib/update-check.ts
+++ b/src/lib/update-check.ts
@@ -73,7 +73,14 @@ export async function fetchLatestVersion(): Promise<string | null> {
   }
 }
 
-function shouldSkipCheck(): boolean {
+export type UpdateCheckOptions = {
+  readonly json?: boolean;
+};
+
+function shouldSkipCheck(opts?: UpdateCheckOptions): boolean {
+  if (opts?.json) {
+    return true;
+  }
   if (process.env.RESEND_NO_UPDATE_NOTIFIER === '1') {
     return true;
   }
@@ -165,8 +172,10 @@ function formatNotice(latestVersion: string): string {
  * Designed to be called after the main command completes — never blocks
  * or throws.
  */
-export async function checkForUpdates(): Promise<void> {
-  if (shouldSkipCheck()) {
+export async function checkForUpdates(
+  opts?: UpdateCheckOptions,
+): Promise<void> {
+  if (shouldSkipCheck(opts)) {
     return;
   }
 

--- a/tests/lib/update-check.test.ts
+++ b/tests/lib/update-check.test.ts
@@ -12,6 +12,7 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
   test,
   vi,
@@ -178,6 +179,34 @@ describe('checkForUpdates', () => {
     mockFetch('canary-20260311');
     await checkForUpdates();
     expect(stderrOutput).toBe('');
+  });
+
+  it('skips check when json option is true (TTY + --json)', async () => {
+    mockFetch(`v${NEWER_VERSION}`);
+    await checkForUpdates({ json: true });
+    expect(stderrOutput).toBe('');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('skips check when json option is true from cached state (TTY + --quiet)', async () => {
+    writeFileSync(
+      statePath,
+      JSON.stringify({ lastChecked: Date.now(), latestVersion: NEWER_VERSION }),
+    );
+    await checkForUpdates({ json: true });
+    expect(stderrOutput).toBe('');
+  });
+
+  it('still prints notice on TTY without json option', async () => {
+    mockFetch(`v${NEWER_VERSION}`);
+    await checkForUpdates();
+    expect(stderrOutput).toContain('Update available');
+  });
+
+  it('still prints notice when json option is explicitly false', async () => {
+    mockFetch(`v${NEWER_VERSION}`);
+    await checkForUpdates({ json: false });
+    expect(stderrOutput).toContain('Update available');
   });
 });
 


### PR DESCRIPTION

## Summary by cubic
Suppress the update banner in machine mode so `--json` or `--quiet` runs produce no stderr output, honoring the “JSON to stdout, nothing to stderr” contract. Resolves BU-651 by preventing noisy TTY runs from breaking automation.

- **Bug Fixes**
  - Added `UpdateCheckOptions` and updated `shouldSkipCheck` to short-circuit when `json` is true.
  - Passed `json: Boolean(globals.json || globals.quiet)` from `src/cli.ts` into `checkForUpdates`.
  - Preserved existing behavior on TTY when machine mode is off.
  - Added regression tests covering `--json`, `--quiet` (cached), and explicit `json: false`.

<sup>Written for commit 7a6933f14919aafce30709c6f82b7e93ac276594. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

