### PR TITLE
fix: add 30s timeout to all fetch requests to prevent CLI stalls

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import './lib/fetch-timeout';
 import { Command } from '@commander-js/extra-typings';
 import pc from 'picocolors';
 import { apiKeysCommand } from './commands/api-keys/index';

--- a/src/lib/fetch-timeout.ts
+++ b/src/lib/fetch-timeout.ts
@@ -1,0 +1,15 @@
+export const REQUEST_TIMEOUT_MS = 30_000;
+
+const originalFetch = globalThis.fetch;
+
+globalThis.fetch = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<Response> => {
+  const timeoutSignal = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
+  const signal = init?.signal
+    ? AbortSignal.any([init.signal, timeoutSignal])
+    : timeoutSignal;
+
+  return originalFetch(input, { ...init, signal });
+};

--- a/tests/lib/fetch-timeout.test.ts
+++ b/tests/lib/fetch-timeout.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('fetch-timeout', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.resetModules();
+    globalThis.fetch = originalFetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('attaches a timeout signal when no signal is provided', async () => {
+    const fakeFetch = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      expect(init?.signal).toBeDefined();
+      return Promise.resolve(new Response('ok'));
+    });
+    globalThis.fetch = fakeFetch as typeof fetch;
+
+    await import('../../src/lib/fetch-timeout');
+    await globalThis.fetch('https://example.com');
+
+    expect(fakeFetch).toHaveBeenCalledOnce();
+  });
+
+  it('preserves a caller-provided signal alongside the timeout', async () => {
+    const callerAbort = new AbortController();
+    const fakeFetch = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      expect(init?.signal).toBeDefined();
+      expect(init?.signal).not.toBe(callerAbort.signal);
+      return Promise.resolve(new Response('ok'));
+    });
+    globalThis.fetch = fakeFetch as typeof fetch;
+
+    await import('../../src/lib/fetch-timeout');
+    await globalThis.fetch('https://example.com', {
+      signal: callerAbort.signal,
+    });
+
+    expect(fakeFetch).toHaveBeenCalledOnce();
+  });
+
+  it('forwards all init options to the underlying fetch', async () => {
+    const fakeFetch = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      expect(init?.method).toBe('POST');
+      expect(init?.headers).toEqual({ 'X-Test': '1' });
+      return Promise.resolve(new Response('ok'));
+    });
+    globalThis.fetch = fakeFetch as typeof fetch;
+
+    await import('../../src/lib/fetch-timeout');
+    await globalThis.fetch('https://example.com', {
+      method: 'POST',
+      headers: { 'X-Test': '1' },
+    });
+
+    expect(fakeFetch).toHaveBeenCalledOnce();
+  });
+
+  it('exports REQUEST_TIMEOUT_MS as 30000', async () => {
+    const mod = await import('../../src/lib/fetch-timeout');
+    expect(mod.REQUEST_TIMEOUT_MS).toBe(30_000);
+  });
+});


### PR DESCRIPTION

## Summary by cubic
Add a 30s timeout to all CLI HTTP requests so the CLI fails fast instead of hanging on network or Resend API stalls. 

- **Bug Fixes**
  - Wraps `globalThis.fetch` with a 30s `AbortSignal.timeout` for every request.
  - Preserves caller signals using `AbortSignal.any` (shortest timeout wins).
  - Imports the wrapper in `src/cli.ts` to cover all SDK and direct requests.
  - Adds tests for timeout behavior, signal composition, and option forwarding.

<sup>Written for commit ec56b4115903512053d6d9d4cc749c6fe7644c8b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

