### PR TITLE
chore: bump 1.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-cli",
-  "version": "1.9.1",
+  "version": "1.10.0",
   "description": "The official CLI for Resend",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump `resend-cli` version from 1.9.1 to 1.10.0 to prepare the v1.10.0 release.
Updates only `package.json`; no functional changes.

<sup>Written for commit 4164678322afd9477bca6917bc097382a2ff118e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

