### PR TITLE
fix: forward pagination params in API key picker and list command

### DIFF
--- a/src/commands/api-keys/list.ts
+++ b/src/commands/api-keys/list.ts
@@ -2,6 +2,11 @@ import { Command } from '@commander-js/extra-typings';
 import { runList } from '../../lib/actions';
 import type { GlobalOpts } from '../../lib/client';
 import { buildHelpText } from '../../lib/help-text';
+import {
+  buildPaginationOpts,
+  parseLimitOpt,
+  printPaginationHint,
+} from '../../lib/pagination';
 import { renderApiKeysTable } from './utils';
 
 export const listApiKeysCommand = new Command('list')
@@ -9,22 +14,50 @@ export const listApiKeysCommand = new Command('list')
   .description(
     'List all API keys (IDs and names — tokens are never returned by this endpoint)',
   )
+  .option('--limit <n>', 'Maximum number of API keys to return (1-100)', '10')
+  .option(
+    '--after <cursor>',
+    'Cursor for forward pagination — list items after this ID',
+  )
+  .option(
+    '--before <cursor>',
+    'Cursor for backward pagination — list items before this ID',
+  )
   .addHelpText(
     'after',
     buildHelpText({
-      output: `  {"object":"list","data":[{"id":"<id>","name":"<name>","created_at":"<date>","last_used_at":"<date>|null"}]}
+      output: `  {"object":"list","has_more":false,"data":[{"id":"<id>","name":"<name>","created_at":"<date>","last_used_at":"<date>|null"}]}
   Tokens are never included in list responses.`,
-      errorCodes: ['auth_error', 'list_error'],
-      examples: ['resend api-keys list', 'resend api-keys list --json'],
+      errorCodes: ['auth_error', 'invalid_limit', 'list_error'],
+      examples: [
+        'resend api-keys list',
+        'resend api-keys list --limit 25 --json',
+        'resend api-keys list --after <cursor> --json',
+      ],
     }),
   )
-  .action(async (_opts, cmd) => {
+  .action(async (opts, cmd) => {
     const globalOpts = cmd.optsWithGlobals() as GlobalOpts;
+    const limit = parseLimitOpt(opts.limit, globalOpts);
+    const paginationOpts = buildPaginationOpts(
+      limit,
+      opts.after,
+      opts.before,
+      globalOpts,
+    );
     await runList(
       {
         loading: 'Fetching API keys...',
-        sdkCall: (resend) => resend.apiKeys.list(),
-        onInteractive: (list) => console.log(renderApiKeysTable(list.data)),
+        sdkCall: (resend) => resend.apiKeys.list(paginationOpts),
+        onInteractive: (list) => {
+          console.log(renderApiKeysTable(list.data));
+          printPaginationHint(list, 'api-keys list', {
+            limit,
+            before: opts.before,
+            apiKey: globalOpts.apiKey,
+            profile: globalOpts.profile,
+          });
+        },
       },
       globalOpts,
     );

--- a/src/commands/api-keys/utils.ts
+++ b/src/commands/api-keys/utils.ts
@@ -7,11 +7,8 @@ export const apiKeyPickerConfig: PickerConfig<{
 }> = {
   resource: 'API key',
   resourcePlural: 'API keys',
-  fetchItems: (resend) =>
-    resend.apiKeys.list().then((r) => ({
-      ...r,
-      data: r.data ? { data: r.data.data, has_more: false } : null,
-    })),
+  fetchItems: (resend, { limit, after }) =>
+    resend.apiKeys.list({ limit, ...(after && { after }) }),
   display: (k) => ({ label: k.name, hint: k.id }),
 };
 

--- a/tests/commands/api-keys/list.test.ts
+++ b/tests/commands/api-keys/list.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -33,6 +33,7 @@ const mockList = vi.fn(async () => ({
         last_used_at: null,
       },
     ],
+    has_more: false,
   },
   error: null,
 }));
@@ -67,7 +68,15 @@ describe('api-keys list command', () => {
     exitSpy = undefined;
   });
 
-  test('calls SDK list with no arguments', async () => {
+  function getFirstCallArgs(): unknown {
+    const firstCall = mockList.mock.calls.at(0);
+    if (!firstCall) {
+      throw new Error('Expected mockList to be called at least once');
+    }
+    return firstCall[0];
+  }
+
+  it('uses default limit of 10 when not specified', async () => {
     spies = setupOutputSpies();
 
     const { listApiKeysCommand } = await import(
@@ -76,9 +85,10 @@ describe('api-keys list command', () => {
     await listApiKeysCommand.parseAsync([], { from: 'user' });
 
     expect(mockList).toHaveBeenCalledTimes(1);
+    expect(getFirstCallArgs()).toMatchObject({ limit: 10 });
   });
 
-  test('outputs JSON list when non-interactive', async () => {
+  it('outputs JSON list when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { listApiKeysCommand } = await import(
@@ -94,7 +104,68 @@ describe('api-keys list command', () => {
     expect(parsed.data[0].name).toBe('Production Key');
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('passes limit to SDK', async () => {
+    spies = setupOutputSpies();
+
+    const { listApiKeysCommand } = await import(
+      '../../../src/commands/api-keys/list'
+    );
+    await listApiKeysCommand.parseAsync(['--limit', '25'], { from: 'user' });
+
+    expect(getFirstCallArgs()).toMatchObject({ limit: 25 });
+  });
+
+  it('passes after cursor to SDK', async () => {
+    spies = setupOutputSpies();
+
+    const { listApiKeysCommand } = await import(
+      '../../../src/commands/api-keys/list'
+    );
+    await listApiKeysCommand.parseAsync(['--after', 'some-cursor'], {
+      from: 'user',
+    });
+
+    expect(getFirstCallArgs()).toMatchObject({
+      after: 'some-cursor',
+    });
+  });
+
+  it('passes before cursor to SDK', async () => {
+    spies = setupOutputSpies();
+
+    const { listApiKeysCommand } = await import(
+      '../../../src/commands/api-keys/list'
+    );
+    await listApiKeysCommand.parseAsync(['--before', 'some-cursor'], {
+      from: 'user',
+    });
+
+    expect(getFirstCallArgs()).toMatchObject({
+      before: 'some-cursor',
+    });
+  });
+
+  it('errors when both after and before cursors are provided', async () => {
+    setNonInteractive();
+    errorSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    exitSpy = mockExitThrow();
+
+    const { listApiKeysCommand } = await import(
+      '../../../src/commands/api-keys/list'
+    );
+    await expectExit1(() =>
+      listApiKeysCommand.parseAsync(
+        ['--after', 'cursor_after', '--before', 'cursor_before'],
+        { from: 'user' },
+      ),
+    );
+
+    expect(mockList).not.toHaveBeenCalled();
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('invalid_pagination');
+  });
+
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -112,7 +183,7 @@ describe('api-keys list command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with list_error when SDK returns an error', async () => {
+  it('errors with list_error when SDK returns an error', async () => {
     setNonInteractive();
     mockList.mockResolvedValueOnce(
       mockSdkError('Unauthorized', 'unauthorized'),

--- a/tests/commands/api-keys/list.test.ts
+++ b/tests/commands/api-keys/list.test.ts
@@ -147,7 +147,7 @@ describe('api-keys list command', () => {
 
   it('errors when both after and before cursors are provided', async () => {
     setNonInteractive();
-    errorSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
     const { listApiKeysCommand } = await import(

--- a/tests/commands/api-keys/utils.test.ts
+++ b/tests/commands/api-keys/utils.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+import { apiKeyPickerConfig } from '../../../src/commands/api-keys/utils';
+
+describe('apiKeyPickerConfig', () => {
+  it('forwards limit and after to resend.apiKeys.list', async () => {
+    const mockList = vi.fn(async () => ({
+      data: {
+        data: [{ id: 'key-1', name: 'Key One' }],
+        has_more: true,
+      },
+      error: null,
+    }));
+    const resend = { apiKeys: { list: mockList } } as never;
+
+    const result = await apiKeyPickerConfig.fetchItems(resend, {
+      limit: 20,
+      after: 'cursor-abc',
+    });
+
+    expect(mockList).toHaveBeenCalledWith({
+      limit: 20,
+      after: 'cursor-abc',
+    });
+    expect(result.data?.has_more).toBe(true);
+  });
+
+  it('omits after when not provided', async () => {
+    const mockList = vi.fn(async () => ({
+      data: {
+        data: [{ id: 'key-1', name: 'Key One' }],
+        has_more: false,
+      },
+      error: null,
+    }));
+    const resend = { apiKeys: { list: mockList } } as never;
+
+    await apiKeyPickerConfig.fetchItems(resend, { limit: 20 });
+
+    expect(mockList).toHaveBeenCalledWith({ limit: 20 });
+  });
+
+  it('preserves has_more from the SDK response', async () => {
+    const mockList = vi.fn(async () => ({
+      data: {
+        data: [{ id: 'key-1', name: 'Key One' }],
+        has_more: true,
+      },
+      error: null,
+    }));
+    const resend = { apiKeys: { list: mockList } } as never;
+
+    const result = await apiKeyPickerConfig.fetchItems(resend, { limit: 20 });
+
+    expect(result.data?.has_more).toBe(true);
+  });
+
+  it('displays name as label and id as hint', () => {
+    const item = { id: 'key-123', name: 'My API Key' };
+    const display = apiKeyPickerConfig.display(item);
+
+    expect(display).toEqual({ label: 'My API Key', hint: 'key-123' });
+  });
+});


### PR DESCRIPTION

## Summary by cubic
Fixes pagination in the API key picker so you can revoke keys beyond the first page, and adds pagination flags to `api-keys list` for consistency and better navigation. Addresses BU-615.

- **Bug Fixes**
  - Picker now forwards `limit` and `after` to `resend.apiKeys.list()` and preserves `has_more`, enabling interactive deletion of older keys.
  - Added tests to confirm pagination forwarding and behavior.

- **New Features**
  - `api-keys list` now supports `--limit`, `--after`, and `--before`, forwards options to the SDK, and prints a pagination hint; default limit is 10.
  - Validates cursors and returns `invalid_pagination` if both `--after` and `--before` are provided.

<sup>Written for commit dfd9471269a772af74f84a0c145a1258905c4494. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

