### PR TITLE
fix: handle domain fetch failure without defaulting to onboarding sender

### DIFF
--- a/src/commands/broadcasts/create.ts
+++ b/src/commands/broadcasts/create.ts
@@ -118,7 +118,11 @@ Scheduling:
 
     if (!from && isInteractive() && !globalOpts.json) {
       const domains = await fetchVerifiedDomains(resend);
-      if (domains.length > 0) {
+      if (domains === null) {
+        process.stderr.write(
+          'Warning: Could not fetch verified domains. Please provide a sender address explicitly.\n',
+        );
+      } else if (domains.length > 0) {
         from = await promptForFromAddress(domains);
       }
     }

--- a/src/commands/emails/send.ts
+++ b/src/commands/emails/send.ts
@@ -190,21 +190,36 @@ export const sendCommand = new Command('send')
       : undefined;
 
     let fromAddress = opts.from;
+    let domainFetchFailed = false;
     if (!fromAddress && !hasTemplate && isInteractive() && !globalOpts.json) {
       const domains = await fetchVerifiedDomains(resend);
-      if (domains.length > 0) {
+      if (domains === null) {
+        domainFetchFailed = true;
+        process.stderr.write(
+          'Warning: Could not fetch verified domains. Please provide a sender address explicitly.\n',
+        );
+      } else if (domains.length > 0) {
         fromAddress = await promptForFromAddress(domains);
       }
     }
 
+    const fromPromptSpec = domainFetchFailed
+      ? {
+          flag: 'from',
+          message: 'From address',
+          placeholder: 'you@yourdomain.com',
+          required: !hasTemplate,
+        }
+      : {
+          flag: 'from',
+          message: 'From address',
+          placeholder: 'onboarding@resend.dev',
+          defaultValue: 'onboarding@resend.dev',
+          required: !hasTemplate,
+        };
+
     const promptFields = [
-      {
-        flag: 'from',
-        message: 'From address',
-        placeholder: 'onboarding@resend.dev',
-        defaultValue: 'onboarding@resend.dev',
-        required: !hasTemplate,
-      },
+      fromPromptSpec,
       {
         flag: 'to',
         message: 'To address',

--- a/src/lib/domains.ts
+++ b/src/lib/domains.ts
@@ -2,21 +2,47 @@ import * as p from '@clack/prompts';
 import type { Resend } from 'resend';
 import { cancelAndExit } from './prompts';
 
-export async function fetchVerifiedDomains(resend: Resend): Promise<string[]> {
-  try {
-    const { data, error } = await resend.domains.list();
-    if (error || !data) {
-      return [];
-    }
-    return data.data
-      .filter(
-        (d) => d.status === 'verified' && d.capabilities.sending === 'enabled',
-      )
-      .map((d) => d.name);
-  } catch {
-    return [];
+const isVerifiedSendingDomain = (d: {
+  status: string;
+  capabilities: { sending: string };
+}) => d.status === 'verified' && d.capabilities.sending === 'enabled';
+
+const collectVerifiedDomains = async (
+  resend: Resend,
+  accumulated: readonly string[],
+  after?: string,
+): Promise<string[] | null> => {
+  const { data, error } = await resend.domains.list(
+    after ? { after } : undefined,
+  );
+
+  if (error || !data) {
+    return null;
   }
-}
+
+  const names = data.data.filter(isVerifiedSendingDomain).map((d) => d.name);
+  const all = [...accumulated, ...names];
+
+  if (!(data.has_more ?? false) || data.data.length === 0) {
+    return all;
+  }
+
+  return collectVerifiedDomains(
+    resend,
+    all,
+    data.data[data.data.length - 1].id,
+  );
+};
+
+export const fetchVerifiedDomains = async (
+  resend: Resend,
+): Promise<string[] | null> => {
+  try {
+    return await collectVerifiedDomains(resend, []);
+  } catch {
+    return null;
+  }
+};
 
 const FROM_PREFIXES = ['noreply', 'hello'];
 

--- a/tests/commands/emails/send.test.ts
+++ b/tests/commands/emails/send.test.ts
@@ -1242,7 +1242,7 @@ describe('send command', () => {
     );
   });
 
-  test('degrades gracefully when domain fetch fails', async () => {
+  test('returns null when domain fetch fails', async () => {
     const { fetchVerifiedDomains } = await import('../../../src/lib/domains');
     const failingResend = {
       domains: {
@@ -1252,8 +1252,7 @@ describe('send command', () => {
       },
     } as Record<string, unknown>;
 
-    // Should return [] without throwing, so the caller falls through to promptForMissing
     const result = await fetchVerifiedDomains(failingResend);
-    expect(result).toEqual([]);
+    expect(result).toBeNull();
   });
 });

--- a/tests/lib/domains.test.ts
+++ b/tests/lib/domains.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fetchVerifiedDomains } from '../../src/lib/domains';
+
+const makeDomain = (
+  id: string,
+  name: string,
+  status = 'verified',
+  sending = 'enabled',
+) => ({
+  id,
+  name,
+  status,
+  capabilities: { sending },
+});
+
+const makeResend = (
+  pages: Array<{
+    data: ReturnType<typeof makeDomain>[];
+    has_more: boolean;
+  }>,
+) => {
+  const listFn = vi.fn();
+  pages.forEach((page) => {
+    listFn.mockResolvedValueOnce({
+      data: { data: page.data, has_more: page.has_more },
+      error: null,
+    });
+  });
+  return { domains: { list: listFn } } as Record<string, unknown>;
+};
+
+describe('fetchVerifiedDomains', () => {
+  it('returns verified sending-enabled domains from a single page', async () => {
+    const resend = makeResend([
+      {
+        data: [
+          makeDomain('d1', 'example.com'),
+          makeDomain('d2', 'pending.com', 'pending'),
+          makeDomain('d3', 'nosend.com', 'verified', 'disabled'),
+        ],
+        has_more: false,
+      },
+    ]);
+
+    const result = await fetchVerifiedDomains(resend);
+    expect(result).toEqual(['example.com']);
+  });
+
+  it('paginates through all pages', async () => {
+    const resend = makeResend([
+      {
+        data: [makeDomain('d1', 'page1.com')],
+        has_more: true,
+      },
+      {
+        data: [makeDomain('d2', 'page2.com')],
+        has_more: true,
+      },
+      {
+        data: [makeDomain('d3', 'page3.com')],
+        has_more: false,
+      },
+    ]);
+
+    const result = await fetchVerifiedDomains(resend);
+    expect(result).toEqual(['page1.com', 'page2.com', 'page3.com']);
+
+    const listFn = resend.domains.list as ReturnType<typeof vi.fn>;
+    expect(listFn).toHaveBeenCalledTimes(3);
+    expect(listFn).toHaveBeenNthCalledWith(1, undefined);
+    expect(listFn).toHaveBeenNthCalledWith(2, { after: 'd1' });
+    expect(listFn).toHaveBeenNthCalledWith(3, { after: 'd2' });
+  });
+
+  it('returns null when domains.list returns an error', async () => {
+    const resend = {
+      domains: {
+        list: vi.fn().mockResolvedValue({
+          data: null,
+          error: { message: 'restricted_api_key', name: 'restricted_api_key' },
+        }),
+      },
+    } as Record<string, unknown>;
+
+    const result = await fetchVerifiedDomains(resend);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when domains.list throws', async () => {
+    const resend = {
+      domains: {
+        list: vi.fn().mockRejectedValue(new Error('Network error')),
+      },
+    } as Record<string, unknown>;
+
+    const result = await fetchVerifiedDomains(resend);
+    expect(result).toBeNull();
+  });
+
+  it('returns empty array when no domains match the filter', async () => {
+    const resend = makeResend([
+      {
+        data: [
+          makeDomain('d1', 'pending.com', 'pending'),
+          makeDomain('d2', 'nosend.com', 'verified', 'disabled'),
+        ],
+        has_more: false,
+      },
+    ]);
+
+    const result = await fetchVerifiedDomains(resend);
+    expect(result).toEqual([]);
+  });
+
+  it('returns null when a subsequent page errors', async () => {
+    const listFn = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: { data: [makeDomain('d1', 'page1.com')], has_more: true },
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: null,
+        error: { message: 'rate_limited', name: 'rate_limited' },
+      });
+
+    const resend = { domains: { list: listFn } } as Record<string, unknown>;
+
+    const result = await fetchVerifiedDomains(resend);
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION

## Summary by cubic
Fix interactive sends so a domain fetch failure no longer defaults to `onboarding@resend.dev`. We now warn and require an explicit From address, and paginate domain listing to find all verified sending domains.

- **Bug Fixes**
  - `fetchVerifiedDomains` returns `null` on API errors or exceptions to distinguish failure from “no domains”.
  - `emails send` and `broadcasts create` warn on failure and prompt for From without a default.
  - Tests updated to expect `null` on failures.

- **New Features**
  - Added pagination using `has_more`/`after` to collect all verified sending domains.
  - Extracted the verified, sending-enabled filter for clarity.

<sup>Written for commit 9907675fb64e36ecfafa6d12030f15c2cf327abb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

