### PR TITLE
feat: automations runs status filter

### DIFF
--- a/skills/resend-cli/SKILL.md
+++ b/skills/resend-cli/SKILL.md
@@ -11,7 +11,7 @@ description: >
 license: MIT
 metadata:
   author: resend
-  version: "1.10.0"
+  version: "1.11.0"
   homepage: https://resend.com/docs/cli-agents
   source: https://github.com/resend/resend-cli
   openclaw:

--- a/skills/resend-cli/references/automations.md
+++ b/skills/resend-cli/references/automations.md
@@ -88,12 +88,15 @@ Opens the automations list or a specific automation's editor in the dashboard.
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
+| `--status <status>` | string | — | Filter by status (comma-separated: `running`, `completed`, `failed`, `cancelled`) |
 | `--limit <n>` | number | 10 | Max results (1-100) |
 | `--after <cursor>` | string | — | Forward pagination |
 | `--before <cursor>` | string | — | Backward pagination |
 
 ```
 resend automations runs <automation-id>
+resend automations runs list <automation-id> --status running
+resend automations runs list <automation-id> --status completed,failed
 ```
 
 **Run status values:** `running` | `completed` | `failed` | `cancelled`

--- a/src/commands/automations/runs/list.ts
+++ b/src/commands/automations/runs/list.ts
@@ -57,7 +57,11 @@ export const listAutomationRunsCommand = new Command('list')
             automationId,
             ...paginationOpts,
             ...(opts.status
-              ? { status: opts.status as Parameters<typeof resend.automations.runs.list>[0]['status'] }
+              ? {
+                  status: opts.status as Parameters<
+                    typeof resend.automations.runs.list
+                  >[0]['status'],
+                }
               : {}),
           }),
         onInteractive: (list) => {

--- a/src/commands/automations/runs/list.ts
+++ b/src/commands/automations/runs/list.ts
@@ -56,7 +56,9 @@ export const listAutomationRunsCommand = new Command('list')
           resend.automations.runs.list({
             automationId,
             ...paginationOpts,
-            ...(opts.status ? { status: opts.status } : {}),
+            ...(opts.status
+              ? { status: opts.status as Parameters<typeof resend.automations.runs.list>[0]['status'] }
+              : {}),
           }),
         onInteractive: (list) => {
           const rows = list.data.map((r) => [

--- a/src/commands/automations/runs/list.ts
+++ b/src/commands/automations/runs/list.ts
@@ -15,6 +15,10 @@ export const listAutomationRunsCommand = new Command('list')
   .alias('ls')
   .description('List runs for an automation')
   .argument('[automation-id]', 'Automation ID')
+  .option(
+    '--status <status>',
+    'Filter by status (running, completed, failed, cancelled). Comma-separated.',
+  )
   .option('--limit <n>', 'Maximum number of runs to return (1-100)', '10')
   .option('--after <cursor>', 'Return runs after this cursor (next page)')
   .option('--before <cursor>', 'Return runs before this cursor (previous page)')
@@ -26,6 +30,7 @@ export const listAutomationRunsCommand = new Command('list')
       examples: [
         'resend automations runs <automation-id>',
         'resend automations runs list <automation-id>',
+        'resend automations runs list <automation-id> --status running',
         'resend automations runs list <automation-id> --limit 25 --json',
       ],
     }),
@@ -51,6 +56,7 @@ export const listAutomationRunsCommand = new Command('list')
           resend.automations.runs.list({
             automationId,
             ...paginationOpts,
+            ...(opts.status ? { status: opts.status } : {}),
           }),
         onInteractive: (list) => {
           const rows = list.data.map((r) => [


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a `--status` filter to `resend automations runs list` to filter runs by `running`, `completed`, `failed`, or `cancelled`. Updates CLI docs, bumps the skill to `1.11.0`, and fixes SDK type compatibility for the flag.

- **New Features**
  - Adds `--status <status>`; accepts comma-separated values (e.g., `completed,failed`), forwards to the API, and updates help/examples.

<sup>Written for commit 4be2042baa95608b742273c6725aadc47349063a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

