### PR TITLE
fix: disable telemetry for non-interactive/CI runs unless opted in

### DIFF
--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -87,6 +87,11 @@ export function trackCommand(
 
   try {
     const interactive = isInteractive() && !opts.json;
+
+    if (!interactive && process.env.RESEND_TELEMETRY_OPT_IN !== '1') {
+      return;
+    }
+
     showFirstRunNotice(interactive);
 
     const distinctId = getOrCreateAnonymousId();

--- a/tests/lib/telemetry.test.ts
+++ b/tests/lib/telemetry.test.ts
@@ -107,6 +107,7 @@ describe('trackCommand', () => {
     process.env.XDG_CONFIG_HOME = testConfigDir;
     delete process.env.DO_NOT_TRACK;
     delete process.env.RESEND_TELEMETRY_DISABLED;
+    process.env.RESEND_TELEMETRY_OPT_IN = '1';
 
     unrefMock = vi.fn();
     const cp = await import('node:child_process');
@@ -264,6 +265,70 @@ describe('trackCommand', () => {
     process.env.RESEND_TELEMETRY_DISABLED = '1';
     trackCommand('emails send', {});
     expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  test('skips telemetry in non-interactive mode without opt-in', () => {
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: undefined,
+      writable: true,
+    });
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: undefined,
+      writable: true,
+    });
+    delete process.env.RESEND_TELEMETRY_OPT_IN;
+
+    trackCommand('emails send', {});
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  test('skips telemetry in CI without opt-in', () => {
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: true,
+      writable: true,
+    });
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: true,
+      writable: true,
+    });
+    process.env.CI = 'true';
+    delete process.env.RESEND_TELEMETRY_OPT_IN;
+
+    trackCommand('emails send', {});
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  test('sends telemetry in non-interactive mode with RESEND_TELEMETRY_OPT_IN=1', () => {
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: undefined,
+      writable: true,
+    });
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: undefined,
+      writable: true,
+    });
+    process.env.RESEND_TELEMETRY_OPT_IN = '1';
+
+    trackCommand('emails send', {});
+    expect(spawnMock).toHaveBeenCalledOnce();
+  });
+
+  test('sends telemetry in interactive mode without opt-in', () => {
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: true,
+      writable: true,
+    });
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: true,
+      writable: true,
+    });
+    delete process.env.CI;
+    delete process.env.GITHUB_ACTIONS;
+    delete process.env.TERM;
+    delete process.env.RESEND_TELEMETRY_OPT_IN;
+
+    trackCommand('emails send', {});
+    expect(spawnMock).toHaveBeenCalledOnce();
   });
 
   test('handles spawn failures gracefully', () => {


### PR DESCRIPTION

## Summary by cubic
Disable CLI telemetry in non-interactive and CI runs by default, unless `RESEND_TELEMETRY_OPT_IN=1` is set. Interactive runs keep the existing behavior with the first-run notice. Addresses Linear BU-620.

- **Bug Fixes**
  - Add early return in `trackCommand` when session is non-interactive and not opted in.
  - Treat CI, piped/non-TTY, and `--json` runs as non-interactive.
  - Add tests covering opt-in gating; adjust existing tests to set `RESEND_TELEMETRY_OPT_IN=1`.

- **Migration**
  - Telemetry in CI/automation is now off by default. Set `RESEND_TELEMETRY_OPT_IN=1` to enable.
  - No change for interactive users; `DO_NOT_TRACK` and `RESEND_TELEMETRY_DISABLED` still work.

<sup>Written for commit 744d93bf8bc71637058887d6d10908b45da88baa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

