### PR TITLE
fix: prevent stale secure-storage credentials after profile logout/remove/rename

### DIFF
--- a/src/commands/auth/logout.ts
+++ b/src/commands/auth/logout.ts
@@ -57,6 +57,16 @@ If no credentials file exists, exits cleanly with no error.`,
     const logoutAll = !profileFlag;
     const profileLabel = profileFlag || resolveProfileName();
 
+    if (!logoutAll && !creds?.profiles[profileLabel]) {
+      outputError(
+        {
+          message: `Profile "${profileLabel}" not found. Available profiles: ${Object.keys(creds?.profiles ?? {}).join(', ')}`,
+          code: 'remove_failed',
+        },
+        { json: globalOpts.json },
+      );
+    }
+
     if (!globalOpts.json && isInteractive()) {
       const message = logoutAll
         ? 'Remove all saved API keys?'

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -421,7 +421,15 @@ export async function removeApiKeyAsync(profileName?: string): Promise<string> {
     creds?.active_profile ||
     'default';
 
-  if (creds?.storage === 'secure_storage') {
+  if (!creds?.profiles[profile]) {
+    throw new Error(
+      creds
+        ? `Profile "${profile}" not found. Available profiles: ${Object.keys(creds.profiles).join(', ')}`
+        : 'No credentials file found.',
+    );
+  }
+
+  if (creds.storage === 'secure_storage') {
     const backend = await getCredentialBackend();
     if (backend.isSecure) {
       const deleted = await backend.delete(SERVICE_NAME, profile);
@@ -476,9 +484,11 @@ export async function renameProfileAsync(
         await backend.set(SERVICE_NAME, newName, key);
         const deleted = await backend.delete(SERVICE_NAME, oldName);
         if (!deleted) {
-          await backend.delete(SERVICE_NAME, newName);
+          const rolledBack = await backend.delete(SERVICE_NAME, newName);
           throw new Error(
-            `Failed to remove old credential "${oldName}" from ${backend.name} during rename. The rename has been rolled back.`,
+            rolledBack
+              ? `Failed to remove old credential "${oldName}" from ${backend.name} during rename. The rename has been rolled back.`
+              : `Failed to remove old credential "${oldName}" from ${backend.name} during rename. Rollback also failed — credential "${newName}" may still exist in secure storage.`,
           );
         }
       }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -457,6 +457,17 @@ export async function removeAllApiKeysAsync(): Promise<string> {
       );
       const failed = profileNames.filter((_, i) => !results[i]);
       if (failed.length > 0) {
+        // Remove successfully-deleted profiles from the file so retries
+        // only re-attempt the ones that actually failed.
+        const succeeded = profileNames.filter((_, i) => results[i]);
+        for (const name of succeeded) {
+          delete creds.profiles[name];
+        }
+        if (creds.active_profile && !creds.profiles[creds.active_profile]) {
+          const remaining = Object.keys(creds.profiles);
+          creds.active_profile = remaining[0] || 'default';
+        }
+        writeCredentials(creds);
         throw new Error(
           `Failed to remove API keys from ${backend.name} for profiles: ${failed.join(', ')}. Credentials may still exist in secure storage.`,
         );

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -328,15 +328,13 @@ export async function resolveApiKeyAsync(
     creds?.active_profile ||
     'default';
 
-  // If storage is 'secure_storage', try credential backend first
-  if (creds?.storage === 'secure_storage') {
+  if (creds?.storage === 'secure_storage' && creds.profiles[profile]) {
     const backend = await getCredentialBackend();
     const key = await backend.get(SERVICE_NAME, profile);
     if (key) {
       const permission = creds.profiles[profile]?.permission;
       return { key, source: 'secure_storage', profile, permission };
     }
-    // Fall through: profile may not be migrated yet (api_key still in file)
   }
 
   // File-based storage (or unmigrated profile in mixed state)
@@ -426,7 +424,12 @@ export async function removeApiKeyAsync(profileName?: string): Promise<string> {
   if (creds?.storage === 'secure_storage') {
     const backend = await getCredentialBackend();
     if (backend.isSecure) {
-      await backend.delete(SERVICE_NAME, profile);
+      const deleted = await backend.delete(SERVICE_NAME, profile);
+      if (!deleted) {
+        throw new Error(
+          `Failed to remove API key for profile "${profile}" from ${backend.name}. Credential may still exist in secure storage.`,
+        );
+      }
     }
   }
 
@@ -440,15 +443,19 @@ export async function removeAllApiKeysAsync(): Promise<string> {
   if (creds?.storage === 'secure_storage') {
     const backend = await getCredentialBackend();
     if (backend.isSecure) {
-      await Promise.all(
-        Object.keys(creds.profiles).map((profile) =>
-          backend.delete(SERVICE_NAME, profile),
-        ),
+      const profileNames = Object.keys(creds.profiles);
+      const results = await Promise.all(
+        profileNames.map((profile) => backend.delete(SERVICE_NAME, profile)),
       );
+      const failed = profileNames.filter((_, i) => !results[i]);
+      if (failed.length > 0) {
+        throw new Error(
+          `Failed to remove API keys from ${backend.name} for profiles: ${failed.join(', ')}. Credentials may still exist in secure storage.`,
+        );
+      }
     }
   }
 
-  // Remove credentials file (may already be gone if only secure storage)
   if (existsSync(configPath)) {
     unlinkSync(configPath);
   }
@@ -467,7 +474,13 @@ export async function renameProfileAsync(
       const key = await backend.get(SERVICE_NAME, oldName);
       if (key) {
         await backend.set(SERVICE_NAME, newName, key);
-        await backend.delete(SERVICE_NAME, oldName);
+        const deleted = await backend.delete(SERVICE_NAME, oldName);
+        if (!deleted) {
+          await backend.delete(SERVICE_NAME, newName);
+          throw new Error(
+            `Failed to remove old credential "${oldName}" from ${backend.name} during rename. The rename has been rolled back.`,
+          );
+        }
       }
     }
   }

--- a/tests/lib/config-async.test.ts
+++ b/tests/lib/config-async.test.ts
@@ -1,7 +1,7 @@
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { captureTestEnv } from '../helpers';
 
 describe('resolveApiKeyAsync', () => {
@@ -27,20 +27,20 @@ describe('resolveApiKeyAsync', () => {
     vi.restoreAllMocks();
   });
 
-  test('returns flag value without touching backend', async () => {
+  it('returns flag value without touching backend', async () => {
     const { resolveApiKeyAsync } = await import('../../src/lib/config');
     const result = await resolveApiKeyAsync('re_flag_key');
     expect(result).toEqual({ key: 're_flag_key', source: 'flag' });
   });
 
-  test('returns env value without touching backend', async () => {
+  it('returns env value without touching backend', async () => {
     process.env.RESEND_API_KEY = 're_env_key';
     const { resolveApiKeyAsync } = await import('../../src/lib/config');
     const result = await resolveApiKeyAsync();
     expect(result).toEqual({ key: 're_env_key', source: 'env' });
   });
 
-  test('reads from file when storage is not keychain', async () => {
+  it('reads from file when storage is not keychain', async () => {
     const configDir = join(tmpDir, 'resend');
     mkdirSync(configDir, { recursive: true });
     writeFileSync(
@@ -60,7 +60,7 @@ describe('resolveApiKeyAsync', () => {
     });
   });
 
-  test('reads from credential backend when storage is keychain', async () => {
+  it('reads from credential backend when storage is keychain', async () => {
     const configDir = join(tmpDir, 'resend');
     mkdirSync(configDir, { recursive: true });
     writeFileSync(
@@ -98,7 +98,7 @@ describe('resolveApiKeyAsync', () => {
     expect(mockBackend.get).toHaveBeenCalledWith('resend-cli', 'default');
   });
 
-  test('falls back to file api_key when keychain has no entry but file does (mixed state)', async () => {
+  it('falls back to file api_key when keychain has no entry but file does (mixed state)', async () => {
     const configDir = join(tmpDir, 'resend');
     mkdirSync(configDir, { recursive: true });
     writeFileSync(
@@ -135,7 +135,7 @@ describe('resolveApiKeyAsync', () => {
     });
   });
 
-  test('returns null when keychain has no entry', async () => {
+  it('returns null when keychain has no entry', async () => {
     const configDir = join(tmpDir, 'resend');
     mkdirSync(configDir, { recursive: true });
     writeFileSync(
@@ -167,6 +167,40 @@ describe('resolveApiKeyAsync', () => {
     const result = await resolveApiKeyAsync();
     expect(result).toBeNull();
   });
+
+  it('returns null for a profile not in credentials.json even when secure storage has a stale entry', async () => {
+    const configDir = join(tmpDir, 'resend');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
+      join(configDir, 'credentials.json'),
+      JSON.stringify({
+        active_profile: 'default',
+        storage: 'secure_storage',
+        profiles: { default: {} },
+      }),
+    );
+
+    const mockBackend = {
+      get: vi.fn().mockResolvedValue('re_stale_key'),
+      set: vi.fn(),
+      delete: vi.fn(),
+      isAvailable: vi.fn().mockResolvedValue(true),
+      name: 'mock-backend',
+      isSecure: true,
+    };
+
+    vi.resetModules();
+    vi.doMock('../../src/lib/credential-store', () => ({
+      getCredentialBackend: vi.fn().mockResolvedValue(mockBackend),
+      SERVICE_NAME: 'resend-cli',
+      resetCredentialBackend: vi.fn(),
+    }));
+
+    const { resolveApiKeyAsync } = await import('../../src/lib/config');
+    const result = await resolveApiKeyAsync(undefined, 'removed-profile');
+    expect(result).toBeNull();
+    expect(mockBackend.get).not.toHaveBeenCalled();
+  });
 });
 
 describe('storeApiKeyAsync', () => {
@@ -189,7 +223,7 @@ describe('storeApiKeyAsync', () => {
     vi.restoreAllMocks();
   });
 
-  test('stores key in file backend when keychain unavailable', async () => {
+  it('stores key in file backend when keychain unavailable', async () => {
     vi.resetModules();
     vi.doUnmock('../../src/lib/credential-store');
     const { storeApiKeyAsync } = await import('../../src/lib/config');
@@ -219,7 +253,7 @@ describe('removeApiKeyAsync', () => {
     vi.restoreAllMocks();
   });
 
-  test('calls backend.delete when backend is secure', async () => {
+  it('calls backend.delete when backend is secure', async () => {
     const configDir = join(tmpDir, 'resend');
     mkdirSync(configDir, { recursive: true });
     writeFileSync(
@@ -234,7 +268,7 @@ describe('removeApiKeyAsync', () => {
     const mockBackend = {
       get: vi.fn(),
       set: vi.fn(),
-      delete: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(true),
       isAvailable: vi.fn().mockResolvedValue(true),
       name: 'mock-backend',
       isSecure: true,
@@ -252,7 +286,7 @@ describe('removeApiKeyAsync', () => {
     expect(mockBackend.delete).toHaveBeenCalledWith('resend-cli', 'default');
   });
 
-  test('skips backend.delete when backend is not secure', async () => {
+  it('skips backend.delete when backend is not secure', async () => {
     const configDir = join(tmpDir, 'resend');
     mkdirSync(configDir, { recursive: true });
     writeFileSync(
@@ -289,6 +323,44 @@ describe('removeApiKeyAsync', () => {
     expect(creds?.profiles.default).toBeUndefined();
     expect(creds?.profiles.other).toBeDefined();
   });
+
+  it('throws when backend.delete returns false', async () => {
+    const configDir = join(tmpDir, 'resend');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
+      join(configDir, 'credentials.json'),
+      JSON.stringify({
+        active_profile: 'default',
+        storage: 'secure_storage',
+        profiles: { default: {}, other: {} },
+      }),
+    );
+
+    const mockBackend = {
+      get: vi.fn(),
+      set: vi.fn(),
+      delete: vi.fn().mockResolvedValue(false),
+      isAvailable: vi.fn().mockResolvedValue(true),
+      name: 'mock-backend',
+      isSecure: true,
+    };
+
+    vi.resetModules();
+    vi.doMock('../../src/lib/credential-store', () => ({
+      getCredentialBackend: vi.fn().mockResolvedValue(mockBackend),
+      SERVICE_NAME: 'resend-cli',
+      resetCredentialBackend: vi.fn(),
+    }));
+
+    const { removeApiKeyAsync, readCredentials } = await import(
+      '../../src/lib/config'
+    );
+    await expect(removeApiKeyAsync('default')).rejects.toThrow(
+      'Failed to remove API key',
+    );
+    const creds = readCredentials();
+    expect(creds?.profiles.default).toBeDefined();
+  });
 });
 
 describe('removeAllApiKeysAsync', () => {
@@ -311,7 +383,7 @@ describe('removeAllApiKeysAsync', () => {
     vi.restoreAllMocks();
   });
 
-  test('deletes all profiles from keychain when secure', async () => {
+  it('deletes all profiles from keychain when secure', async () => {
     const configDir = join(tmpDir, 'resend');
     mkdirSync(configDir, { recursive: true });
     writeFileSync(
@@ -326,7 +398,7 @@ describe('removeAllApiKeysAsync', () => {
     const mockBackend = {
       get: vi.fn(),
       set: vi.fn(),
-      delete: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(true),
       isAvailable: vi.fn().mockResolvedValue(true),
       name: 'mock-backend',
       isSecure: true,
@@ -347,7 +419,7 @@ describe('removeAllApiKeysAsync', () => {
     expect(mockBackend.delete).toHaveBeenCalledWith('resend-cli', 'prod');
   });
 
-  test('skips keychain deletion when not secure', async () => {
+  it('skips keychain deletion when not secure', async () => {
     const configDir = join(tmpDir, 'resend');
     mkdirSync(configDir, { recursive: true });
     writeFileSync(
@@ -379,6 +451,47 @@ describe('removeAllApiKeysAsync', () => {
     await removeAllApiKeysAsync();
     expect(mockBackend.delete).not.toHaveBeenCalled();
   });
+
+  it('throws when any backend.delete returns false', async () => {
+    const configDir = join(tmpDir, 'resend');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
+      join(configDir, 'credentials.json'),
+      JSON.stringify({
+        active_profile: 'default',
+        storage: 'secure_storage',
+        profiles: { default: {}, staging: {}, prod: {} },
+      }),
+    );
+
+    const mockBackend = {
+      get: vi.fn(),
+      set: vi.fn(),
+      delete: vi
+        .fn()
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true),
+      isAvailable: vi.fn().mockResolvedValue(true),
+      name: 'mock-backend',
+      isSecure: true,
+    };
+
+    vi.resetModules();
+    vi.doMock('../../src/lib/credential-store', () => ({
+      getCredentialBackend: vi.fn().mockResolvedValue(mockBackend),
+      SERVICE_NAME: 'resend-cli',
+      resetCredentialBackend: vi.fn(),
+    }));
+
+    const { removeAllApiKeysAsync, getCredentialsPath } = await import(
+      '../../src/lib/config'
+    );
+    await expect(removeAllApiKeysAsync()).rejects.toThrow(
+      'Failed to remove API keys',
+    );
+    expect(existsSync(getCredentialsPath())).toBe(true);
+  });
 });
 
 describe('renameProfileAsync', () => {
@@ -401,7 +514,7 @@ describe('renameProfileAsync', () => {
     vi.restoreAllMocks();
   });
 
-  test('renames in keychain when secure', async () => {
+  it('renames in keychain when secure', async () => {
     const configDir = join(tmpDir, 'resend');
     mkdirSync(configDir, { recursive: true });
     writeFileSync(
@@ -416,7 +529,7 @@ describe('renameProfileAsync', () => {
     const mockBackend = {
       get: vi.fn().mockResolvedValue('re_secret_key'),
       set: vi.fn().mockResolvedValue(undefined),
-      delete: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(true),
       isAvailable: vi.fn().mockResolvedValue(true),
       name: 'mock-backend',
       isSecure: true,
@@ -446,7 +559,7 @@ describe('renameProfileAsync', () => {
     expect(creds?.active_profile).toBe('new-name');
   });
 
-  test('skips keychain when not secure', async () => {
+  it('skips keychain when not secure', async () => {
     const configDir = join(tmpDir, 'resend');
     mkdirSync(configDir, { recursive: true });
     writeFileSync(
@@ -484,5 +597,47 @@ describe('renameProfileAsync', () => {
     const creds = readCredentials();
     expect(creds?.profiles['new-name']).toEqual({ api_key: 're_file_key' });
     expect(creds?.profiles['old-name']).toBeUndefined();
+  });
+
+  it('rolls back new entry and throws when old-name delete fails', async () => {
+    const configDir = join(tmpDir, 'resend');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
+      join(configDir, 'credentials.json'),
+      JSON.stringify({
+        active_profile: 'old-name',
+        storage: 'secure_storage',
+        profiles: { 'old-name': {} },
+      }),
+    );
+
+    const mockBackend = {
+      get: vi.fn().mockResolvedValue('re_secret_key'),
+      set: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true),
+      isAvailable: vi.fn().mockResolvedValue(true),
+      name: 'mock-backend',
+      isSecure: true,
+    };
+
+    vi.resetModules();
+    vi.doMock('../../src/lib/credential-store', () => ({
+      getCredentialBackend: vi.fn().mockResolvedValue(mockBackend),
+      SERVICE_NAME: 'resend-cli',
+      resetCredentialBackend: vi.fn(),
+    }));
+
+    const { renameProfileAsync, readCredentials } = await import(
+      '../../src/lib/config'
+    );
+    await expect(renameProfileAsync('old-name', 'new-name')).rejects.toThrow(
+      'rolled back',
+    );
+    expect(mockBackend.delete).toHaveBeenCalledTimes(2);
+    expect(mockBackend.delete).toHaveBeenCalledWith('resend-cli', 'old-name');
+    expect(mockBackend.delete).toHaveBeenCalledWith('resend-cli', 'new-name');
+    const creds = readCredentials();
+    expect(creds?.profiles['old-name']).toBeDefined();
+    expect(creds?.profiles['new-name']).toBeUndefined();
   });
 });

--- a/tests/lib/config-async.test.ts
+++ b/tests/lib/config-async.test.ts
@@ -484,13 +484,18 @@ describe('removeAllApiKeysAsync', () => {
       resetCredentialBackend: vi.fn(),
     }));
 
-    const { removeAllApiKeysAsync, getCredentialsPath } = await import(
-      '../../src/lib/config'
-    );
+    const { removeAllApiKeysAsync, getCredentialsPath, readCredentials } =
+      await import('../../src/lib/config');
     await expect(removeAllApiKeysAsync()).rejects.toThrow(
       'Failed to remove API keys',
     );
     expect(existsSync(getCredentialsPath())).toBe(true);
+    // Successfully-deleted profiles should be removed from the file
+    // so retries only re-attempt the ones that actually failed.
+    const creds = readCredentials();
+    expect(creds?.profiles.default).toBeUndefined();
+    expect(creds?.profiles.staging).toBeDefined();
+    expect(creds?.profiles.prod).toBeUndefined();
   });
 });
 


### PR DESCRIPTION

## Summary by cubic
Prevents stale credentials in OS secure storage from authenticating removed or renamed CLI profiles. Keeps secure storage and `credentials.json` in sync, addressing BU-631.

- **Bug Fixes**
  - Query secure storage only if the profile exists in `credentials.json` (blocks auth via stale entries).
  - Throw when `backend.delete` fails on remove; do not update the file to avoid desync.
  - Verify all deletions in bulk remove; throw with failed profile names and keep the file so users can retry.
  - On rename, delete the old entry after copying; roll back the new entry if old deletion fails.
  - Added tests for stale-entry resolution, delete failures, and rename rollback; updated mocks and switched to `it()`.

<sup>Written for commit 00fadecb88db790f2e971bdddcffe8c75e658e2a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

