### PR TITLE
fix: add timeout to doctor API validation probe

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -14,7 +14,7 @@ import { createSpinner } from '../lib/spinner';
 import { isInteractive } from '../lib/tty';
 import { GITHUB_RELEASES_URL } from '../lib/update-check';
 import { VERSION } from '../lib/version';
-import { withTimeout } from '../utils/with-timeout';
+import { TIMEOUT_ERROR_NAME, withTimeout } from '../utils/with-timeout';
 
 const API_TIMEOUT_MS = 5000;
 
@@ -158,6 +158,14 @@ async function checkApiValidationAndDomains(
       detail: domains.map((d) => `${d.name} (${d.status})`).join(', '),
     };
   } catch (err) {
+    if (err instanceof Error && err.name === TIMEOUT_ERROR_NAME) {
+      return {
+        name: 'API Validation',
+        status: 'warn',
+        message: 'Could not reach Resend API (request timed out)',
+        detail: 'Check your network connection and try again',
+      };
+    }
     return {
       name: 'API Validation',
       status: 'fail',

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -14,6 +14,9 @@ import { createSpinner } from '../lib/spinner';
 import { isInteractive } from '../lib/tty';
 import { GITHUB_RELEASES_URL } from '../lib/update-check';
 import { VERSION } from '../lib/version';
+import { withTimeout } from '../utils/with-timeout';
+
+const API_TIMEOUT_MS = 5000;
 
 type CheckStatus = 'pass' | 'warn' | 'fail';
 
@@ -104,7 +107,10 @@ async function checkApiValidationAndDomains(
 
   try {
     const resend = new Resend(resolved.key);
-    const { data, error } = await resend.domains.list();
+    const { data, error } = await withTimeout(
+      resend.domains.list(),
+      API_TIMEOUT_MS,
+    );
 
     if (error) {
       const err = error as { name?: string; message?: string };

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -122,6 +122,13 @@ async function checkApiValidationAndDomains(
           detail: SENDING_KEY_MESSAGE,
         };
       }
+      if (err.name === 'application_error') {
+        return {
+          name: 'API Validation',
+          status: 'warn',
+          message: 'Network error. Check your connection and try again',
+        };
+      }
       return {
         name: 'API Validation',
         status: 'fail',
@@ -162,8 +169,7 @@ async function checkApiValidationAndDomains(
       return {
         name: 'API Validation',
         status: 'warn',
-        message: 'Could not reach Resend API (request timed out)',
-        detail: 'Check your network connection and try again',
+        message: 'Request timed out',
       };
     }
     return {

--- a/src/utils/with-timeout.ts
+++ b/src/utils/with-timeout.ts
@@ -1,4 +1,4 @@
-const TIMEOUT_ERROR_NAME = 'TimeoutError';
+export const TIMEOUT_ERROR_NAME = 'TimeoutError';
 
 export const withTimeout = <T>(promise: Promise<T>, ms: number): Promise<T> => {
   let id: ReturnType<typeof setTimeout>;

--- a/src/utils/with-timeout.ts
+++ b/src/utils/with-timeout.ts
@@ -1,14 +1,17 @@
 const TIMEOUT_ERROR_NAME = 'TimeoutError';
 
 export const withTimeout = <T>(promise: Promise<T>, ms: number): Promise<T> => {
+  let id: ReturnType<typeof setTimeout>;
+
   const timeout = new Promise<never>((_, reject) => {
-    const id = setTimeout(() => {
-      clearTimeout(id);
+    id = setTimeout(() => {
       const error = new Error(`Operation timed out after ${ms}ms`);
       error.name = TIMEOUT_ERROR_NAME;
       reject(error);
     }, ms);
   });
 
-  return Promise.race([promise, timeout]);
+  return Promise.race([promise, timeout]).finally(() => {
+    clearTimeout(id);
+  });
 };

--- a/src/utils/with-timeout.ts
+++ b/src/utils/with-timeout.ts
@@ -1,0 +1,14 @@
+const TIMEOUT_ERROR_NAME = 'TimeoutError';
+
+export const withTimeout = <T>(promise: Promise<T>, ms: number): Promise<T> => {
+  const timeout = new Promise<never>((_, reject) => {
+    const id = setTimeout(() => {
+      clearTimeout(id);
+      const error = new Error(`Operation timed out after ${ms}ms`);
+      error.name = TIMEOUT_ERROR_NAME;
+      reject(error);
+    }, ms);
+  });
+
+  return Promise.race([promise, timeout]);
+};

--- a/tests/commands/doctor.test.ts
+++ b/tests/commands/doctor.test.ts
@@ -200,15 +200,12 @@ describe('doctor command', () => {
     expect(apiCheck.message).toContain('Sending-only API key');
   });
 
-  it('fails API validation when domains.list times out', async () => {
+  it('warns when domains.list times out instead of failing', async () => {
     const timeoutError = new Error('Operation timed out after 5000ms');
     timeoutError.name = 'TimeoutError';
     mockDomainListResult = () => Promise.reject(timeoutError);
 
     spies = setupOutputSpies();
-    exitSpy = vi
-      .spyOn(process, 'exit')
-      .mockImplementation(() => undefined as never);
 
     const program = await createDoctorProgram();
     await program.parseAsync(['doctor', '--json'], { from: 'user' });
@@ -220,7 +217,7 @@ describe('doctor command', () => {
       (c: Record<string, unknown>) => c.name === 'API Validation',
     );
     expect(apiCheck).toBeDefined();
-    expect(apiCheck.status).toBe('fail');
+    expect(apiCheck.status).toBe('warn');
     expect(apiCheck.message).toContain('timed out');
   });
 });

--- a/tests/commands/doctor.test.ts
+++ b/tests/commands/doctor.test.ts
@@ -200,6 +200,32 @@ describe('doctor command', () => {
     expect(apiCheck.message).toContain('Sending-only API key');
   });
 
+  it('warns when network is unreachable instead of reporting invalid key', async () => {
+    mockDomainListResult = {
+      data: null,
+      error: {
+        name: 'application_error',
+        statusCode: null,
+        message: 'Unable to fetch data. The request could not be resolved.',
+      },
+    };
+
+    spies = setupOutputSpies();
+
+    const program = await createDoctorProgram();
+    await program.parseAsync(['doctor', '--json'], { from: 'user' });
+
+    const output = spies.logSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output);
+
+    const apiCheck = parsed.checks.find(
+      (c: Record<string, unknown>) => c.name === 'API Validation',
+    );
+    expect(apiCheck).toBeDefined();
+    expect(apiCheck.status).toBe('warn');
+    expect(apiCheck.message).toContain('Network error');
+  });
+
   it('warns when domains.list times out instead of failing', async () => {
     const timeoutError = new Error('Operation timed out after 5000ms');
     timeoutError.name = 'TimeoutError';

--- a/tests/commands/doctor.test.ts
+++ b/tests/commands/doctor.test.ts
@@ -4,8 +4,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -15,17 +15,23 @@ import {
   setupOutputSpies,
 } from '../helpers';
 
-// Mock resend SDK for doctor — default: valid key with one verified domain
-let mockDomainListResult: { data: unknown; error: unknown } = {
-  data: { data: [{ name: 'example.com', status: 'verified' }] },
-  error: null,
-};
+type DomainListResult = { data: unknown; error: unknown };
+
+let mockDomainListResult: DomainListResult | (() => Promise<DomainListResult>) =
+  {
+    data: { data: [{ name: 'example.com', status: 'verified' }] },
+    error: null,
+  };
 
 vi.mock('resend', () => ({
   Resend: class MockResend {
     constructor(public key: string) {}
     domains = {
-      list: vi.fn(async () => mockDomainListResult),
+      list: vi.fn(async () =>
+        typeof mockDomainListResult === 'function'
+          ? mockDomainListResult()
+          : mockDomainListResult,
+      ),
     };
   },
 }));
@@ -63,7 +69,7 @@ describe('doctor command', () => {
     exitSpy = undefined;
   });
 
-  test('outputs JSON with --json flag', async () => {
+  it('outputs JSON with --json flag', async () => {
     spies = setupOutputSpies();
 
     const program = await createDoctorProgram();
@@ -78,7 +84,7 @@ describe('doctor command', () => {
     expect(Array.isArray(parsed.checks)).toBe(true);
   });
 
-  test('JSON output has correct check structure', async () => {
+  it('JSON output has correct check structure', async () => {
     spies = setupOutputSpies();
 
     const program = await createDoctorProgram();
@@ -95,7 +101,7 @@ describe('doctor command', () => {
     }
   });
 
-  test('API key check passes when key is set', async () => {
+  it('API key check passes when key is set', async () => {
     spies = setupOutputSpies();
 
     const program = await createDoctorProgram();
@@ -113,7 +119,7 @@ describe('doctor command', () => {
     expect(keyCheck.message).toContain('env');
   });
 
-  test('API key check fails when no key is set', async () => {
+  it('API key check fails when no key is set', async () => {
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
 
@@ -135,7 +141,7 @@ describe('doctor command', () => {
     expect(keyCheck.status).toBe('fail');
   });
 
-  test('masks API key in output', async () => {
+  it('masks API key in output', async () => {
     process.env.RESEND_API_KEY = 're_abcdefghijklmnop';
     spies = setupOutputSpies();
 
@@ -155,7 +161,7 @@ describe('doctor command', () => {
     expect(keyCheck.message).toContain('...');
   });
 
-  test('exits with code 1 when checks fail', async () => {
+  it('exits with code 1 when checks fail', async () => {
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
 
@@ -168,7 +174,7 @@ describe('doctor command', () => {
     );
   });
 
-  test('shows warn for sending-only API key instead of fail', async () => {
+  it('shows warn for sending-only API key instead of fail', async () => {
     mockDomainListResult = {
       data: null,
       error: {
@@ -192,5 +198,29 @@ describe('doctor command', () => {
     expect(apiCheck).toBeDefined();
     expect(apiCheck.status).toBe('warn');
     expect(apiCheck.message).toContain('Sending-only API key');
+  });
+
+  it('fails API validation when domains.list times out', async () => {
+    const timeoutError = new Error('Operation timed out after 5000ms');
+    timeoutError.name = 'TimeoutError';
+    mockDomainListResult = () => Promise.reject(timeoutError);
+
+    spies = setupOutputSpies();
+    exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never);
+
+    const program = await createDoctorProgram();
+    await program.parseAsync(['doctor', '--json'], { from: 'user' });
+
+    const output = spies.logSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output);
+
+    const apiCheck = parsed.checks.find(
+      (c: Record<string, unknown>) => c.name === 'API Validation',
+    );
+    expect(apiCheck).toBeDefined();
+    expect(apiCheck.status).toBe('fail');
+    expect(apiCheck.message).toContain('timed out');
   });
 });

--- a/tests/utils/with-timeout.test.ts
+++ b/tests/utils/with-timeout.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { withTimeout } from '../../src/utils/with-timeout';
+
+describe('withTimeout', () => {
+  it('resolves when the promise settles before the deadline', async () => {
+    const result = await withTimeout(Promise.resolve('ok'), 1000);
+    expect(result).toBe('ok');
+  });
+
+  it('rejects with TimeoutError when the promise exceeds the deadline', async () => {
+    const never = new Promise<string>(() => {});
+    await expect(withTimeout(never, 50)).rejects.toThrow(
+      'Operation timed out after 50ms',
+    );
+  });
+
+  it('preserves the original rejection when it arrives before timeout', async () => {
+    const failing = Promise.reject(new Error('upstream failure'));
+    await expect(withTimeout(failing, 1000)).rejects.toThrow(
+      'upstream failure',
+    );
+  });
+
+  it('sets error name to TimeoutError', async () => {
+    const never = new Promise<string>(() => {});
+    try {
+      await withTimeout(never, 50);
+      expect.unreachable('expected rejection');
+    } catch (err) {
+      expect((err as Error).name).toBe('TimeoutError');
+    }
+  });
+});


### PR DESCRIPTION

## Summary by cubic
Prevented `resend doctor` from hanging by adding a 5s timeout to the API validation probe, aligning it with the GitHub version check. Closes BU-665.

- **Bug Fixes**
  - Wrapped `resend.domains.list()` with `withTimeout(..., 5000)` in the API validation step.
  - Added `src/utils/with-timeout.ts`, which races a promise against a deadline and throws a `TimeoutError`.
  - Timeouts are reported as a fail with a clear "timed out" message.
  - Added unit tests for `withTimeout` and a doctor test covering the timeout case; migrated doctor tests to `it()`.

<sup>Written for commit aab861253b4f30df25c0a8589b5cfd464e4d6a7d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

