### PR TITLE
fix: use staging directory for atomic binary upgrade in installers

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -85,18 +85,40 @@ try {
     throw "Installation failed."
   }
 
+  $stageDir = Join-Path $installDir ".stage-$([System.Guid]::NewGuid())"
+  New-Item -ItemType Directory -Path $stageDir -Force | Out-Null
+
   try {
-    Expand-Archive -Path $tmpZip -DestinationPath $binDir -Force
+    Expand-Archive -Path $tmpZip -DestinationPath $stageDir -Force
   } catch {
+    Remove-Item -Recurse -Force $stageDir -ErrorAction SilentlyContinue
     Write-Fail "Failed to extract archive: $_"
     throw "Installation failed."
   }
+
+  $stagedExe = Join-Path $stageDir 'resend.exe'
+  if (-not (Test-Path $stagedExe)) {
+    Remove-Item -Recurse -Force $stageDir -ErrorAction SilentlyContinue
+    Write-Fail "Archive did not contain resend.exe. The download may be corrupted -- try again."
+    throw "Installation failed."
+  }
+
+  try {
+    $null = & $stagedExe --version 2>$null
+  } catch {
+    Remove-Item -Recurse -Force $stageDir -ErrorAction SilentlyContinue
+    Write-Fail "Staged binary failed validation (--version check). The download may be corrupted -- try again."
+    throw "Installation failed."
+  }
+
+  Move-Item -Path $stagedExe -Destination $exe -Force
+  Remove-Item -Recurse -Force $stageDir -ErrorAction SilentlyContinue
 } finally {
   Remove-Item -Recurse -Force $tmpDir -ErrorAction SilentlyContinue
 }
 
 if (-not (Test-Path $exe)) {
-  Write-Fail "Binary not found after extraction. The download may be corrupted -- try again."
+  Write-Fail "Binary not found after installation. The download may be corrupted -- try again."
   throw "Installation failed."
 }
 

--- a/install.sh
+++ b/install.sh
@@ -167,17 +167,32 @@ curl --fail --location --progress-bar --output "$tmpfile" "$url" ||
 
   URL: ${url}"
 
-tar -xzf "$tmpfile" -C "$bin_dir" ||
+stage_dir=$(mktemp -d "${install_dir}/.stage.XXXXXX") ||
+  error "Failed to create staging directory"
+trap 'rm -rf "$tmpdir" "$stage_dir"' EXIT INT TERM
+
+tar -xzf "$tmpfile" -C "$stage_dir" ||
   error "Failed to extract archive. The download may be corrupted — try again."
 
-chmod +x "$exe" || error "Failed to make binary executable"
+staged_exe="${stage_dir}/resend"
 
-# Strip macOS Gatekeeper quarantine flag (set automatically on curl downloads)
-# Without this, macOS will block the binary: "cannot be opened because Apple
-# cannot check it for malicious software"
-if [[ $(uname -s) == "Darwin" ]]; then
-  xattr -d com.apple.quarantine "$exe" 2>/dev/null || true
+if [[ ! -f "$staged_exe" ]]; then
+  error "Archive did not contain a 'resend' binary."
 fi
+
+chmod +x "$staged_exe" || error "Failed to make binary executable"
+
+if [[ $(uname -s) == "Darwin" ]]; then
+  xattr -d com.apple.quarantine "$staged_exe" 2>/dev/null || true
+fi
+
+"$staged_exe" --version >/dev/null 2>&1 ||
+  error "Staged binary failed validation (--version check). The download may be corrupted — try again."
+
+mv -f "$staged_exe" "$exe" ||
+  error "Failed to move binary into install directory"
+
+rm -rf "$stage_dir"
 
 # ─── Verify installation ────────────────────────────────────────────────────
 


### PR DESCRIPTION

## Summary by cubic
Make installer upgrades atomic by extracting into a staging directory and swapping the binary only after validation, preventing corrupt or partial upgrades in `install.sh` and `install.ps1`. Addresses BU-663.

- **Bug Fixes**
  - Extract archives to a staging directory under the install path (same filesystem).
  - Validate the staged `resend`/`resend.exe` with `--version`; abort on failure.
  - Atomically move the validated binary into place (`mv -f` / `Move-Item -Force`).
  - Clean up the staging directory; if anything fails, the existing binary is untouched.

<sup>Written for commit 789eb29141f95665cdcf6676bffa803497f6f399. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

