### PR TITLE
feat: add `automations stop` command

### DIFF
--- a/skills/resend-cli/SKILL.md
+++ b/skills/resend-cli/SKILL.md
@@ -135,7 +135,7 @@ Auth resolves: `--api-key` flag > `RESEND_API_KEY` env > config file (`resend lo
 | `domains` | create, verify, update, delete, list |
 | `logs` | list, get, open |
 | `api-keys` | create, list, delete |
-| `automations` | create, get, list, update, delete, open, runs |
+| `automations` | create, get, list, update, delete, stop, open, runs |
 | `events` | create, get, list, update, delete, send, open |
 | `broadcasts` | create, send, update, delete, list |
 | `contacts` | create, update, delete, segments, topics |

--- a/skills/resend-cli/references/automations.md
+++ b/skills/resend-cli/references/automations.md
@@ -54,6 +54,18 @@ resend automations update <id> --status enabled
 
 ---
 
+## automations stop
+
+```
+resend automations stop <id>
+```
+
+Stops a running automation by setting its status to disabled and cancelling active runs.
+
+Returns `{"object":"automation","id":"<id>","status":"disabled"}`.
+
+---
+
 ## automations delete
 
 | Flag | Type | Required | Description |

--- a/src/commands/automations/index.ts
+++ b/src/commands/automations/index.ts
@@ -6,6 +6,7 @@ import { getAutomationCommand } from './get';
 import { listAutomationsCommand } from './list';
 import { openAutomationCommand } from './open';
 import { automationRunsCommand } from './runs/index';
+import { stopAutomationCommand } from './stop';
 import { updateAutomationCommand } from './update';
 
 export const automationsCommand = new Command('automations')
@@ -21,13 +22,15 @@ Connections define the flow between steps (default, condition_met, condition_not
 Lifecycle:
   1. resend automations create --name "Welcome" --file workflow.json
   2. resend automations update <id> --status enabled
-  3. resend automations runs <id>                        (inspect runs)
-  4. resend automations open <id>                        (view in dashboard)`,
+  3. resend automations stop <id>                        (stop automation)
+  4. resend automations runs <id>                        (inspect runs)
+  5. resend automations open <id>                        (view in dashboard)`,
       examples: [
         'resend automations list',
         'resend automations create --name "Welcome Flow" --file workflow.json',
         'resend automations get <id>',
         'resend automations update <id> --status enabled',
+        'resend automations stop <id>',
         'resend automations delete <id> --yes',
         'resend automations runs <automation-id>',
         'resend automations runs get --automation-id <id> --run-id <id>',
@@ -40,5 +43,6 @@ Lifecycle:
   .addCommand(listAutomationsCommand, { isDefault: true })
   .addCommand(updateAutomationCommand)
   .addCommand(deleteAutomationCommand)
+  .addCommand(stopAutomationCommand)
   .addCommand(openAutomationCommand)
   .addCommand(automationRunsCommand);

--- a/src/commands/automations/stop.ts
+++ b/src/commands/automations/stop.ts
@@ -1,0 +1,36 @@
+import { Command } from '@commander-js/extra-typings';
+import { runWrite } from '../../lib/actions';
+import type { GlobalOpts } from '../../lib/client';
+import { buildHelpText } from '../../lib/help-text';
+import { pickId } from '../../lib/prompts';
+import { automationPickerConfig } from './utils';
+
+export const stopAutomationCommand = new Command('stop')
+  .description('Stop a running automation')
+  .argument('[id]', 'Automation ID')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      context:
+        'Stops a running automation by setting its status to disabled and cancelling active runs.',
+      output: '  {"object":"automation","id":"<id>","status":"disabled"}',
+      errorCodes: ['auth_error', 'stop_error'],
+      examples: [
+        'resend automations stop <id>',
+        'resend automations stop <id> --json',
+      ],
+    }),
+  )
+  .action(async (idArg, _opts, cmd) => {
+    const globalOpts = cmd.optsWithGlobals() as GlobalOpts;
+    const id = await pickId(idArg, automationPickerConfig, globalOpts);
+    await runWrite(
+      {
+        loading: 'Stopping automation...',
+        sdkCall: (resend) => resend.automations.stop(id),
+        errorCode: 'stop_error',
+        successMsg: 'Automation stopped',
+      },
+      globalOpts,
+    );
+  });


### PR DESCRIPTION
Add a missing command.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `resend automations stop` CLI command to disable an automation and cancel its active runs. Updates lifecycle help and docs.

- **New Features**
  - Command: `resend automations stop <id>` (interactive ID picker if omitted).
  - Calls `resend.automations.stop(id)`; shows progress and success; supports `--json`.
  - Added to `automations` lifecycle and examples; documented in `references/automations.md` and `SKILL.md`.

<sup>Written for commit 2ecaf69c90eda1b3575bc0413f333b7db2a68d2a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

