### PR TITLE
feat: add --react-email-props support for prop-driven templates

### DIFF
--- a/src/commands/broadcasts/create.ts
+++ b/src/commands/broadcasts/create.ts
@@ -8,6 +8,7 @@ import { fetchVerifiedDomains, promptForFromAddress } from '../../lib/domains';
 import { readFile } from '../../lib/files';
 import { buildHelpText } from '../../lib/help-text';
 import { outputError } from '../../lib/output';
+import { parseReactEmailProps } from '../../lib/parse-react-email-props';
 import { cancelAndExit, pickId } from '../../lib/prompts';
 import { buildReactEmailHtml } from '../../lib/react-email';
 import { isInteractive } from '../../lib/tty';
@@ -35,6 +36,14 @@ export const createBroadcastCommand = new Command('create')
   .option(
     '--react-email <path>',
     'Path to a React Email template (.tsx) to bundle, render, and use as HTML body (npm install only)',
+  )
+  .option(
+    '--react-email-props <json>',
+    'JSON string of props to pass to the React Email component',
+  )
+  .option(
+    '--react-email-props-file <path>',
+    'Path to a JSON file of props to pass to the React Email component',
   )
   .option('--name <name>', 'Internal label for the broadcast (optional)')
   .option('--reply-to <address>', 'Reply-to address (optional)')
@@ -104,6 +113,20 @@ Scheduling:
       outputError(
         {
           message: 'Cannot use --react-email with --html or --html-file',
+          code: 'invalid_options',
+        },
+        { json: globalOpts.json },
+      );
+    }
+
+    if (
+      (opts.reactEmailProps || opts.reactEmailPropsFile) &&
+      !opts.reactEmail
+    ) {
+      outputError(
+        {
+          message:
+            '--react-email-props and --react-email-props-file can only be used with --react-email',
           code: 'invalid_options',
         },
         { json: globalOpts.json },
@@ -191,7 +214,12 @@ Scheduling:
     }
 
     if (opts.reactEmail) {
-      html = await buildReactEmailHtml(opts.reactEmail, globalOpts);
+      const reactProps = parseReactEmailProps(
+        opts.reactEmailProps,
+        opts.reactEmailPropsFile,
+        globalOpts,
+      );
+      html = await buildReactEmailHtml(opts.reactEmail, globalOpts, reactProps);
     }
 
     if (!html && !text) {

--- a/src/commands/broadcasts/update.ts
+++ b/src/commands/broadcasts/update.ts
@@ -4,6 +4,7 @@ import type { GlobalOpts } from '../../lib/client';
 import { readFile } from '../../lib/files';
 import { buildHelpText } from '../../lib/help-text';
 import { outputError } from '../../lib/output';
+import { parseReactEmailProps } from '../../lib/parse-react-email-props';
 import { pickId } from '../../lib/prompts';
 import { buildReactEmailHtml } from '../../lib/react-email';
 import { broadcastPickerConfig } from './utils';
@@ -31,6 +32,14 @@ export const updateBroadcastCommand = new Command('update')
   .option(
     '--react-email <path>',
     'Path to a React Email template (.tsx) to bundle, render, and use as HTML body (npm install only)',
+  )
+  .option(
+    '--react-email-props <json>',
+    'JSON string of props to pass to the React Email component',
+  )
+  .option(
+    '--react-email-props-file <path>',
+    'Path to a JSON file of props to pass to the React Email component',
   )
   .option('--name <name>', 'Update internal label')
   .addHelpText(
@@ -108,6 +117,20 @@ Variable interpolation:
       );
     }
 
+    if (
+      (opts.reactEmailProps != null || opts.reactEmailPropsFile != null) &&
+      opts.reactEmail == null
+    ) {
+      outputError(
+        {
+          message:
+            '--react-email-props and --react-email-props-file can only be used with --react-email',
+          code: 'invalid_options',
+        },
+        { json: globalOpts.json },
+      );
+    }
+
     const id = await pickId(idArg, broadcastPickerConfig, globalOpts);
 
     let html = opts.html;
@@ -132,7 +155,12 @@ Variable interpolation:
     }
 
     if (opts.reactEmail != null) {
-      html = await buildReactEmailHtml(opts.reactEmail, globalOpts);
+      const reactProps = parseReactEmailProps(
+        opts.reactEmailProps,
+        opts.reactEmailPropsFile,
+        globalOpts,
+      );
+      html = await buildReactEmailHtml(opts.reactEmail, globalOpts, reactProps);
     }
 
     await runWrite(

--- a/src/commands/emails/batch.ts
+++ b/src/commands/emails/batch.ts
@@ -5,6 +5,7 @@ import { requireClient } from '../../lib/client';
 import { readFile } from '../../lib/files';
 import { buildHelpText } from '../../lib/help-text';
 import { outputError, outputResult } from '../../lib/output';
+import { parseReactEmailProps } from '../../lib/parse-react-email-props';
 import { requireText } from '../../lib/prompts';
 import { buildReactEmailHtml } from '../../lib/react-email';
 import { withSpinner } from '../../lib/spinner';
@@ -19,6 +20,14 @@ export const batchCommand = new Command('batch')
   .option(
     '--react-email <path>',
     'Path to a React Email template (.tsx) — rendered HTML is set on every email in the batch (npm install only)',
+  )
+  .option(
+    '--react-email-props <json>',
+    'JSON string of props to pass to the React Email component',
+  )
+  .option(
+    '--react-email-props-file <path>',
+    'Path to a JSON file of props to pass to the React Email component',
   )
   .option(
     '--idempotency-key <key>',
@@ -102,8 +111,31 @@ export const batchCommand = new Command('batch')
       );
     }
 
+    if (
+      (opts.reactEmailProps || opts.reactEmailPropsFile) &&
+      !opts.reactEmail
+    ) {
+      outputError(
+        {
+          message:
+            '--react-email-props and --react-email-props-file can only be used with --react-email',
+          code: 'invalid_options',
+        },
+        { json: globalOpts.json },
+      );
+    }
+
     if (opts.reactEmail) {
-      const reactHtml = await buildReactEmailHtml(opts.reactEmail, globalOpts);
+      const reactProps = parseReactEmailProps(
+        opts.reactEmailProps,
+        opts.reactEmailPropsFile,
+        globalOpts,
+      );
+      const reactHtml = await buildReactEmailHtml(
+        opts.reactEmail,
+        globalOpts,
+        reactProps,
+      );
       for (const email of emails) {
         (email as Record<string, unknown>).html = reactHtml;
       }

--- a/src/commands/emails/send.ts
+++ b/src/commands/emails/send.ts
@@ -8,6 +8,7 @@ import { fetchVerifiedDomains, promptForFromAddress } from '../../lib/domains';
 import { readFile } from '../../lib/files';
 import { buildHelpText } from '../../lib/help-text';
 import { outputError, outputResult } from '../../lib/output';
+import { parseReactEmailProps } from '../../lib/parse-react-email-props';
 import { promptForMissing, requireText } from '../../lib/prompts';
 import { buildReactEmailHtml } from '../../lib/react-email';
 import { withSpinner } from '../../lib/spinner';
@@ -37,6 +38,14 @@ export const sendCommand = new Command('send')
   .option(
     '--react-email <path>',
     'Path to a React Email template (.tsx) to bundle, render, and send (npm install only)',
+  )
+  .option(
+    '--react-email-props <json>',
+    'JSON string of props to pass to the React Email component',
+  )
+  .option(
+    '--react-email-props-file <path>',
+    'Path to a JSON file of props to pass to the React Email component',
   )
   .option('--cc <addresses...>', 'CC recipients')
   .option('--bcc <addresses...>', 'BCC recipients')
@@ -130,7 +139,20 @@ export const sendCommand = new Command('send')
       );
     }
 
-    // Validate: --react-email is mutually exclusive with body and template flags
+    if (
+      (opts.reactEmailProps || opts.reactEmailPropsFile) &&
+      !opts.reactEmail
+    ) {
+      outputError(
+        {
+          message:
+            '--react-email-props and --react-email-props-file can only be used with --react-email',
+          code: 'invalid_options',
+        },
+        { json: globalOpts.json },
+      );
+    }
+
     if (opts.reactEmail && (opts.html || opts.htmlFile || hasTemplate)) {
       outputError(
         {
@@ -248,7 +270,12 @@ export const sendCommand = new Command('send')
     }
 
     if (opts.reactEmail) {
-      html = await buildReactEmailHtml(opts.reactEmail, globalOpts);
+      const reactProps = parseReactEmailProps(
+        opts.reactEmailProps,
+        opts.reactEmailPropsFile,
+        globalOpts,
+      );
+      html = await buildReactEmailHtml(opts.reactEmail, globalOpts, reactProps);
     }
 
     let body: string | undefined = text;

--- a/src/commands/templates/create.ts
+++ b/src/commands/templates/create.ts
@@ -5,6 +5,7 @@ import type { GlobalOpts } from '../../lib/client';
 import { readFile } from '../../lib/files';
 import { buildHelpText } from '../../lib/help-text';
 import { outputError } from '../../lib/output';
+import { parseReactEmailProps } from '../../lib/parse-react-email-props';
 import { cancelAndExit } from '../../lib/prompts';
 import { buildReactEmailHtml } from '../../lib/react-email';
 import { isInteractive } from '../../lib/tty';
@@ -27,6 +28,14 @@ export const createTemplateCommand = new Command('create')
   .option(
     '--react-email <path>',
     'Path to a React Email template (.tsx) to bundle, render, and use as HTML body (npm install only)',
+  )
+  .option(
+    '--react-email-props <json>',
+    'JSON string of props to pass to the React Email component',
+  )
+  .option(
+    '--react-email-props-file <path>',
+    'Path to a JSON file of props to pass to the React Email component',
   )
   .option('--from <address>', 'Sender address')
   .option('--reply-to <address>', 'Reply-to address')
@@ -113,6 +122,20 @@ Non-interactive: --name and a body (--html, --html-file, or --react-email) are r
       );
     }
 
+    if (
+      (opts.reactEmailProps || opts.reactEmailPropsFile) &&
+      !opts.reactEmail
+    ) {
+      outputError(
+        {
+          message:
+            '--react-email-props and --react-email-props-file can only be used with --react-email',
+          code: 'invalid_options',
+        },
+        { json: globalOpts.json },
+      );
+    }
+
     let html = opts.html;
     let text = opts.text;
 
@@ -135,7 +158,12 @@ Non-interactive: --name and a body (--html, --html-file, or --react-email) are r
     }
 
     if (opts.reactEmail) {
-      html = await buildReactEmailHtml(opts.reactEmail, globalOpts);
+      const reactProps = parseReactEmailProps(
+        opts.reactEmailProps,
+        opts.reactEmailPropsFile,
+        globalOpts,
+      );
+      html = await buildReactEmailHtml(opts.reactEmail, globalOpts, reactProps);
     }
 
     if (!html) {

--- a/src/commands/templates/update.ts
+++ b/src/commands/templates/update.ts
@@ -4,6 +4,7 @@ import type { GlobalOpts } from '../../lib/client';
 import { readFile } from '../../lib/files';
 import { buildHelpText } from '../../lib/help-text';
 import { outputError } from '../../lib/output';
+import { parseReactEmailProps } from '../../lib/parse-react-email-props';
 import { pickId } from '../../lib/prompts';
 import { buildReactEmailHtml } from '../../lib/react-email';
 import { parseVariables, templatePickerConfig } from './utils';
@@ -26,6 +27,14 @@ export const updateTemplateCommand = new Command('update')
   .option(
     '--react-email <path>',
     'Path to a React Email template (.tsx) to bundle, render, and use as HTML body (npm install only)',
+  )
+  .option(
+    '--react-email-props <json>',
+    'JSON string of props to pass to the React Email component',
+  )
+  .option(
+    '--react-email-props-file <path>',
+    'Path to a JSON file of props to pass to the React Email component',
   )
   .option('--from <address>', 'Update sender address')
   .option('--reply-to <address>', 'Update reply-to address')
@@ -100,6 +109,20 @@ export const updateTemplateCommand = new Command('update')
       );
     }
 
+    if (
+      (opts.reactEmailProps != null || opts.reactEmailPropsFile != null) &&
+      opts.reactEmail == null
+    ) {
+      outputError(
+        {
+          message:
+            '--react-email-props and --react-email-props-file can only be used with --react-email',
+          code: 'invalid_options',
+        },
+        { json: globalOpts.json },
+      );
+    }
+
     if (opts.html != null && opts.htmlFile != null) {
       outputError(
         {
@@ -140,7 +163,12 @@ export const updateTemplateCommand = new Command('update')
     }
 
     if (opts.reactEmail != null) {
-      html = await buildReactEmailHtml(opts.reactEmail, globalOpts);
+      const reactProps = parseReactEmailProps(
+        opts.reactEmailProps,
+        opts.reactEmailPropsFile,
+        globalOpts,
+      );
+      html = await buildReactEmailHtml(opts.reactEmail, globalOpts, reactProps);
     }
 
     await runWrite(

--- a/src/lib/parse-react-email-props.ts
+++ b/src/lib/parse-react-email-props.ts
@@ -1,0 +1,77 @@
+import { existsSync, readFileSync } from 'node:fs';
+import type { GlobalOpts } from './client';
+import { outputError } from './output';
+
+export const parseReactEmailProps = (
+  propsJson: string | undefined,
+  propsFile: string | undefined,
+  globalOpts: GlobalOpts,
+): Record<string, unknown> => {
+  if (propsJson && propsFile) {
+    return outputError(
+      {
+        message:
+          'Cannot use both --react-email-props and --react-email-props-file',
+        code: 'invalid_options',
+      },
+      { json: globalOpts.json },
+    );
+  }
+
+  if (!propsJson && !propsFile) {
+    return {};
+  }
+
+  const raw = propsFile
+    ? readPropsFile(propsFile, globalOpts)
+    : (propsJson as string);
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      parsed === null ||
+      typeof parsed !== 'object' ||
+      Array.isArray(parsed)
+    ) {
+      return outputError(
+        {
+          message: 'React Email props must be a JSON object.',
+          code: 'invalid_options',
+        },
+        { json: globalOpts.json },
+      );
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    return outputError(
+      {
+        message: 'React Email props are not valid JSON.',
+        code: 'invalid_options',
+      },
+      { json: globalOpts.json },
+    );
+  }
+};
+
+const readPropsFile = (filePath: string, globalOpts: GlobalOpts): string => {
+  if (!existsSync(filePath)) {
+    return outputError(
+      {
+        message: `File not found: ${filePath}`,
+        code: 'file_read_error',
+      },
+      { json: globalOpts.json },
+    );
+  }
+  try {
+    return readFileSync(filePath, 'utf-8');
+  } catch {
+    return outputError(
+      {
+        message: `Failed to read file: ${filePath}`,
+        code: 'file_read_error',
+      },
+      { json: globalOpts.json },
+    );
+  }
+};

--- a/src/lib/react-email-renderer.ts
+++ b/src/lib/react-email-renderer.ts
@@ -1,6 +1,9 @@
 import { createRequire } from 'node:module';
 
-export async function renderReactEmail(cjsPath: string): Promise<string> {
+export const renderReactEmail = async (
+  cjsPath: string,
+  props: Record<string, unknown> = {},
+): Promise<string> => {
   const require = createRequire(cjsPath);
   delete require.cache[cjsPath];
   const emailModule = require(cjsPath) as {
@@ -16,7 +19,7 @@ export async function renderReactEmail(cjsPath: string): Promise<string> {
   };
 
   return emailModule.render(
-    emailModule.reactEmailCreateReactElement(emailModule.default, {}),
+    emailModule.reactEmailCreateReactElement(emailModule.default, props),
     {},
   );
-}
+};

--- a/src/lib/react-email.ts
+++ b/src/lib/react-email.ts
@@ -6,20 +6,17 @@ import { bundleReactEmail } from './react-email-bundler';
 import { renderReactEmail } from './react-email-renderer';
 import { createSpinner } from './spinner';
 
-function cleanupTmpDir(tmpDir: string | undefined) {
+const cleanupTmpDir = (tmpDir: string | undefined) => {
   if (tmpDir) {
     rmSync(tmpDir, { recursive: true, force: true });
   }
-}
+};
 
-/**
- * Bundles and renders a React Email template (.tsx) to an HTML string.
- * Shows spinners for each phase and exits with the appropriate error code on failure.
- */
-export async function buildReactEmailHtml(
+export const buildReactEmailHtml = async (
   templatePath: string,
   globalOpts: GlobalOpts,
-): Promise<string> {
+  props: Record<string, unknown> = {},
+): Promise<string> => {
   if ('pkg' in process) {
     return outputError(
       {
@@ -57,7 +54,7 @@ export async function buildReactEmailHtml(
       globalOpts.quiet,
     );
     try {
-      const html = await renderReactEmail(result.cjsPath);
+      const html = await renderReactEmail(result.cjsPath, props);
       renderSpinner.stop('Rendered React Email template');
       cleanupTmpDir(tmpDir);
       return html;
@@ -83,4 +80,4 @@ export async function buildReactEmailHtml(
       { json: globalOpts.json },
     );
   }
-}
+};

--- a/tests/commands/broadcasts/create.test.ts
+++ b/tests/commands/broadcasts/create.test.ts
@@ -634,6 +634,7 @@ describe('broadcasts create command', () => {
     expect(mockBuildReactEmailHtml).toHaveBeenCalledWith(
       './emails/newsletter.tsx',
       expect.anything(),
+      {},
     );
     const args = mockCreate.mock.calls[0][0] as Record<string, unknown>;
     expect(args.html).toBe('<html><body>Rendered</body></html>');

--- a/tests/commands/broadcasts/update.test.ts
+++ b/tests/commands/broadcasts/update.test.ts
@@ -434,6 +434,7 @@ describe('broadcasts update command', () => {
     expect(mockBuildReactEmailHtml).toHaveBeenCalledWith(
       './emails/newsletter.tsx',
       expect.anything(),
+      {},
     );
     const payload = mockUpdate.mock.calls[0][1] as Record<string, unknown>;
     expect(payload.html).toBe('<html><body>Rendered</body></html>');
@@ -450,7 +451,11 @@ describe('broadcasts update command', () => {
       { from: 'user' },
     );
 
-    expect(mockBuildReactEmailHtml).toHaveBeenCalledWith('', expect.anything());
+    expect(mockBuildReactEmailHtml).toHaveBeenCalledWith(
+      '',
+      expect.anything(),
+      {},
+    );
     const payload = mockUpdate.mock.calls[0][1] as Record<string, unknown>;
     expect(payload.html).toBe('<html><body>Rendered</body></html>');
   });

--- a/tests/commands/emails/batch.test.ts
+++ b/tests/commands/emails/batch.test.ts
@@ -425,6 +425,7 @@ describe('batch command', () => {
     expect(mockBuildReactEmailHtml).toHaveBeenCalledWith(
       './emails/welcome.tsx',
       expect.anything(),
+      {},
     );
     expect(mockBatchSend).toHaveBeenCalledTimes(1);
     const emails = mockBatchSend.mock.calls[0][0] as Array<
@@ -433,6 +434,37 @@ describe('batch command', () => {
     for (const email of emails) {
       expect(email.html).toBe('<html><body>Rendered</body></html>');
     }
+  });
+
+  test('forwards --react-email-props to buildReactEmailHtml', async () => {
+    spies = setupOutputSpies();
+
+    const emailsWithoutHtml = [
+      {
+        from: 'you@domain.com',
+        to: ['user1@example.com'],
+        subject: 'Hello 1',
+      },
+    ];
+    const file = await writeTmpJson(emailsWithoutHtml);
+    const { batchCommand } = await import('../../../src/commands/emails/batch');
+    await batchCommand.parseAsync(
+      [
+        '--file',
+        file,
+        '--react-email',
+        './emails/welcome.tsx',
+        '--react-email-props',
+        '{"name":"Alice"}',
+      ],
+      { from: 'user' },
+    );
+
+    expect(mockBuildReactEmailHtml).toHaveBeenCalledWith(
+      './emails/welcome.tsx',
+      expect.anything(),
+      { name: 'Alice' },
+    );
   });
 
   test('errors with batch_error when SDK returns an error', async () => {

--- a/tests/commands/emails/send.test.ts
+++ b/tests/commands/emails/send.test.ts
@@ -1104,6 +1104,7 @@ describe('send command', () => {
     expect(mockBuildReactEmailHtml).toHaveBeenCalledWith(
       './emails/welcome.tsx',
       expect.anything(),
+      {},
     );
     expect(mockSend).toHaveBeenCalledTimes(1);
     const callArgs = mockSend.mock.calls[0][0] as Record<string, unknown>;
@@ -1240,6 +1241,64 @@ describe('send command', () => {
         { from: 'user' },
       ),
     );
+  });
+
+  test('forwards --react-email-props to buildReactEmailHtml', async () => {
+    spies = setupOutputSpies();
+
+    const { sendCommand } = await import('../../../src/commands/emails/send');
+    await sendCommand.parseAsync(
+      [
+        '--from',
+        'a@test.com',
+        '--to',
+        'b@test.com',
+        '--subject',
+        'Welcome',
+        '--react-email',
+        './emails/welcome.tsx',
+        '--react-email-props',
+        '{"name":"John","code":42}',
+      ],
+      { from: 'user' },
+    );
+
+    expect(mockBuildReactEmailHtml).toHaveBeenCalledWith(
+      './emails/welcome.tsx',
+      expect.anything(),
+      { name: 'John', code: 42 },
+    );
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    const callArgs = mockSend.mock.calls[0][0] as Record<string, unknown>;
+    expect(callArgs.html).toBe('<html><body>Rendered</body></html>');
+  });
+
+  test('errors with invalid_options when --react-email-props used without --react-email', async () => {
+    setNonInteractive();
+    errorSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    exitSpy = mockExitThrow();
+
+    const { sendCommand } = await import('../../../src/commands/emails/send');
+    await expectExit1(() =>
+      sendCommand.parseAsync(
+        [
+          '--from',
+          'a@test.com',
+          '--to',
+          'b@test.com',
+          '--subject',
+          'Test',
+          '--text',
+          'Hi',
+          '--react-email-props',
+          '{"name":"John"}',
+        ],
+        { from: 'user' },
+      ),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('invalid_options');
   });
 
   test('degrades gracefully when domain fetch fails', async () => {

--- a/tests/commands/templates/create.test.ts
+++ b/tests/commands/templates/create.test.ts
@@ -264,6 +264,7 @@ describe('templates create command', () => {
     expect(mockBuildReactEmailHtml).toHaveBeenCalledWith(
       './emails/welcome.tsx',
       expect.anything(),
+      {},
     );
     const args = mockCreate.mock.calls[0][0] as Record<string, unknown>;
     expect(args.html).toBe('<html><body>Rendered</body></html>');

--- a/tests/lib/parse-react-email-props.test.ts
+++ b/tests/lib/parse-react-email-props.test.ts
@@ -1,0 +1,158 @@
+import { writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from 'vitest';
+import { parseReactEmailProps } from '../../src/lib/parse-react-email-props';
+import { ExitError, mockExitThrow, setNonInteractive } from '../helpers';
+
+describe('parseReactEmailProps', () => {
+  const globalOpts = { json: false } as Parameters<
+    typeof parseReactEmailProps
+  >[2];
+  let exitSpy: MockInstance | undefined;
+  let logSpy: MockInstance | undefined;
+
+  beforeEach(() => {
+    setNonInteractive();
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    exitSpy = mockExitThrow();
+  });
+
+  afterEach(() => {
+    exitSpy?.mockRestore();
+    logSpy?.mockRestore();
+    exitSpy = undefined;
+    logSpy = undefined;
+  });
+
+  it('returns empty object when both args are undefined', () => {
+    const result = parseReactEmailProps(undefined, undefined, globalOpts);
+    expect(result).toEqual({});
+  });
+
+  it('parses inline JSON string', () => {
+    const result = parseReactEmailProps(
+      '{"name":"John","count":42}',
+      undefined,
+      globalOpts,
+    );
+    expect(result).toEqual({ name: 'John', count: 42 });
+  });
+
+  it('parses nested JSON objects', () => {
+    const result = parseReactEmailProps(
+      '{"user":{"name":"Alice","age":30},"items":["a","b"]}',
+      undefined,
+      globalOpts,
+    );
+    expect(result).toEqual({
+      user: { name: 'Alice', age: 30 },
+      items: ['a', 'b'],
+    });
+  });
+
+  it('reads and parses JSON from a file', () => {
+    const tmpFile = join(
+      tmpdir(),
+      `resend-test-props-${Date.now()}-${Math.random().toString(36).slice(2)}.json`,
+    );
+    writeFileSync(tmpFile, '{"greeting":"Hello","year":2026}');
+
+    const result = parseReactEmailProps(undefined, tmpFile, globalOpts);
+    expect(result).toEqual({ greeting: 'Hello', year: 2026 });
+
+    const { unlinkSync } = require('node:fs');
+    try {
+      unlinkSync(tmpFile);
+    } catch {}
+  });
+
+  it('exits with invalid_options when both propsJson and propsFile are given', async () => {
+    const tmpFile = join(
+      tmpdir(),
+      `resend-test-props-${Date.now()}-${Math.random().toString(36).slice(2)}.json`,
+    );
+    writeFileSync(tmpFile, '{"key":"value"}');
+
+    try {
+      let threw = false;
+      try {
+        parseReactEmailProps('{"key":"value"}', tmpFile, globalOpts);
+      } catch (err) {
+        threw = true;
+        expect(err).toBeInstanceOf(ExitError);
+      }
+      expect(threw).toBe(true);
+    } finally {
+      const { unlinkSync } = require('node:fs');
+      try {
+        unlinkSync(tmpFile);
+      } catch {}
+    }
+  });
+
+  it('exits with invalid_options for invalid JSON string', () => {
+    let threw = false;
+    try {
+      parseReactEmailProps('not-valid-json', undefined, globalOpts);
+    } catch (err) {
+      threw = true;
+      expect(err).toBeInstanceOf(ExitError);
+    }
+    expect(threw).toBe(true);
+
+    const output = logSpy?.mock.calls.map((c) => c[0]).join(' ') ?? '';
+    expect(output).toContain('invalid_options');
+  });
+
+  it('exits with invalid_options when props JSON is an array', () => {
+    let threw = false;
+    try {
+      parseReactEmailProps('[1,2,3]', undefined, globalOpts);
+    } catch (err) {
+      threw = true;
+      expect(err).toBeInstanceOf(ExitError);
+    }
+    expect(threw).toBe(true);
+
+    const output = logSpy?.mock.calls.map((c) => c[0]).join(' ') ?? '';
+    expect(output).toContain('invalid_options');
+  });
+
+  it('exits with invalid_options when props JSON is null', () => {
+    let threw = false;
+    try {
+      parseReactEmailProps('null', undefined, globalOpts);
+    } catch (err) {
+      threw = true;
+      expect(err).toBeInstanceOf(ExitError);
+    }
+    expect(threw).toBe(true);
+  });
+
+  it('exits with file_read_error when props file does not exist', () => {
+    let threw = false;
+    try {
+      parseReactEmailProps(
+        undefined,
+        '/tmp/nonexistent-props-file.json',
+        globalOpts,
+      );
+    } catch (err) {
+      threw = true;
+      expect(err).toBeInstanceOf(ExitError);
+    }
+    expect(threw).toBe(true);
+
+    const output = logSpy?.mock.calls.map((c) => c[0]).join(' ') ?? '';
+    expect(output).toContain('file_read_error');
+  });
+});


### PR DESCRIPTION

## Summary by cubic
Enables prop-driven React Email templates by passing props through the renderer and adding CLI flags to supply them.

- **New Features**
  - `renderReactEmail(cjsPath, props?)` and `buildReactEmailHtml(path, opts, props?)` now accept a props object and forward it to the component.
  - New `--react-email-props <json>` and `--react-email-props-file <path>` flags on: `emails send`, `emails batch`, `templates create`, `templates update`, `broadcasts create`, `broadcasts update`.
  - Added `parseReactEmailProps` to parse/validate inline JSON or file-based props.
  - Tests added for parsing and prop forwarding.

- **Bug Fixes**
  - Removed hardcoded `{}` in the React Email rendering pipeline; props are now correctly passed to components.
  - Validation: props flags require `--react-email`, are mutually exclusive, and must parse to a JSON object (not array/null/primitive).

<sup>Written for commit ea86911c495ea585d04aff073cc8e47cfc8eec83. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

