### PR TITLE
fix: replace unbounded seenIds Set with bounded LRU set in email listener

### DIFF
--- a/src/commands/emails/receiving/listen.ts
+++ b/src/commands/emails/receiving/listen.ts
@@ -8,6 +8,7 @@ import { buildHelpText } from '../../../lib/help-text';
 import { errorMessage, outputError } from '../../../lib/output';
 import { createSpinner } from '../../../lib/spinner';
 import { isInteractive } from '../../../lib/tty';
+import { createBoundedSet } from '../../../utils/bounded-set';
 
 const PAGE_SIZE = 100;
 
@@ -78,7 +79,7 @@ Ctrl+C exits cleanly.`,
       globalOpts.quiet || jsonMode,
     );
 
-    const seenIds = new Set<string>();
+    const seenIds = createBoundedSet<string>();
     let consecutiveErrors = 0;
 
     try {

--- a/src/commands/emails/receiving/listen.ts
+++ b/src/commands/emails/receiving/listen.ts
@@ -184,13 +184,17 @@ Ctrl+C exits cleanly.`,
 
         consecutiveErrors = 0;
 
+        // Reverse to chronological order so newest IDs land at the
+        // tail of the LRU and are evicted last.
+        newEmails.reverse();
+
         // Mark all new emails as seen
         for (const email of newEmails) {
           seenIds.add(email.id);
         }
 
         // Display in chronological order (oldest first)
-        for (const email of newEmails.reverse()) {
+        for (const email of newEmails) {
           displayEmail(email, jsonMode);
         }
       } catch (err) {

--- a/src/utils/bounded-set.ts
+++ b/src/utils/bounded-set.ts
@@ -9,6 +9,10 @@ const DEFAULT_MAX_SIZE = 10_000;
 export const createBoundedSet = <T>(
   maxSize: number = DEFAULT_MAX_SIZE,
 ): BoundedSet<T> => {
+  if (!Number.isInteger(maxSize) || maxSize < 1) {
+    throw new RangeError(`maxSize must be a positive integer, got ${maxSize}`);
+  }
+
   const map = new Map<T, true>();
 
   const evict = () => {
@@ -19,7 +23,14 @@ export const createBoundedSet = <T>(
   };
 
   return {
-    has: (value: T) => map.has(value),
+    has: (value: T) => {
+      if (map.has(value)) {
+        map.delete(value);
+        map.set(value, true);
+        return true;
+      }
+      return false;
+    },
 
     add: (value: T) => {
       if (map.has(value)) {

--- a/src/utils/bounded-set.ts
+++ b/src/utils/bounded-set.ts
@@ -1,0 +1,38 @@
+export type BoundedSet<T> = {
+  readonly has: (value: T) => boolean;
+  readonly add: (value: T) => void;
+  readonly size: () => number;
+};
+
+const DEFAULT_MAX_SIZE = 10_000;
+
+export const createBoundedSet = <T>(
+  maxSize: number = DEFAULT_MAX_SIZE,
+): BoundedSet<T> => {
+  const map = new Map<T, true>();
+
+  const evict = () => {
+    const oldest = map.keys().next();
+    if (!oldest.done) {
+      map.delete(oldest.value);
+    }
+  };
+
+  return {
+    has: (value: T) => map.has(value),
+
+    add: (value: T) => {
+      if (map.has(value)) {
+        map.delete(value);
+        map.set(value, true);
+        return;
+      }
+      if (map.size >= maxSize) {
+        evict();
+      }
+      map.set(value, true);
+    },
+
+    size: () => map.size,
+  };
+};

--- a/tests/utils/bounded-set.test.ts
+++ b/tests/utils/bounded-set.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { createBoundedSet } from '../../src/utils/bounded-set';
+
+describe('createBoundedSet', () => {
+  it('tracks membership correctly', () => {
+    const set = createBoundedSet<string>(5);
+    set.add('a');
+    set.add('b');
+
+    expect(set.has('a')).toBe(true);
+    expect(set.has('b')).toBe(true);
+    expect(set.has('c')).toBe(false);
+  });
+
+  it('evicts oldest entries when capacity is exceeded', () => {
+    const set = createBoundedSet<string>(3);
+    set.add('a');
+    set.add('b');
+    set.add('c');
+    set.add('d');
+
+    expect(set.has('a')).toBe(false);
+    expect(set.has('b')).toBe(true);
+    expect(set.has('c')).toBe(true);
+    expect(set.has('d')).toBe(true);
+    expect(set.size()).toBe(3);
+  });
+
+  it('refreshes recently re-added entries to prevent premature eviction', () => {
+    const set = createBoundedSet<string>(3);
+    set.add('a');
+    set.add('b');
+    set.add('c');
+
+    set.add('a');
+
+    set.add('d');
+
+    expect(set.has('a')).toBe(true);
+    expect(set.has('b')).toBe(false);
+    expect(set.has('c')).toBe(true);
+    expect(set.has('d')).toBe(true);
+  });
+
+  it('does not exceed the configured capacity', () => {
+    const set = createBoundedSet<number>(5);
+    const entries = Array.from({ length: 20 }, (_, i) => i);
+    entries.forEach((n) => {
+      set.add(n);
+    });
+
+    expect(set.size()).toBe(5);
+
+    const retained = entries.filter((n) => set.has(n));
+    expect(retained).toEqual([15, 16, 17, 18, 19]);
+  });
+
+  it('handles duplicate adds without growing', () => {
+    const set = createBoundedSet<string>(3);
+    set.add('x');
+    set.add('x');
+    set.add('x');
+
+    expect(set.size()).toBe(1);
+    expect(set.has('x')).toBe(true);
+  });
+
+  it('uses default capacity when none is provided', () => {
+    const set = createBoundedSet<number>();
+    const entries = Array.from({ length: 10_001 }, (_, i) => i);
+    entries.forEach((n) => {
+      set.add(n);
+    });
+
+    expect(set.size()).toBe(10_000);
+    expect(set.has(0)).toBe(false);
+    expect(set.has(10_000)).toBe(true);
+  });
+});

--- a/tests/utils/bounded-set.test.ts
+++ b/tests/utils/bounded-set.test.ts
@@ -65,6 +65,33 @@ describe('createBoundedSet', () => {
     expect(set.has('x')).toBe(true);
   });
 
+  it('refreshes LRU position on has() checks', () => {
+    const set = createBoundedSet<string>(3);
+    set.add('a');
+    set.add('b');
+    set.add('c');
+
+    // Touch 'a' via has() to refresh its position
+    expect(set.has('a')).toBe(true);
+
+    // 'b' is now the oldest — should be evicted
+    set.add('d');
+    expect(set.has('b')).toBe(false);
+    expect(set.has('a')).toBe(true);
+    expect(set.has('c')).toBe(true);
+    expect(set.has('d')).toBe(true);
+  });
+
+  it('throws on invalid maxSize', () => {
+    expect(() => createBoundedSet(0)).toThrow(RangeError);
+    expect(() => createBoundedSet(-1)).toThrow(RangeError);
+    expect(() => createBoundedSet(3.5)).toThrow(RangeError);
+    expect(() => createBoundedSet(Number.NaN)).toThrow(RangeError);
+    expect(() => createBoundedSet(Number.POSITIVE_INFINITY)).toThrow(
+      RangeError,
+    );
+  });
+
   it('uses default capacity when none is provided', () => {
     const set = createBoundedSet<number>();
     const entries = Array.from({ length: 10_001 }, (_, i) => i);


### PR DESCRIPTION

## Summary by cubic
Replace the unbounded seenIds Set in the inbound email listener with a bounded LRU set to stop linear memory growth and OOMs on busy inboxes. Caps dedup memory to 10,000 IDs while keeping recent-email dedup; resolves BU-643.

- **Bug Fixes**
  - Implemented a Map-based `createBoundedSet` with O(1) eviction and used it in the email receive listener.
  - Added tests for membership, eviction on overflow, LRU refresh on re-add, capacity limits, duplicates, and default size.

<sup>Written for commit 10aad893537b65167a13134a7a696121a9c32d64. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

