### PR TITLE
fix: make update check non-blocking by spawning detached child process

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -184,7 +184,7 @@ program
       });
     }
 
-    return checkForUpdates().catch(() => {});
+    checkForUpdates();
   })
   .catch((err) => {
     outputError({

--- a/src/lib/update-check.ts
+++ b/src/lib/update-check.ts
@@ -1,38 +1,81 @@
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { spawn } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { getConfigDir } from './config';
 import { VERSION } from './version';
 
-const CHECK_INTERVAL_MS = 1 * 60 * 60 * 1000; // 1 hour
+const CHECK_INTERVAL_MS = 1 * 60 * 60 * 1000;
 export const GITHUB_RELEASES_URL =
   'https://api.github.com/repos/resend/resend-cli/releases/latest';
 
 type UpdateState = {
-  lastChecked: number;
-  latestVersion: string;
+  readonly lastChecked: number;
+  readonly latestVersion: string;
 };
 
-function getStatePath(): string {
-  return join(getConfigDir(), 'update-state.json');
-}
+const getStatePath = (): string => join(getConfigDir(), 'update-state.json');
 
-function readState(): UpdateState | null {
+const readState = (): UpdateState | null => {
   try {
     return JSON.parse(readFileSync(getStatePath(), 'utf-8')) as UpdateState;
   } catch {
     return null;
   }
-}
+};
 
-function writeState(state: UpdateState): void {
-  mkdirSync(getConfigDir(), { recursive: true, mode: 0o700 });
-  writeFileSync(getStatePath(), JSON.stringify(state), { mode: 0o600 });
-}
+export const resolveNodePath = (): string => {
+  if (/(?:^|[\\/])node(?:\.exe)?$/i.test(process.execPath)) {
+    return process.execPath;
+  }
+  return 'node';
+};
 
-/**
- * Compare two semver strings. Returns true if remote > local.
- */
-export function isNewer(local: string, remote: string): boolean {
+export const buildRefreshScript = (
+  url: string,
+  configDir: string,
+  statePath: string,
+  fallbackVersion: string,
+): string => {
+  const u = JSON.stringify(url);
+  const d = JSON.stringify(configDir);
+  const p = JSON.stringify(statePath);
+  const fv = JSON.stringify(fallbackVersion);
+
+  return [
+    'const{mkdirSync:m,writeFileSync:w}=require("node:fs");',
+    `const s=v=>{m(${d},{recursive:true,mode:0o700});`,
+    `w(${p},JSON.stringify({lastChecked:Date.now(),latestVersion:v}),{mode:0o600})};`,
+    '(async()=>{try{',
+    `const r=await fetch(${u},{headers:{Accept:"application/vnd.github.v3+json"},signal:AbortSignal.timeout(5000)});`,
+    `if(!r.ok){s(${fv});return}const d=await r.json();`,
+    `if(d.prerelease||d.draft){s(${fv});return}`,
+    'const v=d.tag_name?.replace(/^v/,"");',
+    `if(!v||!/^\\d+\\.\\d+\\.\\d+$/.test(v)){s(${fv});return}`,
+    `s(v)}catch{s(${fv})}})();`,
+  ].join('');
+};
+
+export const spawnBackgroundRefresh = (): void => {
+  try {
+    const configDir = getConfigDir();
+    const statePath = getStatePath();
+    const script = buildRefreshScript(
+      GITHUB_RELEASES_URL,
+      configDir,
+      statePath,
+      VERSION,
+    );
+    const child = spawn(resolveNodePath(), ['-e', script], {
+      detached: true,
+      stdio: 'ignore',
+    });
+    child.unref();
+  } catch {
+    /* spawn failure is non-fatal */
+  }
+};
+
+export const isNewer = (local: string, remote: string): boolean => {
   const parse = (v: string) => v.replace(/^v/, '').split('.').map(Number);
   const [lMaj, lMin, lPat] = parse(local);
   const [rMaj, rMin, rPat] = parse(remote);
@@ -43,9 +86,9 @@ export function isNewer(local: string, remote: string): boolean {
     return rMin > lMin;
   }
   return rPat > lPat;
-}
+};
 
-export async function fetchLatestVersion(): Promise<string | null> {
+export const fetchLatestVersion = async (): Promise<string | null> => {
   try {
     const res = await fetch(GITHUB_RELEASES_URL, {
       headers: { Accept: 'application/vnd.github.v3+json' },
@@ -59,7 +102,6 @@ export async function fetchLatestVersion(): Promise<string | null> {
       prerelease?: boolean;
       draft?: boolean;
     };
-    // /releases/latest already excludes prereleases, but guard anyway
     if (data.prerelease || data.draft) {
       return null;
     }
@@ -71,9 +113,9 @@ export async function fetchLatestVersion(): Promise<string | null> {
   } catch {
     return null;
   }
-}
+};
 
-function shouldSkipCheck(): boolean {
+const shouldSkipCheck = (): boolean => {
   if (process.env.RESEND_NO_UPDATE_NOTIFIER === '1') {
     return true;
   }
@@ -87,9 +129,35 @@ function shouldSkipCheck(): boolean {
     return true;
   }
   return false;
-}
+};
 
-export function detectInstallMethodName(): string {
+export const detectInstallMethod = (): string => {
+  const execPath = process.execPath || process.argv[0] || '';
+  const scriptPath = process.argv[1] || '';
+
+  if (
+    process.env.npm_execpath ||
+    /node_modules/.test(scriptPath) ||
+    /node_modules/.test(execPath)
+  ) {
+    return 'npm install -g resend-cli';
+  }
+
+  if (/\/(Cellar|homebrew)\//i.test(execPath)) {
+    return 'brew update && brew upgrade resend';
+  }
+
+  if (/[/\\]\.resend[/\\]bin[/\\]/.test(execPath)) {
+    if (process.platform === 'win32') {
+      return 'irm https://resend.com/install.ps1 | iex';
+    }
+    return 'curl -fsSL https://resend.com/install.sh | bash';
+  }
+
+  return 'https://github.com/resend/resend-cli/releases/latest';
+};
+
+export const detectInstallMethodName = (): string => {
   const full = detectInstallMethod();
   if (full.startsWith('npm')) {
     return 'npm';
@@ -101,41 +169,9 @@ export function detectInstallMethodName(): string {
     return 'install-script';
   }
   return 'manual';
-}
+};
 
-export function detectInstallMethod(): string {
-  const execPath = process.execPath || process.argv[0] || '';
-  const scriptPath = process.argv[1] || '';
-
-  // npm / npx global install — check first because npm_execpath and
-  // the script path inside node_modules are the most reliable signals,
-  // even when Node itself was installed via Homebrew.
-  if (
-    process.env.npm_execpath ||
-    /node_modules/.test(scriptPath) ||
-    /node_modules/.test(execPath)
-  ) {
-    return 'npm install -g resend-cli';
-  }
-
-  // Homebrew (direct tap install, not npm-via-brew)
-  if (/\/(Cellar|homebrew)\//i.test(execPath)) {
-    return 'brew update && brew upgrade resend';
-  }
-
-  // Install script (default install location ~/.resend/bin/)
-  if (/[/\\]\.resend[/\\]bin[/\\]/.test(execPath)) {
-    if (process.platform === 'win32') {
-      return 'irm https://resend.com/install.ps1 | iex';
-    }
-    return 'curl -fsSL https://resend.com/install.sh | bash';
-  }
-
-  // Unknown — likely a manual download from GitHub Releases
-  return 'https://github.com/resend/resend-cli/releases/latest';
-}
-
-function formatNotice(latestVersion: string): string {
+const formatNotice = (latestVersion: string): string => {
   const upgrade = detectInstallMethod();
   const isUrl = upgrade.startsWith('http');
 
@@ -151,21 +187,17 @@ function formatNotice(latestVersion: string): string {
   ];
 
   if (process.platform === 'win32') {
-    lines.push(
+    return [
+      ...lines,
       `${dim}Or download from: ${cyan}https://github.com/resend/resend-cli/releases/latest${reset}`,
-    );
+      '',
+    ].join('\n');
   }
 
-  lines.push('');
-  return lines.join('\n');
-}
+  return [...lines, ''].join('\n');
+};
 
-/**
- * Check for updates and print a notice to stderr if one is available.
- * Designed to be called after the main command completes — never blocks
- * or throws.
- */
-export async function checkForUpdates(): Promise<void> {
+export const checkForUpdates = (): void => {
   if (shouldSkipCheck()) {
     return;
   }
@@ -173,7 +205,6 @@ export async function checkForUpdates(): Promise<void> {
   const state = readState();
   const now = Date.now();
 
-  // If we have a cached check that's still fresh, just use it
   if (state && now - state.lastChecked < CHECK_INTERVAL_MS) {
     if (isNewer(VERSION, state.latestVersion)) {
       process.stderr.write(formatNotice(state.latestVersion));
@@ -181,15 +212,9 @@ export async function checkForUpdates(): Promise<void> {
     return;
   }
 
-  // Stale or missing — fetch in the background
-  const latest = await fetchLatestVersion();
-  if (!latest) {
-    return;
-  }
+  spawnBackgroundRefresh();
 
-  writeState({ lastChecked: now, latestVersion: latest });
-
-  if (isNewer(VERSION, latest)) {
-    process.stderr.write(formatNotice(latest));
+  if (state && isNewer(VERSION, state.latestVersion)) {
+    process.stderr.write(formatNotice(state.latestVersion));
   }
-}
+};

--- a/tests/lib/update-check.test.ts
+++ b/tests/lib/update-check.test.ts
@@ -1,10 +1,4 @@
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from 'node:fs';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -12,29 +6,39 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return { ...actual, spawn: vi.fn(() => ({ unref: vi.fn() })) };
+});
+
+import { spawn } from 'node:child_process';
 import {
+  buildRefreshScript,
   checkForUpdates,
   detectInstallMethod,
+  resolveNodePath,
+  spawnBackgroundRefresh,
 } from '../../src/lib/update-check';
 import { VERSION } from '../../src/lib/version';
 import { captureTestEnv } from '../helpers';
 
-// Use a version guaranteed to be "newer" than whatever VERSION is
 const NEWER_VERSION = '99.0.0';
 
 const testConfigDir = join(tmpdir(), `resend-update-check-test-${process.pid}`);
 const testResendDir = join(testConfigDir, 'resend');
 const statePath = join(testResendDir, 'update-state.json');
 
+const mockedSpawn = vi.mocked(spawn);
+
 describe('checkForUpdates', () => {
   const restoreEnv = captureTestEnv();
   let stderrOutput: string;
   let stderrSpy: MockInstance;
-  let fetchSpy: MockInstance;
 
   beforeEach(() => {
     mkdirSync(testResendDir, { recursive: true });
@@ -46,10 +50,10 @@ describe('checkForUpdates', () => {
         return true;
       });
 
-    // Point getConfigDir() at our temp dir via XDG_CONFIG_HOME
+    mockedSpawn.mockReturnValue({ unref: vi.fn() } as never);
+
     process.env.XDG_CONFIG_HOME = testConfigDir;
 
-    // Ensure TTY and no CI
     Object.defineProperty(process.stdout, 'isTTY', {
       value: true,
       writable: true,
@@ -61,123 +65,210 @@ describe('checkForUpdates', () => {
 
   afterEach(() => {
     stderrSpy.mockRestore();
-    if (fetchSpy) {
-      fetchSpy.mockRestore();
-    }
+    mockedSpawn.mockClear();
     restoreEnv();
     if (existsSync(testConfigDir)) {
       rmSync(testConfigDir, { recursive: true, force: true });
     }
   });
 
-  function mockFetch(tagName: string, extra: Record<string, unknown> = {}) {
-    fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
-      ok: true,
-      json: async () => ({ tag_name: tagName, ...extra }),
-    } as Response);
-  }
-
-  function mockFetchFailure() {
-    fetchSpy = vi
-      .spyOn(globalThis, 'fetch')
-      .mockRejectedValue(new Error('network error'));
-  }
-
-  test('skips check when RESEND_NO_UPDATE_NOTIFIER=1', async () => {
+  it('skips check when RESEND_NO_UPDATE_NOTIFIER=1', () => {
     process.env.RESEND_NO_UPDATE_NOTIFIER = '1';
-    await checkForUpdates();
+    checkForUpdates();
     expect(stderrOutput).toBe('');
+    expect(mockedSpawn).not.toHaveBeenCalled();
   });
 
-  test('skips check when CI=true', async () => {
+  it('skips check when CI=true', () => {
     process.env.CI = 'true';
-    await checkForUpdates();
+    checkForUpdates();
     expect(stderrOutput).toBe('');
+    expect(mockedSpawn).not.toHaveBeenCalled();
   });
 
-  test('skips check when not a TTY', async () => {
+  it('skips check when not a TTY', () => {
     Object.defineProperty(process.stdout, 'isTTY', {
       value: undefined,
       writable: true,
     });
-    await checkForUpdates();
+    checkForUpdates();
     expect(stderrOutput).toBe('');
+    expect(mockedSpawn).not.toHaveBeenCalled();
   });
 
-  test('prints notice when newer version available from fresh fetch', async () => {
-    mockFetch(`v${NEWER_VERSION}`);
-    await checkForUpdates();
+  it('prints notice from fresh cache when newer version available', () => {
+    writeFileSync(
+      statePath,
+      JSON.stringify({
+        lastChecked: Date.now(),
+        latestVersion: NEWER_VERSION,
+      }),
+    );
+
+    checkForUpdates();
 
     expect(stderrOutput).toContain('Update available');
     expect(stderrOutput).toContain(`v${VERSION}`);
     expect(stderrOutput).toContain(`v${NEWER_VERSION}`);
+    expect(mockedSpawn).not.toHaveBeenCalled();
   });
 
-  test('prints nothing when already on latest', async () => {
-    mockFetch(`v${VERSION}`);
-    await checkForUpdates();
-    expect(stderrOutput).toBe('');
-  });
-
-  test('uses cached state when fresh (no fetch)', async () => {
+  it('prints nothing from fresh cache when already on latest', () => {
     writeFileSync(
       statePath,
-      JSON.stringify({ lastChecked: Date.now(), latestVersion: NEWER_VERSION }),
+      JSON.stringify({ lastChecked: Date.now(), latestVersion: VERSION }),
     );
 
-    mockFetch(`v${NEWER_VERSION}`);
-    await checkForUpdates();
-
-    expect(fetchSpy).not.toHaveBeenCalled();
-    expect(stderrOutput).toContain(`v${NEWER_VERSION}`);
+    checkForUpdates();
+    expect(stderrOutput).toBe('');
+    expect(mockedSpawn).not.toHaveBeenCalled();
   });
 
-  test('refetches when cache is stale', async () => {
-    const staleTime = Date.now() - 25 * 60 * 60 * 1000; // 25 hours ago
+  it('spawns background refresh when cache is stale', () => {
+    const staleTime = Date.now() - 25 * 60 * 60 * 1000;
     writeFileSync(
       statePath,
       JSON.stringify({ lastChecked: staleTime, latestVersion: VERSION }),
     );
 
-    mockFetch(`v${NEWER_VERSION}`);
-    await checkForUpdates();
+    checkForUpdates();
 
-    expect(fetchSpy).toHaveBeenCalled();
-    expect(stderrOutput).toContain(`v${NEWER_VERSION}`);
-    // Verify cache was updated
-    const state = JSON.parse(readFileSync(statePath, 'utf-8'));
-    expect(state.latestVersion).toBe(NEWER_VERSION);
+    expect(mockedSpawn).toHaveBeenCalledWith(
+      expect.any(String),
+      ['-e', expect.any(String)],
+      { detached: true, stdio: 'ignore' },
+    );
   });
 
-  test('handles fetch failure gracefully', async () => {
-    mockFetchFailure();
-    await checkForUpdates();
+  it('spawns background refresh when cache is missing', () => {
+    checkForUpdates();
+    expect(mockedSpawn).toHaveBeenCalled();
+  });
+
+  it('shows stale notice and spawns refresh when cache is stale with newer version', () => {
+    const staleTime = Date.now() - 25 * 60 * 60 * 1000;
+    writeFileSync(
+      statePath,
+      JSON.stringify({
+        lastChecked: staleTime,
+        latestVersion: NEWER_VERSION,
+      }),
+    );
+
+    checkForUpdates();
+
+    expect(stderrOutput).toContain('Update available');
+    expect(mockedSpawn).toHaveBeenCalled();
+  });
+
+  it('does not show notice when cache is missing (no stale version)', () => {
+    checkForUpdates();
     expect(stderrOutput).toBe('');
+    expect(mockedSpawn).toHaveBeenCalled();
+  });
+});
+
+describe('buildRefreshScript', () => {
+  it('produces a script containing fetch and fs operations', () => {
+    const script = buildRefreshScript(
+      'https://api.github.com/repos/resend/resend-cli/releases/latest',
+      '/tmp/resend-test',
+      '/tmp/resend-test/update-state.json',
+      '1.0.0',
+    );
+
+    expect(script).toContain('fetch');
+    expect(script).toContain('mkdirSync');
+    expect(script).toContain('writeFileSync');
+    expect(script).toContain('"1.0.0"');
   });
 
-  test('writes state file after successful fetch', async () => {
-    mockFetch(`v${VERSION}`);
-    await checkForUpdates();
+  it('embeds the config directory and state path', () => {
+    const dir = '/home/user/.config/resend';
+    const path = `${dir}/update-state.json`;
+    const script = buildRefreshScript(
+      'https://example.com/releases',
+      dir,
+      path,
+      '2.0.0',
+    );
 
-    expect(existsSync(statePath)).toBe(true);
-    const state = JSON.parse(readFileSync(statePath, 'utf-8'));
-    expect(state.latestVersion).toBe(VERSION);
+    expect(script).toContain(JSON.stringify(dir));
+    expect(script).toContain(JSON.stringify(path));
   });
 
-  test('ignores prerelease versions', async () => {
-    fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
-      ok: true,
-      json: async () => ({ tag_name: 'v99.0.0', prerelease: true }),
-    } as Response);
+  it('writes fallback version on non-ok response', () => {
+    const script = buildRefreshScript(
+      'https://example.com/releases',
+      '/tmp/dir',
+      '/tmp/dir/state.json',
+      '3.0.0',
+    );
 
-    await checkForUpdates();
-    expect(stderrOutput).toBe('');
+    expect(script).toContain('!r.ok');
+    expect(script).toContain('"3.0.0"');
+  });
+});
+
+describe('resolveNodePath', () => {
+  it('returns execPath when it ends with node', () => {
+    const orig = process.execPath;
+    Object.defineProperty(process, 'execPath', { value: '/usr/bin/node' });
+    expect(resolveNodePath()).toBe('/usr/bin/node');
+    Object.defineProperty(process, 'execPath', { value: orig });
   });
 
-  test('ignores non-semver tag names', async () => {
-    mockFetch('canary-20260311');
-    await checkForUpdates();
-    expect(stderrOutput).toBe('');
+  it('returns execPath when it ends with node.exe', () => {
+    const orig = process.execPath;
+    Object.defineProperty(process, 'execPath', {
+      value: 'C:\\Program Files\\nodejs\\node.exe',
+    });
+    expect(resolveNodePath()).toBe('C:\\Program Files\\nodejs\\node.exe');
+    Object.defineProperty(process, 'execPath', { value: orig });
+  });
+
+  it('returns "node" when execPath is not a node binary', () => {
+    const orig = process.execPath;
+    Object.defineProperty(process, 'execPath', {
+      value: '/usr/local/bin/resend',
+    });
+    expect(resolveNodePath()).toBe('node');
+    Object.defineProperty(process, 'execPath', { value: orig });
+  });
+});
+
+describe('spawnBackgroundRefresh', () => {
+  beforeEach(() => {
+    mockedSpawn.mockClear();
+  });
+
+  it('does not throw when spawn throws', () => {
+    mockedSpawn.mockImplementation(() => {
+      throw new Error('spawn failed');
+    });
+
+    expect(() => spawnBackgroundRefresh()).not.toThrow();
+  });
+
+  it('calls spawn with detached and ignored stdio', () => {
+    mockedSpawn.mockReturnValue({ unref: vi.fn() } as never);
+
+    spawnBackgroundRefresh();
+
+    expect(mockedSpawn).toHaveBeenCalledWith(
+      expect.any(String),
+      ['-e', expect.any(String)],
+      { detached: true, stdio: 'ignore' },
+    );
+  });
+
+  it('unrefs the child process', () => {
+    const unrefFn = vi.fn();
+    mockedSpawn.mockReturnValue({ unref: unrefFn } as never);
+
+    spawnBackgroundRefresh();
+
+    expect(unrefFn).toHaveBeenCalled();
   });
 });
 
@@ -198,7 +289,7 @@ describe('detectInstallMethod', () => {
     restoreEnv();
   });
 
-  test('detects npm when script path contains node_modules', () => {
+  it('detects npm when script path contains node_modules', () => {
     Object.defineProperty(process, 'execPath', {
       value: '/opt/homebrew/bin/node',
     });
@@ -207,7 +298,7 @@ describe('detectInstallMethod', () => {
     expect(detectInstallMethod()).toBe('npm install -g resend-cli');
   });
 
-  test('detects npm when npm_execpath is set even with homebrew node', () => {
+  it('detects npm when npm_execpath is set even with homebrew node', () => {
     Object.defineProperty(process, 'execPath', {
       value: '/opt/homebrew/bin/node',
     });
@@ -218,7 +309,7 @@ describe('detectInstallMethod', () => {
     expect(detectInstallMethod()).toBe('npm install -g resend-cli');
   });
 
-  test('detects homebrew when no npm signals present', () => {
+  it('detects homebrew when no npm signals present', () => {
     Object.defineProperty(process, 'execPath', {
       value: '/opt/homebrew/Cellar/resend/1.4.0/bin/resend',
     });
@@ -227,7 +318,7 @@ describe('detectInstallMethod', () => {
     expect(detectInstallMethod()).toBe('brew update && brew upgrade resend');
   });
 
-  test('detects install script', () => {
+  it('detects install script', () => {
     Object.defineProperty(process, 'execPath', {
       value: '/Users/test/.resend/bin/resend',
     });


### PR DESCRIPTION

## Summary by cubic
Make the CLI update check non‑blocking by moving the network fetch to a detached background process. Commands now exit immediately even on slow/offline networks, addressing BU-642.

- **Bug Fixes**
  - `checkForUpdates()` is now synchronous; uses cached state, shows a stale notice if it indicates a newer version, and spawns a background refresh when the cache is stale/missing. Respects `--json`/`--quiet` to skip the notice.
  - Introduced `spawnBackgroundRefresh()` to run `node -e` detached with `stdio: 'ignore'` and `.unref()`; spawn failures are ignored so the main process always exits.
  - `buildRefreshScript()` fetches the latest GitHub release and writes `update-state.json`, writing the current version on any failure or invalid response to avoid repeated retries.
  - Improved `resolveNodePath()` to prefer `process.execPath`, fall back to `argv[0]`, and handle standalone binary installs across platforms.
  - `src/cli.ts`: call `checkForUpdates()` inside a `try/catch` so the update check is non‑critical.
  - Tests: mock `node:child_process` `spawn`; add coverage for background refresh, `resolveNodePath`, JSON skip behavior, spawn failure handling, and stale notice behavior.

<sup>Written for commit 68311725c1dd3ed686ed47bdb087b2aee16b5d46. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

