### PR TITLE
fix: add esbuild bundling guard and tests to prevent react-email regression

### DIFF
--- a/scripts/verify-bundle.mjs
+++ b/scripts/verify-bundle.mjs
@@ -8,3 +8,18 @@ if (!bundle.includes('phc_')) {
   );
   process.exit(1);
 }
+
+const esbuildBundledMarker = 'The esbuild JavaScript API cannot be bundled';
+if (bundle.includes(esbuildBundledMarker)) {
+  console.error(
+    'Error: esbuild was inlined into the bundle — add it to the external list in scripts/build.mjs',
+  );
+  process.exit(1);
+}
+
+if (!bundle.includes('require("esbuild")')) {
+  console.error(
+    'Error: esbuild external require not found — ensure esbuild is externalized in scripts/build.mjs',
+  );
+  process.exit(1);
+}

--- a/scripts/verify-bundle.mjs
+++ b/scripts/verify-bundle.mjs
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 
-const bundle = readFileSync('dist/cli.cjs', 'utf8');
+const bundlePath = process.argv[2] ?? 'dist/cli.cjs';
+const bundle = readFileSync(bundlePath, 'utf8');
 
 if (!bundle.includes('phc_')) {
   console.error(
@@ -20,6 +21,13 @@ if (bundle.includes(esbuildBundledMarker)) {
 if (!bundle.includes('require("esbuild")')) {
   console.error(
     'Error: esbuild external require not found — ensure esbuild is externalized in scripts/build.mjs',
+  );
+  process.exit(1);
+}
+
+if (!bundle.includes('require("esbuild-wasm")')) {
+  console.error(
+    'Error: esbuild-wasm external require not found — ensure esbuild-wasm is externalized in scripts/build.mjs',
   );
   process.exit(1);
 }

--- a/src/lib/esbuild/load-esbuild.ts
+++ b/src/lib/esbuild/load-esbuild.ts
@@ -1,0 +1,6 @@
+export function loadEsbuild(): typeof import('esbuild') {
+  if ('pkg' in process) {
+    return require('esbuild-wasm');
+  }
+  return require('esbuild');
+}

--- a/src/lib/react-email-bundler.ts
+++ b/src/lib/react-email-bundler.ts
@@ -1,14 +1,8 @@
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { loadEsbuild } from './esbuild/load-esbuild';
 import { renderingUtilitiesExporter } from './esbuild/rendering-utilities-exporter';
-
-function loadEsbuild(): typeof import('esbuild') {
-  if ('pkg' in process) {
-    return require('esbuild-wasm');
-  }
-  return require('esbuild');
-}
 
 export interface BundleResult {
   cjsPath: string;

--- a/tests/lib/react-email-bundler.test.ts
+++ b/tests/lib/react-email-bundler.test.ts
@@ -1,4 +1,11 @@
-import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -12,8 +19,8 @@ const mockBuild = vi.fn(
   },
 );
 
-vi.mock('esbuild', () => ({
-  build: (opts: Record<string, unknown>) => mockBuild(opts as never),
+vi.mock('../../src/lib/esbuild/load-esbuild', () => ({
+  loadEsbuild: () => ({ build: mockBuild }),
 }));
 
 const { bundleReactEmail } = await import('../../src/lib/react-email-bundler');
@@ -52,11 +59,20 @@ describe('bundleReactEmail', () => {
   });
 
   it('cleans up tmpDir on build failure', async () => {
+    const before = readdirSync(tmpdir()).filter((d) =>
+      d.startsWith('resend-react-email-'),
+    );
+
     mockBuild.mockRejectedValueOnce(new Error('build failed'));
 
     await expect(bundleReactEmail('/fake/broken.tsx')).rejects.toThrow(
       'build failed',
     );
+
+    const after = readdirSync(tmpdir()).filter((d) =>
+      d.startsWith('resend-react-email-'),
+    );
+    expect(after.length).toBe(before.length);
   });
 
   it('produces a cjs output path named after the input', async () => {

--- a/tests/lib/react-email-bundler.test.ts
+++ b/tests/lib/react-email-bundler.test.ts
@@ -1,0 +1,75 @@
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockBuild = vi.fn(
+  async (opts: { outdir: string; entryPoints: string[] }) => {
+    const name = path.basename(
+      opts.entryPoints[0],
+      path.extname(opts.entryPoints[0]),
+    );
+    writeFileSync(path.join(opts.outdir, `${name}.cjs`), 'module.exports = {}');
+  },
+);
+
+vi.mock('esbuild', () => ({
+  build: (opts: Record<string, unknown>) => mockBuild(opts as never),
+}));
+
+const { bundleReactEmail } = await import('../../src/lib/react-email-bundler');
+
+const createdDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of createdDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  createdDirs.length = 0;
+  mockBuild.mockClear();
+});
+
+describe('bundleReactEmail', () => {
+  it('returns cjsPath and tmpDir for a valid template path', async () => {
+    const result = await bundleReactEmail('/fake/test-email.tsx');
+    createdDirs.push(result.tmpDir);
+
+    expect(result.cjsPath).toContain('test-email.cjs');
+    expect(result.tmpDir).toBeTruthy();
+    expect(existsSync(result.cjsPath)).toBe(true);
+    expect(readFileSync(result.cjsPath, 'utf8')).toBe('module.exports = {}');
+  });
+
+  it('calls esbuild.build with correct options', async () => {
+    const result = await bundleReactEmail('/fake/welcome.tsx');
+    createdDirs.push(result.tmpDir);
+
+    expect(mockBuild).toHaveBeenCalledTimes(1);
+    const opts = mockBuild.mock.calls[0][0] as Record<string, unknown>;
+    expect(opts.bundle).toBe(true);
+    expect(opts.format).toBe('cjs');
+    expect(opts.jsx).toBe('automatic');
+    expect(opts.platform).toBe('node');
+  });
+
+  it('cleans up tmpDir on build failure', async () => {
+    mockBuild.mockRejectedValueOnce(new Error('build failed'));
+
+    await expect(bundleReactEmail('/fake/broken.tsx')).rejects.toThrow(
+      'build failed',
+    );
+  });
+
+  it('produces a cjs output path named after the input', async () => {
+    const result = await bundleReactEmail('/fake/welcome.tsx');
+    createdDirs.push(result.tmpDir);
+
+    expect(path.basename(result.cjsPath)).toBe('welcome.cjs');
+  });
+
+  it('creates tmpDir inside os tmpdir with resend prefix', async () => {
+    const result = await bundleReactEmail('/fake/email.tsx');
+    createdDirs.push(result.tmpDir);
+
+    expect(result.tmpDir).toContain('resend-react-email-');
+  });
+});

--- a/tests/scripts/verify-bundle.test.ts
+++ b/tests/scripts/verify-bundle.test.ts
@@ -1,0 +1,75 @@
+import { execSync } from 'node:child_process';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const distDir = path.resolve('dist');
+const bundlePath = path.join(distDir, 'cli.cjs');
+const scriptPath = path.resolve('scripts/verify-bundle.mjs');
+
+const run = () =>
+  execSync(`node ${scriptPath}`, {
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+const runCatching = () => {
+  try {
+    const stdout = run();
+    return { exitCode: 0, stdout, stderr: '' };
+  } catch (err: unknown) {
+    const e = err as { status: number; stdout: string; stderr: string };
+    return { exitCode: e.status, stdout: e.stdout, stderr: e.stderr };
+  }
+};
+
+describe('verify-bundle', () => {
+  let originalBundle: string | undefined;
+
+  beforeEach(() => {
+    try {
+      originalBundle = require('node:fs').readFileSync(bundlePath, 'utf8');
+    } catch {
+      originalBundle = undefined;
+    }
+    mkdirSync(distDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (originalBundle !== undefined) {
+      writeFileSync(bundlePath, originalBundle);
+    } else {
+      rmSync(bundlePath, { force: true });
+    }
+  });
+
+  it('fails when posthog key is missing', () => {
+    writeFileSync(bundlePath, 'require("esbuild"); some content');
+    const result = runCatching();
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('POSTHOG_PUBLIC_KEY');
+  });
+
+  it('fails when esbuild is inlined (bundled marker present)', () => {
+    writeFileSync(
+      bundlePath,
+      'phc_key; The esbuild JavaScript API cannot be bundled; require("esbuild")',
+    );
+    const result = runCatching();
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('esbuild was inlined');
+  });
+
+  it('fails when esbuild external require is missing', () => {
+    writeFileSync(bundlePath, 'phc_key; no external require here');
+    const result = runCatching();
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('esbuild external require not found');
+  });
+
+  it('passes when bundle is valid', () => {
+    writeFileSync(bundlePath, 'phc_key; require("esbuild"); valid bundle');
+    const result = runCatching();
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/tests/scripts/verify-bundle.test.ts
+++ b/tests/scripts/verify-bundle.test.ts
@@ -1,21 +1,20 @@
 import { execSync } from 'node:child_process';
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-const distDir = path.resolve('dist');
-const bundlePath = path.join(distDir, 'cli.cjs');
 const scriptPath = path.resolve('scripts/verify-bundle.mjs');
 
-const run = () =>
-  execSync(`node ${scriptPath}`, {
+const run = (bundlePath: string) =>
+  execSync(`node ${scriptPath} ${bundlePath}`, {
     encoding: 'utf8',
     stdio: ['pipe', 'pipe', 'pipe'],
   });
 
-const runCatching = () => {
+const runCatching = (bundlePath: string) => {
   try {
-    const stdout = run();
+    const stdout = run(bundlePath);
     return { exitCode: 0, stdout, stderr: '' };
   } catch (err: unknown) {
     const e = err as { status: number; stdout: string; stderr: string };
@@ -23,29 +22,28 @@ const runCatching = () => {
   }
 };
 
+const validBundle =
+  'phc_key; require("esbuild"); require("esbuild-wasm"); valid bundle';
+
 describe('verify-bundle', () => {
-  let originalBundle: string | undefined;
+  let tmpDir: string;
+  let bundlePath: string;
 
   beforeEach(() => {
-    try {
-      originalBundle = require('node:fs').readFileSync(bundlePath, 'utf8');
-    } catch {
-      originalBundle = undefined;
-    }
-    mkdirSync(distDir, { recursive: true });
+    tmpDir = mkdtempSync(path.join(tmpdir(), 'verify-bundle-test-'));
+    bundlePath = path.join(tmpDir, 'cli.cjs');
   });
 
   afterEach(() => {
-    if (originalBundle !== undefined) {
-      writeFileSync(bundlePath, originalBundle);
-    } else {
-      rmSync(bundlePath, { force: true });
-    }
+    rmSync(tmpDir, { recursive: true, force: true });
   });
 
   it('fails when posthog key is missing', () => {
-    writeFileSync(bundlePath, 'require("esbuild"); some content');
-    const result = runCatching();
+    writeFileSync(
+      bundlePath,
+      'require("esbuild"); require("esbuild-wasm"); some content',
+    );
+    const result = runCatching(bundlePath);
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain('POSTHOG_PUBLIC_KEY');
   });
@@ -53,23 +51,36 @@ describe('verify-bundle', () => {
   it('fails when esbuild is inlined (bundled marker present)', () => {
     writeFileSync(
       bundlePath,
-      'phc_key; The esbuild JavaScript API cannot be bundled; require("esbuild")',
+      'phc_key; The esbuild JavaScript API cannot be bundled; require("esbuild"); require("esbuild-wasm")',
     );
-    const result = runCatching();
+    const result = runCatching(bundlePath);
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain('esbuild was inlined');
   });
 
   it('fails when esbuild external require is missing', () => {
-    writeFileSync(bundlePath, 'phc_key; no external require here');
-    const result = runCatching();
+    writeFileSync(
+      bundlePath,
+      'phc_key; require("esbuild-wasm"); no esbuild require here',
+    );
+    const result = runCatching(bundlePath);
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain('esbuild external require not found');
   });
 
+  it('fails when esbuild-wasm external require is missing', () => {
+    writeFileSync(
+      bundlePath,
+      'phc_key; require("esbuild"); no wasm require here',
+    );
+    const result = runCatching(bundlePath);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('esbuild-wasm external require not found');
+  });
+
   it('passes when bundle is valid', () => {
-    writeFileSync(bundlePath, 'phc_key; require("esbuild"); valid bundle');
-    const result = runCatching();
+    writeFileSync(bundlePath, validBundle);
+    const result = runCatching(bundlePath);
     expect(result.exitCode).toBe(0);
   });
 });


### PR DESCRIPTION

## Summary by cubic
Adds prepack bundle guards and tests to ensure `esbuild` stays external and is never inlined. Follow-up to BU-610 to prevent React email bundling regressions.

- **Bug Fixes**
  - Prepack checks in `scripts/verify-bundle.mjs`: fail if the inlined `esbuild` marker is found or if `require("esbuild")` is missing from `dist/cli.cjs`.
  - Tests for `bundleReactEmail` and the verify script: verify build options, tmp cleanup on failure, and all validation paths (PostHog key, inlined marker, missing external require, happy path).

<sup>Written for commit 203ab0a195f235efb763019fe202e4dcfd38d983. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

