### PR TITLE
chore: bump to 1.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-cli",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "The official CLI for Resend",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump `resend-cli` version from 1.10.0 to 1.11.0 for the next release.

<sup>Written for commit 0ab45d1a1ef2150a247495c72410db501dccc048. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

