### PR TITLE
fix: ensure install before packing and bump patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-cli",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "The official CLI for Resend",
   "license": "MIT",
   "repository": {
@@ -37,7 +37,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:e2e": "vitest run --config vitest.config.e2e.ts",
-    "prepack": "pnpm build && node scripts/verify-bundle.mjs"
+    "prepack": "pnpm install && pnpm build && node scripts/verify-bundle.mjs"
   },
   "dependencies": {
     "@clack/prompts": "1.2.0",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ensure dependencies are installed before packing by updating the `prepack` script to run `pnpm install` before build, preventing pack/publish failures from missing modules. Bumps `resend-cli` to `1.9.1`.

<sup>Written for commit 163a867ff9a8a12ef068c83f602d3565eaa7a55d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

