### PR TITLE
fix: use explorer.exe instead of cmd.exe for Windows browser-open

### DIFF
--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -3,8 +3,12 @@ import pc from 'picocolors';
 
 const RESEND_BASE = 'https://resend.com';
 
-export const openInBrowser = (url: string): Promise<boolean> =>
-  new Promise((resolve) => {
+/**
+ * Try to open a URL in the user's default browser. Returns true if the open
+ * succeeded, false on error or when the terminal has no browser (e.g. SSH).
+ */
+export function openInBrowser(url: string): Promise<boolean> {
+  return new Promise((resolve) => {
     const cmd =
       process.platform === 'win32'
         ? 'explorer.exe'
@@ -13,16 +17,22 @@ export const openInBrowser = (url: string): Promise<boolean> =>
           : 'xdg-open';
     execFile(cmd, [url], { timeout: 5000 }, (err) => resolve(!err));
   });
+}
 
 export type OpenInBrowserOrLogOpts = {
   json?: boolean;
   quiet?: boolean;
 };
 
-export const openInBrowserOrLog = async (
+/**
+ * Opens the URL in the browser and logs the outcome: success with link, or
+ * warning with link to copy when the browser could not be opened. No output
+ * when opts.json or opts.quiet.
+ */
+export async function openInBrowserOrLog(
   url: string,
   opts?: OpenInBrowserOrLogOpts,
-): Promise<void> => {
+): Promise<void> {
   const opened = await openInBrowser(url);
   if (opts?.json || opts?.quiet) {
     return;
@@ -35,7 +45,7 @@ export const openInBrowserOrLog = async (
       pc.blue(url),
     );
   }
-};
+}
 
 export const RESEND_URLS = {
   emails: `${RESEND_BASE}/emails`,

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -3,46 +3,26 @@ import pc from 'picocolors';
 
 const RESEND_BASE = 'https://resend.com';
 
-/**
- * Try to open a URL in the user's default browser. Returns true if the open
- * succeeded, false on error or when the terminal has no browser (e.g. SSH).
- */
-export function openInBrowser(url: string): Promise<boolean> {
-  return new Promise((resolve) => {
+export const openInBrowser = (url: string): Promise<boolean> =>
+  new Promise((resolve) => {
     const cmd =
       process.platform === 'win32'
-        ? 'cmd.exe'
+        ? 'explorer.exe'
         : process.platform === 'darwin'
           ? 'open'
           : 'xdg-open';
-    const safeUrl = url.replaceAll('"', '');
-    const args =
-      process.platform === 'win32'
-        ? ['/c', 'start', '""', `"${safeUrl}"`]
-        : [url];
-    execFile(
-      cmd,
-      args,
-      { timeout: 5000, windowsVerbatimArguments: true },
-      (err) => resolve(!err),
-    );
+    execFile(cmd, [url], { timeout: 5000 }, (err) => resolve(!err));
   });
-}
 
 export type OpenInBrowserOrLogOpts = {
   json?: boolean;
   quiet?: boolean;
 };
 
-/**
- * Opens the URL in the browser and logs the outcome: success with link, or
- * warning with link to copy when the browser could not be opened. No output
- * when opts.json or opts.quiet.
- */
-export async function openInBrowserOrLog(
+export const openInBrowserOrLog = async (
   url: string,
   opts?: OpenInBrowserOrLogOpts,
-): Promise<void> {
+): Promise<void> => {
   const opened = await openInBrowser(url);
   if (opts?.json || opts?.quiet) {
     return;
@@ -55,7 +35,7 @@ export async function openInBrowserOrLog(
       pc.blue(url),
     );
   }
-}
+};
 
 export const RESEND_URLS = {
   emails: `${RESEND_BASE}/emails`,

--- a/tests/lib/browser.test.ts
+++ b/tests/lib/browser.test.ts
@@ -38,7 +38,8 @@ describe('openInBrowser', () => {
     try {
       await openInBrowser('https://resend.com/templates/abc');
 
-      const opts = execFileMock.mock.calls[0]?.[2] as Record<string, unknown>;
+      const lastCall = execFileMock.mock.calls.at(-1);
+      const opts = lastCall?.[2] as Record<string, unknown>;
       expect(opts).not.toHaveProperty('windowsVerbatimArguments');
     } finally {
       Object.defineProperty(process, 'platform', { value: original });

--- a/tests/lib/browser.test.ts
+++ b/tests/lib/browser.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:child_process', () => ({
+  execFile: vi.fn((_cmd, _args, _opts, cb) => cb(null)),
+}));
+
+import { execFile } from 'node:child_process';
+import { openInBrowser } from '../../src/lib/browser';
+
+const execFileMock = vi.mocked(execFile);
+
+describe('openInBrowser', () => {
+  it('uses explorer.exe on win32 to avoid cmd.exe env-var expansion', async () => {
+    const original = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+
+    try {
+      const result = await openInBrowser(
+        'https://resend.com/templates/%SECRET%',
+      );
+
+      expect(result).toBe(true);
+      expect(execFileMock).toHaveBeenCalledWith(
+        'explorer.exe',
+        ['https://resend.com/templates/%SECRET%'],
+        expect.objectContaining({ timeout: 5000 }),
+        expect.any(Function),
+      );
+    } finally {
+      Object.defineProperty(process, 'platform', { value: original });
+    }
+  });
+
+  it('does not pass windowsVerbatimArguments', async () => {
+    const original = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+
+    try {
+      await openInBrowser('https://resend.com/templates/abc');
+
+      const opts = execFileMock.mock.calls[0]?.[2] as Record<string, unknown>;
+      expect(opts).not.toHaveProperty('windowsVerbatimArguments');
+    } finally {
+      Object.defineProperty(process, 'platform', { value: original });
+    }
+  });
+
+  it('uses open on darwin', async () => {
+    const original = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+
+    try {
+      await openInBrowser('https://resend.com/templates/abc');
+
+      expect(execFileMock).toHaveBeenCalledWith(
+        'open',
+        ['https://resend.com/templates/abc'],
+        expect.objectContaining({ timeout: 5000 }),
+        expect.any(Function),
+      );
+    } finally {
+      Object.defineProperty(process, 'platform', { value: original });
+    }
+  });
+
+  it('uses xdg-open on linux', async () => {
+    const original = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+
+    try {
+      await openInBrowser('https://resend.com/templates/abc');
+
+      expect(execFileMock).toHaveBeenCalledWith(
+        'xdg-open',
+        ['https://resend.com/templates/abc'],
+        expect.objectContaining({ timeout: 5000 }),
+        expect.any(Function),
+      );
+    } finally {
+      Object.defineProperty(process, 'platform', { value: original });
+    }
+  });
+
+  it('returns false when execFile reports an error', async () => {
+    execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
+      (cb as (err: Error | null) => void)(new Error('fail'));
+      return undefined as never;
+    });
+
+    const result = await openInBrowser('https://resend.com');
+
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION

## Summary by cubic
Fixes env-var expansion on Windows by opening URLs with explorer.exe instead of cmd.exe, preventing secret leaks in URLs, history, and logs. Addresses BU-622.

- **Bug Fixes**
  - Use `explorer.exe` on Windows; avoids `%VAR%` expansion from `cmd.exe /c start`.
  - Remove `windowsVerbatimArguments` and quote-stripping workaround.
  - Keep `open` (macOS) and `xdg-open` (Linux) behavior unchanged.
  - Add tests for platform selection, options, and error handling.

<sup>Written for commit 384b33f5191bd1eea6fbca0e3ce7445e817a2fbe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

