### PR TITLE
fix: sanitize picker labels/hints to prevent terminal escape injection

### DIFF
--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -5,6 +5,7 @@ import type { GlobalOpts } from './client';
 import { requireClient } from './client';
 import { renameProfileAsync, validateProfileName } from './config';
 import { errorMessage, outputError } from './output';
+import { sanitizeTerminalText } from './sanitize-terminal-text';
 import { createSpinner } from './spinner';
 import { isInteractive } from './tty';
 
@@ -357,8 +358,8 @@ export async function pickItem<T extends { id: string }>(
     const options: { value: string; label: string; hint?: string }[] =
       itemOptions.map(({ item, label, hint }) => ({
         value: item.id,
-        label,
-        hint,
+        label: sanitizeTerminalText(label),
+        ...(hint && { hint: sanitizeTerminalText(hint) }),
       }));
 
     if (optional) {

--- a/src/lib/sanitize-terminal-text.ts
+++ b/src/lib/sanitize-terminal-text.ts
@@ -1,0 +1,6 @@
+import { stripVTControlCharacters } from 'node:util';
+
+const C0_C1_REGEX = new RegExp('[\\x00-\\x1f\\x7f-\\x9f]', 'g');
+
+export const sanitizeTerminalText = (value: string): string =>
+  stripVTControlCharacters(value).replace(C0_C1_REGEX, '');

--- a/tests/lib/sanitize-terminal-text.test.ts
+++ b/tests/lib/sanitize-terminal-text.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeTerminalText } from '../../src/lib/sanitize-terminal-text';
+
+describe('sanitizeTerminalText', () => {
+  it('returns plain text unchanged', () => {
+    expect(sanitizeTerminalText('Hello World')).toBe('Hello World');
+  });
+
+  it('strips ANSI color sequences', () => {
+    expect(sanitizeTerminalText('\x1b[31mred text\x1b[0m')).toBe('red text');
+  });
+
+  it('strips OSC 52 clipboard write sequences', () => {
+    expect(sanitizeTerminalText('\x1b]52;c;Zm9v\x07Invoice')).toBe('Invoice');
+  });
+
+  it('strips OSC 8 hyperlink sequences', () => {
+    const input = '\x1b]8;;https://evil.com\x07Click here\x1b]8;;\x07';
+    expect(sanitizeTerminalText(input)).toBe('Click here');
+  });
+
+  it('strips C0 control characters', () => {
+    expect(sanitizeTerminalText('line1\x00line2\x01line3')).toBe(
+      'line1line2line3',
+    );
+  });
+
+  it('strips C1 control characters', () => {
+    expect(sanitizeTerminalText('before\x8dafter')).toBe('beforeafter');
+  });
+
+  it('strips cursor movement sequences', () => {
+    expect(sanitizeTerminalText('\x1b[2J\x1b[HFake prompt')).toBe(
+      'Fake prompt',
+    );
+  });
+
+  it('handles empty string', () => {
+    expect(sanitizeTerminalText('')).toBe('');
+  });
+
+  it('preserves unicode text after stripping escapes', () => {
+    expect(sanitizeTerminalText('\x1b[1mCafé ☕\x1b[0m')).toBe('Café ☕');
+  });
+});


### PR DESCRIPTION

## Summary by cubic
Sanitize picker option labels and hints to strip terminal escape sequences and control characters, preventing terminal escape injection in interactive CLI prompts. Centralized in `pickId()` to protect all `PickerConfig` flows; addresses BU-616.

- **Bug Fixes**
  - Added `sanitizeTerminalText` utility using `node:util`’s `stripVTControlCharacters` and C0/C1 removal.
  - Applied sanitization to `label`/`hint` in `pickId()` before passing to `@clack/prompts`.
  - Added tests covering ANSI/OSC sequences, control bytes, and unicode.

<sup>Written for commit 9d8c423bfcc3fe9d0ba2f63f6add4c4219c8719b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

