### PR TITLE
fix: reject --domain-id when --permission is not sending_access

### DIFF
--- a/src/commands/api-keys/create.ts
+++ b/src/commands/api-keys/create.ts
@@ -34,7 +34,12 @@ Permissions:
   sending_access  Send-only access; optionally scope to a domain with --domain-id`,
       output: `  {"id":"<id>","token":"<token>"}
   The token is only returned at creation time and cannot be retrieved again.`,
-      errorCodes: ['auth_error', 'missing_name', 'create_error'],
+      errorCodes: [
+        'auth_error',
+        'missing_name',
+        'invalid_flags',
+        'create_error',
+      ],
       examples: [
         'resend api-keys create --name "Production"',
         'resend api-keys create --name "CI Token" --permission sending_access',
@@ -89,6 +94,17 @@ Permissions:
     }
 
     let domainId = opts.domainId;
+
+    if (domainId && permission !== 'sending_access') {
+      outputError(
+        {
+          message: '--domain-id requires --permission sending_access',
+          code: 'invalid_flags',
+        },
+        { json: globalOpts.json },
+      );
+    }
+
     if (!domainId && permission === 'sending_access') {
       domainId = await pickId(undefined, domainPickerConfig, globalOpts, {
         optional: true,

--- a/src/commands/api-keys/create.ts
+++ b/src/commands/api-keys/create.ts
@@ -95,7 +95,7 @@ Permissions:
 
     let domainId = opts.domainId;
 
-    if (domainId && permission !== 'sending_access') {
+    if (domainId !== undefined && permission !== 'sending_access') {
       outputError(
         {
           message: '--domain-id requires --permission sending_access',

--- a/tests/commands/api-keys/create.test.ts
+++ b/tests/commands/api-keys/create.test.ts
@@ -235,7 +235,7 @@ describe('api-keys create command', () => {
 
   it('errors with invalid_flags when --domain-id is used without --permission sending_access', async () => {
     setNonInteractive();
-    errorSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
     const { createApiKeyCommand } = await import(
@@ -257,7 +257,7 @@ describe('api-keys create command', () => {
 
   it('errors with invalid_flags when --domain-id is used with --permission full_access', async () => {
     setNonInteractive();
-    errorSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
     const { createApiKeyCommand } = await import(
@@ -283,7 +283,7 @@ describe('api-keys create command', () => {
 
   it('does not call SDK when --domain-id is used without sending_access', async () => {
     setNonInteractive();
-    errorSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
     const { createApiKeyCommand } = await import(

--- a/tests/commands/api-keys/create.test.ts
+++ b/tests/commands/api-keys/create.test.ts
@@ -3,6 +3,7 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
   test,
   vi,
@@ -230,5 +231,95 @@ describe('api-keys create command', () => {
 
     const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
     expect(output).toContain('create_error');
+  });
+
+  it('errors with invalid_flags when --domain-id is used without --permission sending_access', async () => {
+    setNonInteractive();
+    errorSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    exitSpy = mockExitThrow();
+
+    const { createApiKeyCommand } = await import(
+      '../../../src/commands/api-keys/create'
+    );
+    await expectExit1(() =>
+      createApiKeyCommand.parseAsync(
+        ['--name', 'CI Token', '--domain-id', 'domain-123'],
+        { from: 'user' },
+      ),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('invalid_flags');
+    expect(output).toContain(
+      '--domain-id requires --permission sending_access',
+    );
+  });
+
+  it('errors with invalid_flags when --domain-id is used with --permission full_access', async () => {
+    setNonInteractive();
+    errorSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    exitSpy = mockExitThrow();
+
+    const { createApiKeyCommand } = await import(
+      '../../../src/commands/api-keys/create'
+    );
+    await expectExit1(() =>
+      createApiKeyCommand.parseAsync(
+        [
+          '--name',
+          'CI Token',
+          '--permission',
+          'full_access',
+          '--domain-id',
+          'domain-123',
+        ],
+        { from: 'user' },
+      ),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('invalid_flags');
+  });
+
+  it('does not call SDK when --domain-id is used without sending_access', async () => {
+    setNonInteractive();
+    errorSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    exitSpy = mockExitThrow();
+
+    const { createApiKeyCommand } = await import(
+      '../../../src/commands/api-keys/create'
+    );
+    await expectExit1(() =>
+      createApiKeyCommand.parseAsync(
+        ['--name', 'CI Token', '--domain-id', 'domain-123'],
+        { from: 'user' },
+      ),
+    );
+
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it('allows --domain-id with --permission sending_access', async () => {
+    spies = setupOutputSpies();
+
+    const { createApiKeyCommand } = await import(
+      '../../../src/commands/api-keys/create'
+    );
+    await createApiKeyCommand.parseAsync(
+      [
+        '--name',
+        'Domain Token',
+        '--permission',
+        'sending_access',
+        '--domain-id',
+        'domain-123',
+      ],
+      { from: 'user' },
+    );
+
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    const args = mockCreate.mock.calls[0][0] as Record<string, unknown>;
+    expect(args.domain_id).toBe('domain-123');
+    expect(args.permission).toBe('sending_access');
   });
 });


### PR DESCRIPTION

## Summary by cubic
Reject using --domain-id unless --permission is sending_access in the `resend api-keys create` command. Prevents unintended full-access keys and fulfills Linear BU-655.

- **Bug Fixes**
  - Fail fast with `invalid_flags` when `--domain-id` is provided without `--permission sending_access`; skip SDK call.
  - Update documented error codes; add tests covering rejection and valid domain-scoped creation.

<sup>Written for commit 10d76f1e4248ea22b7690a9266eac5989ef832a4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

