### PR TITLE
fix: add SHA-256 checksum verification to CLI installers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,6 +187,17 @@ jobs:
                     dist/resend-windows-x64.zip; do
             [ -s "$f" ] || { echo "Missing or empty: $f"; exit 1; }
           done
+      - name: Generate SHA-256 checksums
+        run: |
+          cd dist
+          sha256sum \
+            resend-darwin-arm64.tar.gz \
+            resend-darwin-x64.tar.gz \
+            resend-linux-x64.tar.gz \
+            resend-linux-arm64.tar.gz \
+            resend-windows-x64.zip \
+            > CHECKSUMS.txt
+          cat CHECKSUMS.txt
       - name: Detect pre-release
         id: meta
         run: |
@@ -231,6 +242,7 @@ jobs:
             dist/resend-linux-x64.tar.gz
             dist/resend-linux-arm64.tar.gz
             dist/resend-windows-x64.zip
+            dist/CHECKSUMS.txt
   notify-tap:
     if: github.event_name != 'workflow_dispatch' && needs.release.outputs.prerelease == 'false'
     name: Trigger Homebrew Tap Update

--- a/install.ps1
+++ b/install.ps1
@@ -90,28 +90,33 @@ $tmpZip = Join-Path $tmpDir 'resend.zip'
     Write-Info "Verifying checksum..."
 
     $tmpChecksums = Join-Path $tmpDir 'CHECKSUMS.txt'
+    $checksumAvailable = $true
     try {
       Invoke-WebRequest -Uri $checksumsUrl -OutFile $tmpChecksums -UseBasicParsing
     } catch {
-      Write-Fail "Failed to download checksums manifest.`n`n  URL: $checksumsUrl`n`n  The release may not include a CHECKSUMS.txt file."
-      throw "Installation failed."
+      $checksumAvailable = $false
+      Write-Host "  warn: CHECKSUMS.txt not found -- skipping verification." -ForegroundColor Yellow
+      Write-Info "This release may predate checksum publishing."
+      Write-Info "Future releases will include a CHECKSUMS.txt manifest."
     }
 
-    $checksumLine = Get-Content $tmpChecksums | Where-Object { $_ -match $archiveName } | Select-Object -First 1
-    if (-not $checksumLine) {
-      Write-Fail "Checksum for $archiveName not found in CHECKSUMS.txt"
-      throw "Installation failed."
+    if ($checksumAvailable) {
+      $checksumLine = Get-Content $tmpChecksums | Where-Object { $_ -match $archiveName } | Select-Object -First 1
+      if (-not $checksumLine) {
+        Write-Fail "Checksum for $archiveName not found in CHECKSUMS.txt"
+        throw "Installation failed."
+      }
+      $expectedChecksum = ($checksumLine -split '\s+')[0]
+
+      $actualChecksum = (Get-FileHash -Path $tmpZip -Algorithm SHA256).Hash.ToLower()
+
+      if ($actualChecksum -ne $expectedChecksum) {
+        Write-Fail "Checksum verification failed.`n`n  Expected: $expectedChecksum`n  Actual:   $actualChecksum`n`n  The downloaded archive may have been tampered with. Do not use it."
+        throw "Installation failed."
+      }
+
+      Write-Ok "Checksum verified"
     }
-    $expectedChecksum = ($checksumLine -split '\s+')[0]
-
-    $actualChecksum = (Get-FileHash -Path $tmpZip -Algorithm SHA256).Hash.ToLower()
-
-    if ($actualChecksum -ne $expectedChecksum) {
-      Write-Fail "Checksum verification failed.`n`n  Expected: $expectedChecksum`n  Actual:   $actualChecksum`n`n  The downloaded archive may have been tampered with. Do not use it."
-      throw "Installation failed."
-    }
-
-    Write-Ok "Checksum verified"
     Write-Host ""
 
     try {

--- a/install.ps1
+++ b/install.ps1
@@ -39,6 +39,7 @@ if ($env:PROCESSOR_ARCHITECTURE -notin @('AMD64', 'EM64T')) {
 
 $repo = 'https://github.com/resend/resend-cli'
 $target = 'windows-x64'
+$archiveName = "resend-$target.zip"
 
 if ($Version) {
   $Version = $Version.TrimStart('v')
@@ -46,9 +47,11 @@ if ($Version) {
     Write-Fail "Invalid version format: $Version`n`n  Expected: semantic version like 0.1.0 or 1.2.3-beta.1`n  Usage:    `$env:RESEND_VERSION = 'v0.1.0'; irm https://resend.com/install.ps1 | iex"
     throw "Installation failed."
   }
-  $url = "$repo/releases/download/v$Version/resend-$target.zip"
+  $url = "$repo/releases/download/v$Version/$archiveName"
+  $checksumsUrl = "$repo/releases/download/v$Version/CHECKSUMS.txt"
 } else {
-  $url = "$repo/releases/latest/download/resend-$target.zip"
+  $url = "$repo/releases/latest/download/$archiveName"
+  $checksumsUrl = "$repo/releases/latest/download/CHECKSUMS.txt"
 }
 
 # --- Install directory -------------------------------------------------------
@@ -73,24 +76,50 @@ $tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) "resend-$([System.Guid]::N
 New-Item -ItemType Directory -Path $tmpDir -Force | Out-Null
 $tmpZip = Join-Path $tmpDir 'resend.zip'
 
-try {
   try {
-    # Force TLS 1.2 for Windows PowerShell 5.1 (no-op on PowerShell 7+ where it is the default)
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    $ProgressPreference = 'SilentlyContinue'  # Invoke-WebRequest is ~10x faster without progress bar
-    Invoke-WebRequest -Uri $url -OutFile $tmpZip -UseBasicParsing
-  } catch {
-    if ($Version) { $ver = $Version } else { $ver = 'latest' }
-    Write-Fail "Download failed.`n`n  Possible causes:`n    - No internet connection`n    - The version does not exist: $ver`n    - GitHub is unreachable`n`n  URL: $url"
-    throw "Installation failed."
-  }
+    try {
+      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+      $ProgressPreference = 'SilentlyContinue'
+      Invoke-WebRequest -Uri $url -OutFile $tmpZip -UseBasicParsing
+    } catch {
+      if ($Version) { $ver = $Version } else { $ver = 'latest' }
+      Write-Fail "Download failed.`n`n  Possible causes:`n    - No internet connection`n    - The version does not exist: $ver`n    - GitHub is unreachable`n`n  URL: $url"
+      throw "Installation failed."
+    }
 
-  try {
-    Expand-Archive -Path $tmpZip -DestinationPath $binDir -Force
-  } catch {
-    Write-Fail "Failed to extract archive: $_"
-    throw "Installation failed."
-  }
+    Write-Info "Verifying checksum..."
+
+    $tmpChecksums = Join-Path $tmpDir 'CHECKSUMS.txt'
+    try {
+      Invoke-WebRequest -Uri $checksumsUrl -OutFile $tmpChecksums -UseBasicParsing
+    } catch {
+      Write-Fail "Failed to download checksums manifest.`n`n  URL: $checksumsUrl`n`n  The release may not include a CHECKSUMS.txt file."
+      throw "Installation failed."
+    }
+
+    $checksumLine = Get-Content $tmpChecksums | Where-Object { $_ -match $archiveName } | Select-Object -First 1
+    if (-not $checksumLine) {
+      Write-Fail "Checksum for $archiveName not found in CHECKSUMS.txt"
+      throw "Installation failed."
+    }
+    $expectedChecksum = ($checksumLine -split '\s+')[0]
+
+    $actualChecksum = (Get-FileHash -Path $tmpZip -Algorithm SHA256).Hash.ToLower()
+
+    if ($actualChecksum -ne $expectedChecksum) {
+      Write-Fail "Checksum verification failed.`n`n  Expected: $expectedChecksum`n  Actual:   $actualChecksum`n`n  The downloaded archive may have been tampered with. Do not use it."
+      throw "Installation failed."
+    }
+
+    Write-Ok "Checksum verified"
+    Write-Host ""
+
+    try {
+      Expand-Archive -Path $tmpZip -DestinationPath $binDir -Force
+    } catch {
+      Write-Fail "Failed to extract archive: $_"
+      throw "Installation failed."
+    }
 } finally {
   Remove-Item -Recurse -Force $tmpDir -ErrorAction SilentlyContinue
 }

--- a/install.sh
+++ b/install.sh
@@ -182,31 +182,31 @@ checksums_file="${tmpdir}/CHECKSUMS.txt"
 
 info "  Verifying checksum..."
 
-curl --fail --silent --location --output "$checksums_file" "$checksums_url" ||
-  error "Failed to download checksums manifest.
+if curl --fail --silent --location --output "$checksums_file" "$checksums_url" 2>/dev/null; then
+  expected_checksum=$(grep "${archive_name}" "$checksums_file" | awk '{print $1}')
 
-  URL: ${checksums_url}
+  if [[ -z $expected_checksum ]]; then
+    error "Checksum for ${archive_name} not found in CHECKSUMS.txt"
+  fi
 
-  The release may not include a CHECKSUMS.txt file."
+  actual_checksum=$($sha256_cmd "$tmpfile" | awk '{print $1}')
 
-expected_checksum=$(grep "${archive_name}" "$checksums_file" | awk '{print $1}')
-
-if [[ -z $expected_checksum ]]; then
-  error "Checksum for ${archive_name} not found in CHECKSUMS.txt"
-fi
-
-actual_checksum=$($sha256_cmd "$tmpfile" | awk '{print $1}')
-
-if [[ "$actual_checksum" != "$expected_checksum" ]]; then
-  error "Checksum verification failed.
+  if [[ "$actual_checksum" != "$expected_checksum" ]]; then
+    error "Checksum verification failed.
 
   Expected: ${expected_checksum}
   Actual:   ${actual_checksum}
 
   The downloaded archive may have been tampered with. Do not use it."
-fi
+  fi
 
-info "  Checksum verified ✓"
+  info "  Checksum verified ✓"
+else
+  warn "CHECKSUMS.txt not found — skipping verification.
+
+  This release may predate checksum publishing.
+  Future releases will include a CHECKSUMS.txt manifest."
+fi
 echo ""
 
 tar -xzf "$tmpfile" -C "$bin_dir" ||

--- a/install.sh
+++ b/install.sh
@@ -65,6 +65,14 @@ tildify() {
 command -v curl >/dev/null 2>&1 || error "curl is required but not found. Install it and try again."
 command -v tar  >/dev/null 2>&1 || error "tar is required but not found. Install it and try again."
 
+if command -v sha256sum >/dev/null 2>&1; then
+  sha256_cmd="sha256sum"
+elif command -v shasum >/dev/null 2>&1; then
+  sha256_cmd="shasum -a 256"
+else
+  error "sha256sum or shasum is required but not found. Install one and try again."
+fi
+
 # ─── OS / Architecture detection ────────────────────────────────────────────
 
 platform=$(uname -ms)
@@ -121,8 +129,9 @@ REPO="${GITHUB_BASE}/resend/resend-cli"
 VERSION=${1:-}
 
 # Validate version format if provided
+archive_name="resend-${target}.tar.gz"
+
 if [[ -n $VERSION ]]; then
-  # Strip leading 'v' if present, then re-add for the tag
   VERSION="${VERSION#v}"
   if ! [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
     error "Invalid version format: ${VERSION}
@@ -130,9 +139,11 @@ if [[ -n $VERSION ]]; then
   Expected: semantic version like 0.1.0 or 1.2.3-beta.1
   Usage:    curl -fsSL https://resend.com/install.sh | bash -s v0.1.0"
   fi
-  url="${REPO}/releases/download/v${VERSION}/resend-${target}.tar.gz"
+  url="${REPO}/releases/download/v${VERSION}/${archive_name}"
+  checksums_url="${REPO}/releases/download/v${VERSION}/CHECKSUMS.txt"
 else
-  url="${REPO}/releases/latest/download/resend-${target}.tar.gz"
+  url="${REPO}/releases/latest/download/${archive_name}"
+  checksums_url="${REPO}/releases/latest/download/CHECKSUMS.txt"
 fi
 
 # ─── Install directory ──────────────────────────────────────────────────────
@@ -167,14 +178,42 @@ curl --fail --location --progress-bar --output "$tmpfile" "$url" ||
 
   URL: ${url}"
 
+checksums_file="${tmpdir}/CHECKSUMS.txt"
+
+info "  Verifying checksum..."
+
+curl --fail --silent --location --output "$checksums_file" "$checksums_url" ||
+  error "Failed to download checksums manifest.
+
+  URL: ${checksums_url}
+
+  The release may not include a CHECKSUMS.txt file."
+
+expected_checksum=$(grep "${archive_name}" "$checksums_file" | awk '{print $1}')
+
+if [[ -z $expected_checksum ]]; then
+  error "Checksum for ${archive_name} not found in CHECKSUMS.txt"
+fi
+
+actual_checksum=$($sha256_cmd "$tmpfile" | awk '{print $1}')
+
+if [[ "$actual_checksum" != "$expected_checksum" ]]; then
+  error "Checksum verification failed.
+
+  Expected: ${expected_checksum}
+  Actual:   ${actual_checksum}
+
+  The downloaded archive may have been tampered with. Do not use it."
+fi
+
+info "  Checksum verified ✓"
+echo ""
+
 tar -xzf "$tmpfile" -C "$bin_dir" ||
   error "Failed to extract archive. The download may be corrupted — try again."
 
 chmod +x "$exe" || error "Failed to make binary executable"
 
-# Strip macOS Gatekeeper quarantine flag (set automatically on curl downloads)
-# Without this, macOS will block the binary: "cannot be opened because Apple
-# cannot check it for malicious software"
 if [[ $(uname -s) == "Darwin" ]]; then
   xattr -d com.apple.quarantine "$exe" 2>/dev/null || true
 fi


### PR DESCRIPTION

## Summary by cubic
Adds SHA-256 checksum verification to Unix and Windows CLI installers and publishes `CHECKSUMS.txt` with each release. Blocks on mismatch; warns and continues when the manifest is missing on older releases, resolving BU-664.

- **Bug Fixes**
  - Release workflow generates SHA-256 hashes for all archives and uploads `CHECKSUMS.txt`.
  - `install.sh` and `install.ps1` download `CHECKSUMS.txt`, verify the archive hash, and abort before extraction on mismatch; if the manifest is missing, they warn and proceed.
  - `install.sh` requires `sha256sum` or `shasum`; macOS quarantine removal runs only after verification succeeds.

<sup>Written for commit 565c39858ebea8c234d64086126779736c16d61b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

