### PR TITLE
fix: prevent orphaned API keys in secure-storage profile mutations

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -3,6 +3,7 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  renameSync,
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
@@ -89,10 +90,12 @@ export function writeCredentials(creds: CredentialsFile): string {
   mkdirSync(configDir, { recursive: true, mode: 0o700 });
 
   const configPath = getCredentialsPath();
-  writeFileSync(configPath, `${JSON.stringify(creds, null, 2)}\n`, {
+  const tmpPath = `${configPath}.tmp.${process.pid}`;
+  writeFileSync(tmpPath, `${JSON.stringify(creds, null, 2)}\n`, {
     mode: 0o600,
   });
-  chmodSync(configPath, 0o600);
+  chmodSync(tmpPath, 0o600);
+  renameSync(tmpPath, configPath);
 
   return configPath;
 }
@@ -387,18 +390,12 @@ export async function storeApiKeyAsync(
   const isFileBackend = !backend.isSecure;
 
   if (isFileBackend) {
-    // Do NOT clear a pre-existing `storage: 'secure_storage'` marker here.
-    // Other profiles may still have their keys in secure storage.
-    // resolveApiKeyAsync already falls through from secure storage to file-based
-    // lookup, so keeping the marker is safe and avoids orphaning those profiles.
     const configPath = storeApiKey(apiKey, profile, permission);
     return { configPath, backend };
   }
 
-  // Store in secure backend
   await backend.set(SERVICE_NAME, profile, apiKey);
 
-  // Update credentials file: mark storage as secure, keep profile entry (without api_key)
   const creds = readCredentials() || {
     active_profile: 'default',
     profiles: {},
@@ -410,8 +407,13 @@ export async function storeApiKeyAsync(
     creds.active_profile = profile;
   }
 
-  const configPath = writeCredentials(creds);
-  return { configPath, backend };
+  try {
+    const configPath = writeCredentials(creds);
+    return { configPath, backend };
+  } catch (err) {
+    await backend.delete(SERVICE_NAME, profile);
+    throw err;
+  }
 }
 
 export async function removeApiKeyAsync(profileName?: string): Promise<string> {
@@ -426,7 +428,16 @@ export async function removeApiKeyAsync(profileName?: string): Promise<string> {
   if (creds?.storage === 'secure_storage') {
     const backend = await getCredentialBackend();
     if (backend.isSecure) {
+      const existingKey = await backend.get(SERVICE_NAME, profile);
       await backend.delete(SERVICE_NAME, profile);
+      try {
+        return removeApiKey(profile);
+      } catch (err) {
+        if (existingKey) {
+          await backend.set(SERVICE_NAME, profile, existingKey);
+        }
+        throw err;
+      }
     }
   }
 
@@ -440,15 +451,30 @@ export async function removeAllApiKeysAsync(): Promise<string> {
   if (creds?.storage === 'secure_storage') {
     const backend = await getCredentialBackend();
     if (backend.isSecure) {
-      await Promise.all(
-        Object.keys(creds.profiles).map((profile) =>
-          backend.delete(SERVICE_NAME, profile),
-        ),
-      );
+      const savedKeys: Array<{ profile: string; key: string }> = [];
+      for (const profile of Object.keys(creds.profiles)) {
+        const key = await backend.get(SERVICE_NAME, profile);
+        if (key) {
+          savedKeys.push({ profile, key });
+        }
+        await backend.delete(SERVICE_NAME, profile);
+      }
+      try {
+        if (existsSync(configPath)) {
+          unlinkSync(configPath);
+        }
+        return configPath;
+      } catch (err) {
+        await Promise.all(
+          savedKeys.map(({ profile, key }) =>
+            backend.set(SERVICE_NAME, profile, key),
+          ),
+        );
+        throw err;
+      }
     }
   }
 
-  // Remove credentials file (may already be gone if only secure storage)
   if (existsSync(configPath)) {
     unlinkSync(configPath);
   }
@@ -467,7 +493,14 @@ export async function renameProfileAsync(
       const key = await backend.get(SERVICE_NAME, oldName);
       if (key) {
         await backend.set(SERVICE_NAME, newName, key);
+        try {
+          renameProfile(oldName, newName);
+        } catch (err) {
+          await backend.delete(SERVICE_NAME, newName);
+          throw err;
+        }
         await backend.delete(SERVICE_NAME, oldName);
+        return;
       }
     }
   }

--- a/tests/lib/config-async.test.ts
+++ b/tests/lib/config-async.test.ts
@@ -1,7 +1,13 @@
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest';
 import { captureTestEnv } from '../helpers';
 
 describe('resolveApiKeyAsync', () => {
@@ -483,6 +489,373 @@ describe('renameProfileAsync', () => {
     expect(mockBackend.delete).not.toHaveBeenCalled();
     const creds = readCredentials();
     expect(creds?.profiles['new-name']).toEqual({ api_key: 're_file_key' });
+    expect(creds?.profiles['old-name']).toBeUndefined();
+  });
+});
+
+describe('writeCredentials atomic write', () => {
+  const restoreEnv = captureTestEnv();
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(
+      tmpdir(),
+      `resend-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(tmpDir, { recursive: true });
+    process.env.XDG_CONFIG_HOME = tmpDir;
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('does not leave a temp file on success', async () => {
+    vi.resetModules();
+    const { writeCredentials, getCredentialsPath } = await import(
+      '../../src/lib/config'
+    );
+    writeCredentials({
+      active_profile: 'default',
+      profiles: { default: {} },
+    });
+    const configDir = join(tmpDir, 'resend');
+    const files = require('node:fs').readdirSync(configDir);
+    const tmpFiles = files.filter((f: string) => f.includes('.tmp.'));
+    expect(tmpFiles).toEqual([]);
+    expect(existsSync(getCredentialsPath())).toBe(true);
+  });
+
+  it('preserves existing file when write fails', async () => {
+    vi.resetModules();
+    const { writeCredentials, readCredentials } = await import(
+      '../../src/lib/config'
+    );
+    writeCredentials({
+      active_profile: 'default',
+      profiles: { default: { api_key: 're_original' } },
+    });
+
+    const configDir = join(tmpDir, 'resend');
+    chmodSync(configDir, 0o555);
+    try {
+      expect(() =>
+        writeCredentials({
+          active_profile: 'default',
+          profiles: { default: { api_key: 're_new' } },
+        }),
+      ).toThrow();
+    } finally {
+      chmodSync(configDir, 0o700);
+    }
+
+    const creds = readCredentials();
+    expect(creds?.profiles.default?.api_key).toBe('re_original');
+  });
+});
+
+describe('storeApiKeyAsync rollback', () => {
+  const restoreEnv = captureTestEnv();
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(
+      tmpdir(),
+      `resend-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(tmpDir, { recursive: true });
+    process.env.XDG_CONFIG_HOME = tmpDir;
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('rolls back backend.set when writeCredentials fails', async () => {
+    const mockBackend = {
+      get: vi.fn().mockResolvedValue(null),
+      set: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(true),
+      isAvailable: vi.fn().mockResolvedValue(true),
+      name: 'mock-backend',
+      isSecure: true,
+    };
+
+    vi.resetModules();
+    vi.doMock('../../src/lib/credential-store', () => ({
+      getCredentialBackend: vi.fn().mockResolvedValue(mockBackend),
+      SERVICE_NAME: 'resend-cli',
+      resetCredentialBackend: vi.fn(),
+    }));
+
+    const configDir = join(tmpDir, 'resend');
+    mkdirSync(configDir, { recursive: true, mode: 0o700 });
+
+    const { storeApiKeyAsync } = await import('../../src/lib/config');
+    chmodSync(configDir, 0o555);
+    try {
+      await expect(storeApiKeyAsync('re_new_key', 'default')).rejects.toThrow();
+      expect(mockBackend.set).toHaveBeenCalledWith(
+        'resend-cli',
+        'default',
+        're_new_key',
+      );
+      expect(mockBackend.delete).toHaveBeenCalledWith('resend-cli', 'default');
+    } finally {
+      chmodSync(configDir, 0o700);
+    }
+  });
+});
+
+describe('removeApiKeyAsync rollback', () => {
+  const restoreEnv = captureTestEnv();
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(
+      tmpdir(),
+      `resend-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(tmpDir, { recursive: true });
+    process.env.XDG_CONFIG_HOME = tmpDir;
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('restores backend secret when file removal fails', async () => {
+    const configDir = join(tmpDir, 'resend');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
+      join(configDir, 'credentials.json'),
+      JSON.stringify({
+        active_profile: 'default',
+        storage: 'secure_storage',
+        profiles: { default: {} },
+      }),
+    );
+
+    const mockBackend = {
+      get: vi.fn().mockResolvedValue('re_saved_key'),
+      set: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(true),
+      isAvailable: vi.fn().mockResolvedValue(true),
+      name: 'mock-backend',
+      isSecure: true,
+    };
+
+    vi.resetModules();
+    vi.doMock('../../src/lib/credential-store', () => ({
+      getCredentialBackend: vi.fn().mockResolvedValue(mockBackend),
+      SERVICE_NAME: 'resend-cli',
+      resetCredentialBackend: vi.fn(),
+    }));
+
+    const { removeApiKeyAsync } = await import('../../src/lib/config');
+    chmodSync(configDir, 0o555);
+    try {
+      await expect(removeApiKeyAsync('default')).rejects.toThrow();
+      expect(mockBackend.delete).toHaveBeenCalledWith('resend-cli', 'default');
+      expect(mockBackend.set).toHaveBeenCalledWith(
+        'resend-cli',
+        'default',
+        're_saved_key',
+      );
+    } finally {
+      chmodSync(configDir, 0o700);
+    }
+  });
+});
+
+describe('removeAllApiKeysAsync rollback', () => {
+  const restoreEnv = captureTestEnv();
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(
+      tmpdir(),
+      `resend-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(tmpDir, { recursive: true });
+    process.env.XDG_CONFIG_HOME = tmpDir;
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('restores all backend secrets when file unlink fails', async () => {
+    const configDir = join(tmpDir, 'resend');
+    mkdirSync(configDir, { recursive: true });
+    const credsPath = join(configDir, 'credentials.json');
+    writeFileSync(
+      credsPath,
+      JSON.stringify({
+        active_profile: 'default',
+        storage: 'secure_storage',
+        profiles: { default: {}, staging: {} },
+      }),
+    );
+
+    const secrets: Record<string, string> = {
+      default: 're_default_key',
+      staging: 're_staging_key',
+    };
+
+    const mockBackend = {
+      get: vi.fn((_, account: string) =>
+        Promise.resolve(secrets[account] ?? null),
+      ),
+      set: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(true),
+      isAvailable: vi.fn().mockResolvedValue(true),
+      name: 'mock-backend',
+      isSecure: true,
+    };
+
+    vi.resetModules();
+    vi.doMock('../../src/lib/credential-store', () => ({
+      getCredentialBackend: vi.fn().mockResolvedValue(mockBackend),
+      SERVICE_NAME: 'resend-cli',
+      resetCredentialBackend: vi.fn(),
+    }));
+
+    const { removeAllApiKeysAsync } = await import('../../src/lib/config');
+    chmodSync(configDir, 0o555);
+    try {
+      await expect(removeAllApiKeysAsync()).rejects.toThrow();
+      expect(mockBackend.delete).toHaveBeenCalledTimes(2);
+      expect(mockBackend.set).toHaveBeenCalledWith(
+        'resend-cli',
+        'default',
+        're_default_key',
+      );
+      expect(mockBackend.set).toHaveBeenCalledWith(
+        'resend-cli',
+        'staging',
+        're_staging_key',
+      );
+    } finally {
+      chmodSync(configDir, 0o700);
+    }
+  });
+});
+
+describe('renameProfileAsync rollback', () => {
+  const restoreEnv = captureTestEnv();
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(
+      tmpdir(),
+      `resend-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(tmpDir, { recursive: true });
+    process.env.XDG_CONFIG_HOME = tmpDir;
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('rolls back backend.set(newName) when file rename fails', async () => {
+    const configDir = join(tmpDir, 'resend');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
+      join(configDir, 'credentials.json'),
+      JSON.stringify({
+        active_profile: 'alpha',
+        storage: 'secure_storage',
+        profiles: { alpha: {}, beta: {} },
+      }),
+    );
+
+    const mockBackend = {
+      get: vi.fn().mockResolvedValue('re_alpha_key'),
+      set: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(true),
+      isAvailable: vi.fn().mockResolvedValue(true),
+      name: 'mock-backend',
+      isSecure: true,
+    };
+
+    vi.resetModules();
+    vi.doMock('../../src/lib/credential-store', () => ({
+      getCredentialBackend: vi.fn().mockResolvedValue(mockBackend),
+      SERVICE_NAME: 'resend-cli',
+      resetCredentialBackend: vi.fn(),
+    }));
+
+    const { renameProfileAsync, readCredentials } = await import(
+      '../../src/lib/config'
+    );
+    await expect(renameProfileAsync('alpha', 'beta')).rejects.toThrow(
+      'already exists',
+    );
+    expect(mockBackend.set).toHaveBeenCalledWith(
+      'resend-cli',
+      'beta',
+      're_alpha_key',
+    );
+    expect(mockBackend.delete).toHaveBeenCalledWith('resend-cli', 'beta');
+    const creds = readCredentials();
+    expect(creds?.profiles.alpha).toBeDefined();
+    expect(creds?.active_profile).toBe('alpha');
+  });
+
+  it('does not delete old backend key until file rename succeeds', async () => {
+    const configDir = join(tmpDir, 'resend');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
+      join(configDir, 'credentials.json'),
+      JSON.stringify({
+        active_profile: 'old-name',
+        storage: 'secure_storage',
+        profiles: { 'old-name': {} },
+      }),
+    );
+
+    const mockBackend = {
+      get: vi.fn().mockResolvedValue('re_the_key'),
+      set: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(true),
+      isAvailable: vi.fn().mockResolvedValue(true),
+      name: 'mock-backend',
+      isSecure: true,
+    };
+
+    vi.resetModules();
+    vi.doMock('../../src/lib/credential-store', () => ({
+      getCredentialBackend: vi.fn().mockResolvedValue(mockBackend),
+      SERVICE_NAME: 'resend-cli',
+      resetCredentialBackend: vi.fn(),
+    }));
+
+    const { renameProfileAsync, readCredentials } = await import(
+      '../../src/lib/config'
+    );
+    await renameProfileAsync('old-name', 'new-name');
+    expect(mockBackend.set).toHaveBeenCalledWith(
+      'resend-cli',
+      'new-name',
+      're_the_key',
+    );
+    const deleteCallOrder = mockBackend.delete.mock.invocationCallOrder[0];
+    const setCallOrder = mockBackend.set.mock.invocationCallOrder[0];
+    expect(deleteCallOrder).toBeGreaterThan(setCallOrder);
+    expect(mockBackend.delete).toHaveBeenCalledWith('resend-cli', 'old-name');
+    const creds = readCredentials();
+    expect(creds?.profiles['new-name']).toBeDefined();
     expect(creds?.profiles['old-name']).toBeUndefined();
   });
 });


### PR DESCRIPTION
The CLI treats secure storage as a two-layer system (OS credential backend + credentials.json), but mutations update these layers in separate non-atomic steps with no rollback. A failure in the second step (file write/delete) after a successful backend mutation leaves the two stores permanently out of sync, causing:

Store: Secret exists in keychain but credentials.json has no marker, so resolveApiKeyAsync() never consults secure storage — the key is orphaned.
Remove: Backend secret is deleted but credentials.json still lists the profile with storage: 'secure_storage' — resolution fails with no fallback.
Rename: Backend secret is moved to the new name but credentials.json still uses the old name — the active profile can't resolve its key.

## Summary by cubic
Fixes orphaned API keys by making secure-storage profile mutations atomic with compensating rollbacks. Addresses Linear BU-636.

- **Bug Fixes**
  - Atomic writes in `writeCredentials` via temp file + `renameSync` to prevent partial `credentials.json` updates.
  - `storeApiKeyAsync`: if the file write fails after storing the secret, delete the new secret from the secure backend.
  - `removeApiKeyAsync`: cache the existing secret and restore it if the file update fails.
  - `removeAllApiKeysAsync`: cache all secrets and restore them if `credentials.json` deletion fails.
  - `renameProfileAsync`: copy secret to the new name, commit the file rename, then delete the old secret; revert the new secret if the file rename fails.

<sup>Written for commit 92bcda3d0b572b16d0246f30f3e814cbb1866b67. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

