### PR TITLE
feat: skill openclaw metadata

### DIFF
--- a/skills/resend-cli/SKILL.md
+++ b/skills/resend-cli/SKILL.md
@@ -11,8 +11,8 @@ description: >
 license: MIT
 metadata:
   author: resend
-  version: "1.9.0"
-  homepage: https://resend.com
+  version: "1.10.0"
+  homepage: https://resend.com/docs/cli-agents
   source: https://github.com/resend/resend-cli
   openclaw:
     primaryEnv: RESEND_API_KEY
@@ -27,7 +27,6 @@ metadata:
         bins: [resend]
         label: Resend CLI
     links:
-      homepage: https://resend.com
       repository: https://github.com/resend/resend-cli
       documentation: https://resend.com/docs/cli
 inputs:

--- a/skills/resend-cli/SKILL.md
+++ b/skills/resend-cli/SKILL.md
@@ -21,6 +21,13 @@ metadata:
         - RESEND_API_KEY
       bins:
         - resend
+    envVars:
+      - name: RESEND_API_KEY
+        required: true
+        description: Resend API key for authenticating CLI commands
+      - name: RESEND_PROFILE
+        required: false
+        description: Named auth profile for multi-account setups
     install:
       - kind: node
         package: resend-cli

--- a/skills/resend-cli/SKILL.md
+++ b/skills/resend-cli/SKILL.md
@@ -14,10 +14,29 @@ metadata:
   version: "1.9.0"
   homepage: https://resend.com
   source: https://github.com/resend/resend-cli
+  openclaw:
+    primaryEnv: RESEND_API_KEY
+    requires:
+      env:
+        - RESEND_API_KEY
+      bins:
+        - resend
+    install:
+      - kind: node
+        package: resend-cli
+        bins: [resend]
+        label: Resend CLI
+    links:
+      homepage: https://resend.com
+      repository: https://github.com/resend/resend-cli
+      documentation: https://resend.com/docs/cli
 inputs:
   - name: RESEND_API_KEY
     description: Resend API key for authenticating CLI commands. Get yours at https://resend.com/api-keys
     required: true
+  - name: RESEND_PROFILE
+    description: Named auth profile for multi-account setups. Selects which stored API key to use (see `resend auth`).
+    required: false
 references:
   - references/emails.md
   - references/domains.md


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds ClawHub-compatible `openclaw` metadata to the Resend CLI skill so the scanner recognizes credentials, binaries, and install steps. Bumps to `1.10.0` and updates the homepage to the CLI agents docs.

- **New Features**
  - Add `metadata.openclaw` with `primaryEnv`, `requires` (env=`RESEND_API_KEY`, bins=`resend`), `envVars`, `install` for `resend-cli`, and links (repository, docs).
  - Add optional `RESEND_PROFILE` input for multi-account auth.

- **Bug Fixes**
  - Remove duplicate homepage link and clarify env var descriptions.

<sup>Written for commit efc013efadd67da6bcb5dfe64d4866eafa9475ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

