### PR TITLE
fix: use structured error output for whoami failures in machine mode

### DIFF
--- a/src/commands/whoami.ts
+++ b/src/commands/whoami.ts
@@ -21,7 +21,7 @@ export const whoamiCommand = new Command('whoami')
       context: `Local only — no network calls.
 Shows which profile is active and where the API key comes from.`,
       output: `  {"authenticated":true,"profile":"production","api_key":"re_...abcd","source":"config","config_path":"/Users/you/.config/resend/credentials.json"}
-  {"authenticated":false}`,
+  {"error":{"message":"Not authenticated.\\nRun \`resend login\` to get started.","code":"not_authenticated"}}`,
       examples: [
         'resend whoami',
         'resend whoami --json',
@@ -42,7 +42,6 @@ Shows which profile is active and where the API key comes from.`,
       const profileExists = profiles.some((p) => p.name === requestedProfile);
       const explicitProfile = profileFlag || process.env.RESEND_PROFILE;
 
-      // If a specific profile was requested but doesn't exist, show a targeted error
       const message =
         explicitProfile && !profileExists
           ? `Profile "${requestedProfile}" not found.\nAvailable profiles: ${profiles.map((p) => p.name).join(', ') || '(none)'}`
@@ -52,20 +51,7 @@ Shows which profile is active and where the API key comes from.`,
           ? 'profile_not_found'
           : 'not_authenticated';
 
-      if (globalOpts.json || !isInteractive()) {
-        outputResult(
-          {
-            authenticated: false,
-            ...(explicitProfile && !profileExists
-              ? { profile: requestedProfile }
-              : {}),
-          },
-          { json: globalOpts.json, exitCode: 1 },
-        );
-        // outputResult with exitCode calls process.exit, but TS doesn't know
-        return;
-      }
-      outputError({ message, code }, { json: false });
+      outputError({ message, code }, { json: globalOpts.json });
       return;
     }
 

--- a/src/commands/whoami.ts
+++ b/src/commands/whoami.ts
@@ -51,10 +51,11 @@ Shows which profile is active and where the API key comes from.`,
           ? 'profile_not_found'
           : 'not_authenticated';
 
-      outputError(
-        { message, code },
-        { json: globalOpts.json || !isInteractive() },
-      );
+      if (globalOpts.json || !isInteractive()) {
+        outputError({ message, code }, { json: globalOpts.json });
+      } else {
+        outputError({ message, code }, { json: false });
+      }
       return;
     }
 

--- a/src/commands/whoami.ts
+++ b/src/commands/whoami.ts
@@ -51,7 +51,10 @@ Shows which profile is active and where the API key comes from.`,
           ? 'profile_not_found'
           : 'not_authenticated';
 
-      outputError({ message, code }, { json: globalOpts.json });
+      outputError(
+        { message, code },
+        { json: globalOpts.json || !isInteractive() },
+      );
       return;
     }
 

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -1,5 +1,4 @@
 import pc from 'picocolors';
-import { isInteractive } from './tty';
 
 export function errorMessage(err: unknown, fallback: string): string {
   return err instanceof Error ? err.message : fallback;
@@ -14,7 +13,7 @@ function shouldOutputJson(json?: boolean): boolean {
   if (json) {
     return true;
   }
-  if (!isInteractive()) {
+  if (!process.stdout.isTTY) {
     return true;
   }
   return false;

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -1,4 +1,5 @@
 import pc from 'picocolors';
+import { isInteractive } from './tty';
 
 export function errorMessage(err: unknown, fallback: string): string {
   return err instanceof Error ? err.message : fallback;
@@ -13,7 +14,7 @@ function shouldOutputJson(json?: boolean): boolean {
   if (json) {
     return true;
   }
-  if (!process.stdout.isTTY) {
+  if (!isInteractive()) {
     return true;
   }
   return false;

--- a/tests/commands/whoami.test.ts
+++ b/tests/commands/whoami.test.ts
@@ -45,18 +45,35 @@ describe('whoami command', () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('exits 1 when not authenticated (non-interactive)', async () => {
+  it('exits 1 with structured error when not authenticated (non-interactive)', async () => {
     spies = setupOutputSpies();
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
     const { whoamiCommand } = await import('../../src/commands/whoami');
     await expectExit1(() => whoamiCommand.parseAsync([], { from: 'user' }));
 
-    const output = spies.logSpy.mock.calls[0]?.[0] as string | undefined;
-    if (output) {
-      const parsed = JSON.parse(output);
-      expect(parsed.authenticated).toBe(false);
-    }
+    const output = String(errorSpy.mock.calls[0]?.[0] ?? '');
+    const parsed = JSON.parse(output);
+    expect(parsed.error).toBeDefined();
+    expect(parsed.error.code).toBe('not_authenticated');
+    expect(parsed.error.message).toContain('Not authenticated');
+  });
+
+  it('exits 1 with profile_not_found error for missing profile (non-interactive)', async () => {
+    process.env.RESEND_PROFILE = 'nonexistent';
+    spies = setupOutputSpies();
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = mockExitThrow();
+
+    const { whoamiCommand } = await import('../../src/commands/whoami');
+    await expectExit1(() => whoamiCommand.parseAsync([], { from: 'user' }));
+
+    const output = String(errorSpy.mock.calls[0]?.[0] ?? '');
+    const parsed = JSON.parse(output);
+    expect(parsed.error).toBeDefined();
+    expect(parsed.error.code).toBe('profile_not_found');
+    expect(parsed.error.message).toContain('not found');
   });
 
   it('shows authenticated JSON when key exists in config', async () => {


### PR DESCRIPTION

## Summary by cubic
Fixes BU-654 by making `whoami` return structured errors in machine mode. Now it outputs `{ "error": { "message": "...", "code": "not_authenticated" | "profile_not_found" } }`, so scripts can parse error codes reliably.

- **Bug Fixes**
  - Use `outputError` for failure paths in machine/non-interactive mode, emitting `not_authenticated` or `profile_not_found`.
  - Updated help text and tests; added a test for the missing profile case.

<sup>Written for commit 3e05eb163620364815b2f2f0284efa2defb38c31. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

