### PR TITLE
fix: enforce secure credential storage when explicitly requested

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -328,15 +328,16 @@ export async function resolveApiKeyAsync(
     creds?.active_profile ||
     'default';
 
-  // If storage is 'secure_storage', try credential backend first
   if (creds?.storage === 'secure_storage') {
     const backend = await getCredentialBackend();
     const key = await backend.get(SERVICE_NAME, profile);
     if (key) {
       const permission = creds.profiles[profile]?.permission;
-      return { key, source: 'secure_storage', profile, permission };
+      const source: ApiKeySource = backend.isSecure
+        ? 'secure_storage'
+        : 'config';
+      return { key, source, profile, permission };
     }
-    // Fall through: profile may not be migrated yet (api_key still in file)
   }
 
   // File-based storage (or unmigrated profile in mixed state)
@@ -387,10 +388,6 @@ export async function storeApiKeyAsync(
   const isFileBackend = !backend.isSecure;
 
   if (isFileBackend) {
-    // Do NOT clear a pre-existing `storage: 'secure_storage'` marker here.
-    // Other profiles may still have their keys in secure storage.
-    // resolveApiKeyAsync already falls through from secure storage to file-based
-    // lookup, so keeping the marker is safe and avoids orphaning those profiles.
     const configPath = storeApiKey(apiKey, profile, permission);
     return { configPath, backend };
   }

--- a/src/lib/credential-store.ts
+++ b/src/lib/credential-store.ts
@@ -25,14 +25,16 @@ export async function getCredentialBackend(): Promise<CredentialBackend> {
 
   if (override === 'secure_storage' || override === 'keychain') {
     const backend = await getOsBackend();
-    if (backend) {
-      cachedBackend = backend;
-      return cachedBackend;
+    if (!backend) {
+      throw new Error(
+        'Secure credential storage was requested (RESEND_CREDENTIAL_STORE=' +
+          `${override}) but no secure backend is available on this system`,
+      );
     }
-    // Fall through to file if keychain forced but unavailable
+    cachedBackend = backend;
+    return cachedBackend;
   }
 
-  // Auto-detect: try OS backend first
   if (!override) {
     const backend = await getOsBackend();
     if (backend) {
@@ -69,7 +71,6 @@ async function getOsBackend(): Promise<CredentialBackend | null> {
   return null;
 }
 
-/** Reset cached backend (for testing) */
 export function resetCredentialBackend(): void {
   cachedBackend = null;
 }

--- a/tests/lib/config-async.test.ts
+++ b/tests/lib/config-async.test.ts
@@ -135,6 +135,43 @@ describe('resolveApiKeyAsync', () => {
     });
   });
 
+  test('reports source as config when backend is not secure despite storage marker', async () => {
+    const configDir = join(tmpDir, 'resend');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
+      join(configDir, 'credentials.json'),
+      JSON.stringify({
+        active_profile: 'default',
+        storage: 'secure_storage',
+        profiles: { default: {} },
+      }),
+    );
+
+    const mockBackend = {
+      get: vi.fn().mockResolvedValue('re_file_key'),
+      set: vi.fn(),
+      delete: vi.fn(),
+      isAvailable: vi.fn().mockResolvedValue(true),
+      name: 'plaintext file',
+      isSecure: false,
+    };
+
+    vi.resetModules();
+    vi.doMock('../../src/lib/credential-store', () => ({
+      getCredentialBackend: vi.fn().mockResolvedValue(mockBackend),
+      SERVICE_NAME: 'resend-cli',
+      resetCredentialBackend: vi.fn(),
+    }));
+
+    const { resolveApiKeyAsync } = await import('../../src/lib/config');
+    const result = await resolveApiKeyAsync();
+    expect(result).toEqual({
+      key: 're_file_key',
+      source: 'config',
+      profile: 'default',
+    });
+  });
+
   test('returns null when keychain has no entry', async () => {
     const configDir = join(tmpDir, 'resend');
     mkdirSync(configDir, { recursive: true });

--- a/tests/lib/credential-store.test.ts
+++ b/tests/lib/credential-store.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { captureTestEnv } from '../helpers';
+
+describe('getCredentialBackend', () => {
+  const restoreEnv = captureTestEnv();
+
+  beforeEach(() => {
+    vi.resetModules();
+    delete process.env.RESEND_CREDENTIAL_STORE;
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    vi.restoreAllMocks();
+  });
+
+  it('returns FileBackend when override is "file"', async () => {
+    process.env.RESEND_CREDENTIAL_STORE = 'file';
+    const { getCredentialBackend } = await import(
+      '../../src/lib/credential-store'
+    );
+    const backend = await getCredentialBackend();
+    expect(backend.isSecure).toBe(false);
+    expect(backend.name).toBe('plaintext file');
+  });
+
+  it('throws when override is "secure_storage" and no OS backend is available', async () => {
+    process.env.RESEND_CREDENTIAL_STORE = 'secure_storage';
+    const { getCredentialBackend } = await import(
+      '../../src/lib/credential-store'
+    );
+    await expect(getCredentialBackend()).rejects.toThrow(
+      'Secure credential storage was requested',
+    );
+  });
+
+  it('throws when override is "keychain" and no OS backend is available', async () => {
+    process.env.RESEND_CREDENTIAL_STORE = 'keychain';
+    const { getCredentialBackend } = await import(
+      '../../src/lib/credential-store'
+    );
+    await expect(getCredentialBackend()).rejects.toThrow(
+      'no secure backend is available',
+    );
+  });
+
+  it('falls back to FileBackend when no override and no OS backend', async () => {
+    const { getCredentialBackend } = await import(
+      '../../src/lib/credential-store'
+    );
+    const backend = await getCredentialBackend();
+    expect(backend.isSecure).toBe(false);
+  });
+});


### PR DESCRIPTION

## Summary by cubic
Enforces secure credential storage when explicitly requested and fixes misleading source reporting. If `RESEND_CREDENTIAL_STORE` is `secure_storage` or `keychain` and no OS backend exists, the CLI now throws instead of writing plaintext (addresses BU-635).

- **Bug Fixes**
  - Throw in `getCredentialBackend()` when a secure backend is forced but unavailable, instead of falling back to plaintext.
  - `resolveApiKeyAsync()` now sets `source` based on `backend.isSecure`; reports `config` when not secure.
  - Added tests for secure-only enforcement and correct source reporting.

- **Migration**
  - CI or environments using `RESEND_CREDENTIAL_STORE=secure_storage` or `keychain` must install an OS keychain (e.g., `secret-tool`, Keychain) or switch the env var to `file`; otherwise the CLI will error.

<sup>Written for commit 6ecdf94cd4d7b9b650286f49a60d0b3192f231d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

