### PR TITLE
chore: replace test() with it() in all vitest test files

### DIFF
--- a/tests/commands/api-keys/create.test.ts
+++ b/tests/commands/api-keys/create.test.ts
@@ -5,7 +5,6 @@ import {
   expect,
   it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -57,7 +56,7 @@ describe('api-keys create command', () => {
     }
   });
 
-  test('creates API key with --name flag', async () => {
+  it('creates API key with --name flag', async () => {
     spies = setupOutputSpies();
 
     const { createApiKeyCommand } = await import(
@@ -72,7 +71,7 @@ describe('api-keys create command', () => {
     expect(args.name).toBe('Production');
   });
 
-  test('passes permission flag to SDK', async () => {
+  it('passes permission flag to SDK', async () => {
     spies = setupOutputSpies();
 
     const { createApiKeyCommand } = await import(
@@ -87,7 +86,7 @@ describe('api-keys create command', () => {
     expect(args.permission).toBe('sending_access');
   });
 
-  test('passes domain_id (snake_case) to SDK when --domain-id is provided', async () => {
+  it('passes domain_id (snake_case) to SDK when --domain-id is provided', async () => {
     spies = setupOutputSpies();
 
     const { createApiKeyCommand } = await import(
@@ -109,7 +108,7 @@ describe('api-keys create command', () => {
     expect(args.domain_id).toBe('domain-123');
   });
 
-  test('outputs JSON result when non-interactive', async () => {
+  it('outputs JSON result when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { createApiKeyCommand } = await import(
@@ -125,7 +124,7 @@ describe('api-keys create command', () => {
     expect(parsed.token).toBe('re_testtoken1234567890');
   });
 
-  test('errors with missing_name when --name absent in non-interactive mode', async () => {
+  it('errors with missing_name when --name absent in non-interactive mode', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -141,7 +140,7 @@ describe('api-keys create command', () => {
     expect(output).toContain('missing_name');
   });
 
-  test('errors with missing_name when --json is set even in TTY', async () => {
+  it('errors with missing_name when --json is set even in TTY', async () => {
     Object.defineProperty(process.stdin, 'isTTY', {
       value: true,
       writable: true,
@@ -174,7 +173,7 @@ describe('api-keys create command', () => {
     expect(output).toContain('missing_name');
   });
 
-  test('does not call SDK when missing_name error is raised', async () => {
+  it('does not call SDK when missing_name error is raised', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -189,7 +188,7 @@ describe('api-keys create command', () => {
     expect(mockCreate).not.toHaveBeenCalled();
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -209,7 +208,7 @@ describe('api-keys create command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with create_error when SDK returns an error', async () => {
+  it('errors with create_error when SDK returns an error', async () => {
     setNonInteractive();
     mockCreate.mockResolvedValueOnce(
       mockSdkError('Name already taken', 'validation_error'),

--- a/tests/commands/api-keys/delete.test.ts
+++ b/tests/commands/api-keys/delete.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -51,7 +51,7 @@ describe('api-keys delete command', () => {
     exitSpy = undefined;
   });
 
-  test('deletes API key with --yes flag', async () => {
+  it('deletes API key with --yes flag', async () => {
     spies = setupOutputSpies();
 
     const { deleteApiKeyCommand } = await import(
@@ -64,7 +64,7 @@ describe('api-keys delete command', () => {
     expect(mockRemove).toHaveBeenCalledWith('test-key-id');
   });
 
-  test('outputs synthesized deleted JSON on success', async () => {
+  it('outputs synthesized deleted JSON on success', async () => {
     spies = setupOutputSpies();
 
     const { deleteApiKeyCommand } = await import(
@@ -80,7 +80,7 @@ describe('api-keys delete command', () => {
     expect(parsed.id).toBe('test-key-id');
   });
 
-  test('errors with confirmation_required when --yes absent in non-interactive mode', async () => {
+  it('errors with confirmation_required when --yes absent in non-interactive mode', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -96,7 +96,7 @@ describe('api-keys delete command', () => {
     expect(output).toContain('confirmation_required');
   });
 
-  test('does not call SDK when confirmation is required but not given', async () => {
+  it('does not call SDK when confirmation is required but not given', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -111,7 +111,7 @@ describe('api-keys delete command', () => {
     expect(mockRemove).not.toHaveBeenCalled();
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -131,7 +131,7 @@ describe('api-keys delete command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with delete_error when SDK returns an error', async () => {
+  it('errors with delete_error when SDK returns an error', async () => {
     setNonInteractive();
     mockRemove.mockResolvedValueOnce(
       mockSdkError('API key not found', 'not_found'),

--- a/tests/commands/auth/list.test.ts
+++ b/tests/commands/auth/list.test.ts
@@ -2,7 +2,7 @@ import { mkdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Command } from '@commander-js/extra-typings';
-import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { storeApiKey } from '../../../src/lib/config';
 import { captureTestEnv, setupOutputSpies } from '../../helpers';
 
@@ -35,7 +35,7 @@ describe('auth list command', () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  test('lists profiles in JSON mode', async () => {
+  it('lists profiles in JSON mode', async () => {
     spies = setupOutputSpies();
     storeApiKey('re_default', 'default');
     storeApiKey('re_staging', 'staging');
@@ -50,7 +50,7 @@ describe('auth list command', () => {
     ]);
   });
 
-  test('shows message when no profiles configured', async () => {
+  it('shows message when no profiles configured', async () => {
     spies = setupOutputSpies();
 
     const program = await createProgram();

--- a/tests/commands/auth/login.test.ts
+++ b/tests/commands/auth/login.test.ts
@@ -12,8 +12,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -72,7 +72,7 @@ describe('login command', () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  test('rejects key that fails API validation', async () => {
+  it('rejects key that fails API validation', async () => {
     mockDomainListResult = {
       data: null,
       error: {
@@ -101,7 +101,7 @@ describe('login command', () => {
     expect(existsSync(configPath)).toBe(false);
   });
 
-  test('rejects key not starting with re_', async () => {
+  it('rejects key not starting with re_', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -115,7 +115,7 @@ describe('login command', () => {
     expect(output).toContain('invalid_key_format');
   });
 
-  test('rejects empty or whitespace-only key with missing_key in non-interactive', async () => {
+  it('rejects empty or whitespace-only key with missing_key in non-interactive', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -129,7 +129,7 @@ describe('login command', () => {
     expect(output).toContain('missing_key');
   });
 
-  test('trims API key before storing', async () => {
+  it('trims API key before storing', async () => {
     setNonInteractive();
 
     const { loginCommand } = await import('../../../src/commands/auth/login');
@@ -142,7 +142,7 @@ describe('login command', () => {
     expect(data.profiles.default.api_key).toBe('re_trimmed_key_456');
   });
 
-  test('stores valid key to credentials.json and sets active_profile', async () => {
+  it('stores valid key to credentials.json and sets active_profile', async () => {
     setupOutputSpies();
 
     const { loginCommand } = await import('../../../src/commands/auth/login');
@@ -156,7 +156,7 @@ describe('login command', () => {
     expect(data.active_profile).toBe('default');
   });
 
-  test('requires --key in non-interactive mode', async () => {
+  it('requires --key in non-interactive mode', async () => {
     setupOutputSpies();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -169,7 +169,7 @@ describe('login command', () => {
     expect(output).toContain('missing_key');
   });
 
-  test('errors with missing_key when --json is set but --key is omitted even in TTY', async () => {
+  it('errors with missing_key when --json is set but --key is omitted even in TTY', async () => {
     Object.defineProperty(process.stdin, 'isTTY', {
       value: true,
       writable: true,
@@ -201,7 +201,7 @@ describe('login command', () => {
     loginCommand.parent = null;
   });
 
-  test('non-interactive login stores as default when profiles exist', async () => {
+  it('non-interactive login stores as default when profiles exist', async () => {
     // Pre-populate credentials with an existing profile
     const configDir = join(tmpDir, 'resend');
     mkdirSync(configDir, { recursive: true });
@@ -228,7 +228,7 @@ describe('login command', () => {
     expect(data.active_profile).toBe('production');
   });
 
-  test('auto-switches to profile specified via --profile flag', async () => {
+  it('auto-switches to profile specified via --profile flag', async () => {
     setupOutputSpies();
 
     const { Command } = await import('@commander-js/extra-typings');
@@ -263,7 +263,7 @@ describe('login command', () => {
     expect(data.profiles.staging.api_key).toBe('re_staging_key_123');
   });
 
-  test('deprecated --team alias works like --profile', async () => {
+  it('deprecated --team alias works like --profile', async () => {
     setupOutputSpies();
 
     const { Command } = await import('@commander-js/extra-typings');
@@ -287,7 +287,7 @@ describe('login command', () => {
     expect(data.profiles.legacy.api_key).toBe('re_team_alias_key_123');
   });
 
-  test('rejects invalid profile name with invalid_profile_name', async () => {
+  it('rejects invalid profile name with invalid_profile_name', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -312,7 +312,7 @@ describe('login command', () => {
     expect(output).toContain('invalid_profile_name');
   });
 
-  test('trims --profile before storing', async () => {
+  it('trims --profile before storing', async () => {
     setupOutputSpies();
 
     const { Command } = await import('@commander-js/extra-typings');
@@ -337,7 +337,7 @@ describe('login command', () => {
     expect(data.active_profile).toBe('myprofile');
   });
 
-  test('--json output includes success, config_path, and profile', async () => {
+  it('--json output includes success, config_path, and profile', async () => {
     setupOutputSpies();
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
@@ -363,7 +363,7 @@ describe('login command', () => {
     expect(parsed.profile).toBe('prod');
   });
 
-  test('accepts sending-only key and stores permission', async () => {
+  it('accepts sending-only key and stores permission', async () => {
     mockDomainListResult = {
       data: null,
       error: {
@@ -386,7 +386,7 @@ describe('login command', () => {
     expect(data.profiles.default.permission).toBe('sending_access');
   });
 
-  test('stores full_access permission for valid full access key', async () => {
+  it('stores full_access permission for valid full access key', async () => {
     setupOutputSpies();
 
     const { loginCommand } = await import('../../../src/commands/auth/login');
@@ -400,7 +400,7 @@ describe('login command', () => {
     expect(data.profiles.default.permission).toBe('full_access');
   });
 
-  test('--json output includes permission for sending-only key', async () => {
+  it('--json output includes permission for sending-only key', async () => {
     mockDomainListResult = {
       data: null,
       error: {

--- a/tests/commands/auth/logout.test.ts
+++ b/tests/commands/auth/logout.test.ts
@@ -6,8 +6,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -60,7 +60,7 @@ describe('logout command', () => {
     );
   }
 
-  test('removes credentials file when it exists (non-interactive)', async () => {
+  it('removes credentials file when it exists (non-interactive)', async () => {
     spies = setupOutputSpies();
     writeCredentials();
 
@@ -75,7 +75,7 @@ describe('logout command', () => {
     expect(output.config_path).toContain('credentials.json');
   });
 
-  test('exits cleanly when no credentials file exists (non-interactive)', async () => {
+  it('exits cleanly when no credentials file exists (non-interactive)', async () => {
     spies = setupOutputSpies();
 
     const { logoutCommand } = await import('../../../src/commands/auth/logout');
@@ -86,7 +86,7 @@ describe('logout command', () => {
     expect(output.already_logged_out).toBe(true);
   });
 
-  test('logout without --profile removes all profiles', async () => {
+  it('logout without --profile removes all profiles', async () => {
     spies = setupOutputSpies();
     writeCredentials({ staging: 're_staging_key', production: 're_prod_key' });
 
@@ -101,7 +101,7 @@ describe('logout command', () => {
     expect(output.profile).toBe('all');
   });
 
-  test('logout with --profile removes only that profile', async () => {
+  it('logout with --profile removes only that profile', async () => {
     spies = setupOutputSpies();
     writeCredentials({ staging: 're_staging_key', production: 're_prod_key' });
 
@@ -133,7 +133,7 @@ describe('logout command', () => {
     expect(output.profile).toBe('staging');
   });
 
-  test('exits with error when file removal fails', async () => {
+  it('exits with error when file removal fails', async () => {
     spies = setupOutputSpies();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();

--- a/tests/commands/auth/remove.test.ts
+++ b/tests/commands/auth/remove.test.ts
@@ -7,8 +7,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import { storeApiKey } from '../../../src/lib/config';
@@ -54,7 +54,7 @@ describe('auth remove command', () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  test('removes profile in JSON mode', async () => {
+  it('removes profile in JSON mode', async () => {
     spies = setupOutputSpies();
     storeApiKey('re_default', 'default');
     storeApiKey('re_staging', 'staging');
@@ -69,7 +69,7 @@ describe('auth remove command', () => {
     expect(output.removed_profile).toBe('staging');
   });
 
-  test('deletes credentials file when last profile removed', async () => {
+  it('deletes credentials file when last profile removed', async () => {
     spies = setupOutputSpies();
     storeApiKey('re_only', 'only');
 
@@ -80,7 +80,7 @@ describe('auth remove command', () => {
     expect(existsSync(configPath)).toBe(false);
   });
 
-  test('errors when name omitted in non-interactive mode', async () => {
+  it('errors when name omitted in non-interactive mode', async () => {
     spies = setupOutputSpies();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -95,7 +95,7 @@ describe('auth remove command', () => {
     expect(output.error.code).toBe('missing_name');
   });
 
-  test('errors with missing_name when --json is set even in TTY', async () => {
+  it('errors with missing_name when --json is set even in TTY', async () => {
     Object.defineProperty(process.stdin, 'isTTY', {
       value: true,
       writable: true,
@@ -117,7 +117,7 @@ describe('auth remove command', () => {
     expect(output.error.code).toBe('missing_name');
   });
 
-  test('errors when profile does not exist', async () => {
+  it('errors when profile does not exist', async () => {
     spies = setupOutputSpies();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();

--- a/tests/commands/auth/switch.test.ts
+++ b/tests/commands/auth/switch.test.ts
@@ -7,8 +7,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import { storeApiKey } from '../../../src/lib/config';
@@ -54,7 +54,7 @@ describe('auth switch command', () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  test('switches active profile in JSON mode', async () => {
+  it('switches active profile in JSON mode', async () => {
     spies = setupOutputSpies();
     storeApiKey('re_default', 'default');
     storeApiKey('re_staging', 'staging');
@@ -73,7 +73,7 @@ describe('auth switch command', () => {
     expect(data.active_profile).toBe('staging');
   });
 
-  test('errors when name omitted in non-interactive mode', async () => {
+  it('errors when name omitted in non-interactive mode', async () => {
     spies = setupOutputSpies();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -88,7 +88,7 @@ describe('auth switch command', () => {
     expect(output.error.code).toBe('missing_name');
   });
 
-  test('errors with missing_name when --json is set even in TTY', async () => {
+  it('errors with missing_name when --json is set even in TTY', async () => {
     Object.defineProperty(process.stdin, 'isTTY', {
       value: true,
       writable: true,
@@ -110,7 +110,7 @@ describe('auth switch command', () => {
     expect(output.error.code).toBe('missing_name');
   });
 
-  test('errors when profile does not exist', async () => {
+  it('errors when profile does not exist', async () => {
     spies = setupOutputSpies();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();

--- a/tests/commands/broadcasts/create.test.ts
+++ b/tests/commands/broadcasts/create.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import * as files from '../../../src/lib/files';
@@ -69,7 +69,7 @@ describe('broadcasts create command', () => {
     }
   });
 
-  test('creates broadcast with required flags', async () => {
+  it('creates broadcast with required flags', async () => {
     spies = setupOutputSpies();
 
     const { createBroadcastCommand } = await import(
@@ -97,7 +97,7 @@ describe('broadcasts create command', () => {
     expect(args.html).toBe('<p>Hi</p>');
   });
 
-  test('dry-run does not call API and prints create payload', async () => {
+  it('dry-run does not call API and prints create payload', async () => {
     spies = setupOutputSpies();
 
     const { createBroadcastCommand } = await import(
@@ -125,7 +125,7 @@ describe('broadcasts create command', () => {
     expect(out.request.segmentId).toBe('7b1e0a3d-4c5f-4e8a-9b2d-1a3c5e7f9b2d');
   });
 
-  test('dry-run does not require API key', async () => {
+  it('dry-run does not require API key', async () => {
     spies = setupOutputSpies();
     delete process.env.RESEND_API_KEY;
 
@@ -152,7 +152,7 @@ describe('broadcasts create command', () => {
     expect(out.dryRun).toBe(true);
   });
 
-  test('outputs JSON id when non-interactive', async () => {
+  it('outputs JSON id when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { createBroadcastCommand } = await import(
@@ -177,7 +177,7 @@ describe('broadcasts create command', () => {
     expect(parsed.id).toBe('d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6');
   });
 
-  test('passes --send flag to SDK', async () => {
+  it('passes --send flag to SDK', async () => {
     spies = setupOutputSpies();
 
     const { createBroadcastCommand } = await import(
@@ -202,7 +202,7 @@ describe('broadcasts create command', () => {
     expect(args.send).toBe(true);
   });
 
-  test('passes --scheduled-at with --send to SDK', async () => {
+  it('passes --scheduled-at with --send to SDK', async () => {
     spies = setupOutputSpies();
 
     const { createBroadcastCommand } = await import(
@@ -229,7 +229,7 @@ describe('broadcasts create command', () => {
     expect(args.scheduledAt).toBe('in 1 hour');
   });
 
-  test('passes optional flags to SDK', async () => {
+  it('passes optional flags to SDK', async () => {
     spies = setupOutputSpies();
 
     const { createBroadcastCommand } = await import(
@@ -264,7 +264,7 @@ describe('broadcasts create command', () => {
     expect(args.topicId).toBe('topic_xyz');
   });
 
-  test('errors with missing_from when --from absent in non-interactive mode', async () => {
+  it('errors with missing_from when --from absent in non-interactive mode', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -290,7 +290,7 @@ describe('broadcasts create command', () => {
     expect(output).toContain('missing_from');
   });
 
-  test('errors with missing_subject when --subject absent in non-interactive mode', async () => {
+  it('errors with missing_subject when --subject absent in non-interactive mode', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -316,7 +316,7 @@ describe('broadcasts create command', () => {
     expect(output).toContain('missing_subject');
   });
 
-  test('errors with missing_segment when --segment-id absent in non-interactive mode', async () => {
+  it('errors with missing_segment when --segment-id absent in non-interactive mode', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -342,7 +342,7 @@ describe('broadcasts create command', () => {
     expect(output).toContain('missing_segment');
   });
 
-  test('errors with missing_body when no body flag in non-interactive mode', async () => {
+  it('errors with missing_body when no body flag in non-interactive mode', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -368,7 +368,7 @@ describe('broadcasts create command', () => {
     expect(output).toContain('missing_body');
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -398,7 +398,7 @@ describe('broadcasts create command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with create_error when SDK returns an error', async () => {
+  it('errors with create_error when SDK returns an error', async () => {
     setNonInteractive();
     mockCreate.mockResolvedValueOnce(
       mockSdkError('Segment not found', 'not_found'),
@@ -432,7 +432,7 @@ describe('broadcasts create command', () => {
     expect(output).toContain('create_error');
   });
 
-  test('does not call SDK when validation fails', async () => {
+  it('does not call SDK when validation fails', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -447,7 +447,7 @@ describe('broadcasts create command', () => {
     expect(mockCreate).not.toHaveBeenCalled();
   });
 
-  test('errors with missing_from when --json is set even in TTY', async () => {
+  it('errors with missing_from when --json is set even in TTY', async () => {
     Object.defineProperty(process.stdin, 'isTTY', {
       value: true,
       writable: true,
@@ -492,7 +492,7 @@ describe('broadcasts create command', () => {
     expect(output).toContain('missing_from');
   });
 
-  test('reads html body from --html-file and passes it to SDK', async () => {
+  it('reads html body from --html-file and passes it to SDK', async () => {
     spies = setupOutputSpies();
     readFileSpy = vi
       .spyOn(files, 'readFile')
@@ -520,7 +520,7 @@ describe('broadcasts create command', () => {
     expect(args.html).toBe('<p>From file</p>');
   });
 
-  test('reads text body from --text-file and passes it to SDK', async () => {
+  it('reads text body from --text-file and passes it to SDK', async () => {
     spies = setupOutputSpies();
     readFileSpy = vi
       .spyOn(files, 'readFile')
@@ -548,7 +548,7 @@ describe('broadcasts create command', () => {
     expect(args.text).toBe('Plain text from file');
   });
 
-  test('errors with invalid_options when --html and --html-file both provided', async () => {
+  it('errors with invalid_options when --html and --html-file both provided', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -580,7 +580,7 @@ describe('broadcasts create command', () => {
     expect(mockCreate).not.toHaveBeenCalled();
   });
 
-  test('errors with invalid_options when --text and --text-file both provided', async () => {
+  it('errors with invalid_options when --text and --text-file both provided', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -612,7 +612,7 @@ describe('broadcasts create command', () => {
     expect(mockCreate).not.toHaveBeenCalled();
   });
 
-  test('errors with invalid_options when --html-file - and --text-file - both read stdin', async () => {
+  it('errors with invalid_options when --html-file - and --text-file - both read stdin', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -642,7 +642,7 @@ describe('broadcasts create command', () => {
     expect(output).toContain('invalid_options');
   });
 
-  test('--text-file - passes stdin to readFile', async () => {
+  it('--text-file - passes stdin to readFile', async () => {
     spies = setupOutputSpies();
     readFileSpy = vi
       .spyOn(files, 'readFile')
@@ -670,7 +670,7 @@ describe('broadcasts create command', () => {
     expect(args.text).toBe('stdin text content');
   });
 
-  test('creates broadcast with --react-email flag', async () => {
+  it('creates broadcast with --react-email flag', async () => {
     spies = setupOutputSpies();
 
     const { createBroadcastCommand } = await import(
@@ -698,7 +698,7 @@ describe('broadcasts create command', () => {
     expect(args.html).toBe('<html><body>Rendered</body></html>');
   });
 
-  test('errors with invalid_options when --react-email and --html used together', async () => {
+  it('errors with invalid_options when --react-email and --html used together', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -728,7 +728,7 @@ describe('broadcasts create command', () => {
     expect(output).toContain('invalid_options');
   });
 
-  test('errors with file_read_error when --html-file path is unreadable', async () => {
+  it('errors with file_read_error when --html-file path is unreadable', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     stderrSpy = vi

--- a/tests/commands/broadcasts/delete.test.ts
+++ b/tests/commands/broadcasts/delete.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -55,7 +55,7 @@ describe('broadcasts delete command', () => {
     exitSpy = undefined;
   });
 
-  test('deletes broadcast with --yes flag', async () => {
+  it('deletes broadcast with --yes flag', async () => {
     spies = setupOutputSpies();
 
     const { deleteBroadcastCommand } = await import(
@@ -74,7 +74,7 @@ describe('broadcasts delete command', () => {
     );
   });
 
-  test('outputs JSON result when non-interactive', async () => {
+  it('outputs JSON result when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { deleteBroadcastCommand } = await import(
@@ -94,7 +94,7 @@ describe('broadcasts delete command', () => {
     expect(parsed.object).toBe('broadcast');
   });
 
-  test('errors with confirmation_required when --yes absent in non-interactive mode', async () => {
+  it('errors with confirmation_required when --yes absent in non-interactive mode', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -113,7 +113,7 @@ describe('broadcasts delete command', () => {
     expect(output).toContain('confirmation_required');
   });
 
-  test('does not call SDK when confirmation_required error is raised', async () => {
+  it('does not call SDK when confirmation_required error is raised', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -131,7 +131,7 @@ describe('broadcasts delete command', () => {
     expect(mockRemove).not.toHaveBeenCalled();
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -154,7 +154,7 @@ describe('broadcasts delete command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with delete_error when SDK returns an error', async () => {
+  it('errors with delete_error when SDK returns an error', async () => {
     setNonInteractive();
     mockRemove.mockResolvedValueOnce(
       mockSdkError('Cannot delete sent broadcast', 'validation_error'),

--- a/tests/commands/broadcasts/get.test.ts
+++ b/tests/commands/broadcasts/get.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -68,7 +68,7 @@ describe('broadcasts get command', () => {
     exitSpy = undefined;
   });
 
-  test('fetches broadcast by id', async () => {
+  it('fetches broadcast by id', async () => {
     spies = setupOutputSpies();
 
     const { getBroadcastCommand } = await import(
@@ -85,7 +85,7 @@ describe('broadcasts get command', () => {
     );
   });
 
-  test('outputs full JSON when non-interactive', async () => {
+  it('outputs full JSON when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { getBroadcastCommand } = await import(
@@ -103,7 +103,7 @@ describe('broadcasts get command', () => {
     expect(parsed.subject).toBe('This week in Resend');
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -123,7 +123,7 @@ describe('broadcasts get command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with fetch_error when SDK returns an error', async () => {
+  it('errors with fetch_error when SDK returns an error', async () => {
     setNonInteractive();
     mockGet.mockResolvedValueOnce(mockSdkError('Not found', 'not_found'));
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/tests/commands/broadcasts/list.test.ts
+++ b/tests/commands/broadcasts/list.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -66,7 +66,7 @@ describe('broadcasts list command', () => {
     exitSpy = undefined;
   });
 
-  test('lists broadcasts', async () => {
+  it('lists broadcasts', async () => {
     spies = setupOutputSpies();
 
     const { listBroadcastsCommand } = await import(
@@ -77,7 +77,7 @@ describe('broadcasts list command', () => {
     expect(mockList).toHaveBeenCalledTimes(1);
   });
 
-  test('outputs JSON list when non-interactive', async () => {
+  it('outputs JSON list when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { listBroadcastsCommand } = await import(
@@ -92,7 +92,7 @@ describe('broadcasts list command', () => {
     expect(parsed.data[0].id).toBe('d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6');
   });
 
-  test('passes --limit to SDK', async () => {
+  it('passes --limit to SDK', async () => {
     spies = setupOutputSpies();
 
     const { listBroadcastsCommand } = await import(
@@ -104,7 +104,7 @@ describe('broadcasts list command', () => {
     expect(opts.limit).toBe(5);
   });
 
-  test('passes --after cursor to SDK', async () => {
+  it('passes --after cursor to SDK', async () => {
     spies = setupOutputSpies();
 
     const { listBroadcastsCommand } = await import(
@@ -121,7 +121,7 @@ describe('broadcasts list command', () => {
     expect(opts.after).toBe('c0c0c0c0-d1d1-e2e2-f3f3-a4a4a4a4a4a4');
   });
 
-  test('passes --before cursor to SDK', async () => {
+  it('passes --before cursor to SDK', async () => {
     spies = setupOutputSpies();
 
     const { listBroadcastsCommand } = await import(
@@ -138,7 +138,7 @@ describe('broadcasts list command', () => {
     expect(opts.before).toBe('c0c0c0c0-d1d1-e2e2-f3f3-a4a4a4a4a4a4');
   });
 
-  test('errors with invalid_limit when --limit is out of range', async () => {
+  it('errors with invalid_limit when --limit is out of range', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     stderrSpy = vi
@@ -157,7 +157,7 @@ describe('broadcasts list command', () => {
     expect(output).toContain('invalid_limit');
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -175,7 +175,7 @@ describe('broadcasts list command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with list_error when SDK returns an error', async () => {
+  it('errors with list_error when SDK returns an error', async () => {
     setNonInteractive();
     mockList.mockResolvedValueOnce(
       mockSdkError('Internal server error', 'server_error'),

--- a/tests/commands/broadcasts/open.test.ts
+++ b/tests/commands/broadcasts/open.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as browser from '../../../src/lib/browser';
 
 describe('broadcasts open command', () => {
@@ -10,7 +10,7 @@ describe('broadcasts open command', () => {
     vi.restoreAllMocks();
   });
 
-  test('with no args opens broadcasts list', async () => {
+  it('with no args opens broadcasts list', async () => {
     const { openBroadcastCommand } = await import(
       '../../../src/commands/broadcasts/open'
     );
@@ -23,7 +23,7 @@ describe('broadcasts open command', () => {
     );
   });
 
-  test('with id opens broadcast URL', async () => {
+  it('with id opens broadcast URL', async () => {
     const { openBroadcastCommand } = await import(
       '../../../src/commands/broadcasts/open'
     );

--- a/tests/commands/broadcasts/send.test.ts
+++ b/tests/commands/broadcasts/send.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -51,7 +51,7 @@ describe('broadcasts send command', () => {
     exitSpy = undefined;
   });
 
-  test('sends broadcast by id', async () => {
+  it('sends broadcast by id', async () => {
     spies = setupOutputSpies();
 
     const { sendBroadcastCommand } = await import(
@@ -68,7 +68,7 @@ describe('broadcasts send command', () => {
     );
   });
 
-  test('outputs JSON id when non-interactive', async () => {
+  it('outputs JSON id when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { sendBroadcastCommand } = await import(
@@ -84,7 +84,7 @@ describe('broadcasts send command', () => {
     expect(parsed.id).toBe('d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6');
   });
 
-  test('passes --scheduled-at to SDK', async () => {
+  it('passes --scheduled-at to SDK', async () => {
     spies = setupOutputSpies();
 
     const { sendBroadcastCommand } = await import(
@@ -99,7 +99,7 @@ describe('broadcasts send command', () => {
     expect(payload.scheduledAt).toBe('in 1 hour');
   });
 
-  test('does not pass scheduledAt when flag absent', async () => {
+  it('does not pass scheduledAt when flag absent', async () => {
     spies = setupOutputSpies();
 
     const { sendBroadcastCommand } = await import(
@@ -114,7 +114,7 @@ describe('broadcasts send command', () => {
     expect(payload.scheduledAt).toBeUndefined();
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -135,7 +135,7 @@ describe('broadcasts send command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with send_error when SDK returns an error', async () => {
+  it('errors with send_error when SDK returns an error', async () => {
     setNonInteractive();
     mockSend.mockResolvedValueOnce(
       mockSdkError('Broadcast not found', 'not_found'),

--- a/tests/commands/broadcasts/update.test.ts
+++ b/tests/commands/broadcasts/update.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import * as files from '../../../src/lib/files';
@@ -64,7 +64,7 @@ describe('broadcasts update command', () => {
     readFileSpy = undefined;
   });
 
-  test('updates broadcast subject', async () => {
+  it('updates broadcast subject', async () => {
     spies = setupOutputSpies();
 
     const { updateBroadcastCommand } = await import(
@@ -83,7 +83,7 @@ describe('broadcasts update command', () => {
     expect(payload.subject).toBe('Updated Subject');
   });
 
-  test('passes all update flags to SDK', async () => {
+  it('passes all update flags to SDK', async () => {
     spies = setupOutputSpies();
 
     const { updateBroadcastCommand } = await import(
@@ -111,7 +111,7 @@ describe('broadcasts update command', () => {
     expect(payload.name).toBe('New Label');
   });
 
-  test('passes explicit empty text to the SDK', async () => {
+  it('passes explicit empty text to the SDK', async () => {
     spies = setupOutputSpies();
 
     const { updateBroadcastCommand } = await import(
@@ -126,7 +126,7 @@ describe('broadcasts update command', () => {
     expect(payload.text).toBe('');
   });
 
-  test('passes explicit empty html to the SDK', async () => {
+  it('passes explicit empty html to the SDK', async () => {
     spies = setupOutputSpies();
 
     const { updateBroadcastCommand } = await import(
@@ -141,7 +141,7 @@ describe('broadcasts update command', () => {
     expect(payload.html).toBe('');
   });
 
-  test('outputs JSON id when non-interactive', async () => {
+  it('outputs JSON id when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { updateBroadcastCommand } = await import(
@@ -157,7 +157,7 @@ describe('broadcasts update command', () => {
     expect(parsed.id).toBe('d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6');
   });
 
-  test('omits undefined fields from SDK payload', async () => {
+  it('omits undefined fields from SDK payload', async () => {
     spies = setupOutputSpies();
 
     const { updateBroadcastCommand } = await import(
@@ -174,7 +174,7 @@ describe('broadcasts update command', () => {
     expect(payload.subject).toBeUndefined();
   });
 
-  test('errors with no_changes when no flags are provided', async () => {
+  it('errors with no_changes when no flags are provided', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -193,7 +193,7 @@ describe('broadcasts update command', () => {
     expect(output).toContain('no_changes');
   });
 
-  test('does not call SDK when no_changes error is raised', async () => {
+  it('does not call SDK when no_changes error is raised', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -211,7 +211,7 @@ describe('broadcasts update command', () => {
     expect(mockUpdate).not.toHaveBeenCalled();
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -234,7 +234,7 @@ describe('broadcasts update command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with update_error when SDK returns an error', async () => {
+  it('errors with update_error when SDK returns an error', async () => {
     setNonInteractive();
     mockUpdate.mockResolvedValueOnce(
       mockSdkError('Cannot update sent broadcast', 'validation_error'),
@@ -261,7 +261,7 @@ describe('broadcasts update command', () => {
     expect(output).toContain('update_error');
   });
 
-  test('reads html body from --html-file and passes it to SDK', async () => {
+  it('reads html body from --html-file and passes it to SDK', async () => {
     spies = setupOutputSpies();
     readFileSpy = vi
       .spyOn(files, 'readFile')
@@ -284,7 +284,7 @@ describe('broadcasts update command', () => {
     expect(payload.html).toBe('<p>Updated from file</p>');
   });
 
-  test('treats empty --html-file as a provided file input', async () => {
+  it('treats empty --html-file as a provided file input', async () => {
     spies = setupOutputSpies();
     readFileSpy = vi
       .spyOn(files, 'readFile')
@@ -303,7 +303,7 @@ describe('broadcasts update command', () => {
     expect(payload.html).toBe('<p>From empty path</p>');
   });
 
-  test('reads text body from --text-file and passes it to SDK', async () => {
+  it('reads text body from --text-file and passes it to SDK', async () => {
     spies = setupOutputSpies();
     readFileSpy = vi
       .spyOn(files, 'readFile')
@@ -322,7 +322,7 @@ describe('broadcasts update command', () => {
     expect(payload.text).toBe('Updated text from file');
   });
 
-  test('treats empty --text-file as a provided file input', async () => {
+  it('treats empty --text-file as a provided file input', async () => {
     spies = setupOutputSpies();
     readFileSpy = vi
       .spyOn(files, 'readFile')
@@ -341,7 +341,7 @@ describe('broadcasts update command', () => {
     expect(payload.text).toBe('Text from empty path');
   });
 
-  test('errors with invalid_options when --html and --html-file both provided', async () => {
+  it('errors with invalid_options when --html and --html-file both provided', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -368,7 +368,7 @@ describe('broadcasts update command', () => {
     expect(mockUpdate).not.toHaveBeenCalled();
   });
 
-  test('errors with invalid_options when --text and --text-file both provided', async () => {
+  it('errors with invalid_options when --text and --text-file both provided', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -395,7 +395,7 @@ describe('broadcasts update command', () => {
     expect(mockUpdate).not.toHaveBeenCalled();
   });
 
-  test('errors with invalid_options when --html-file - and --text-file - both read stdin', async () => {
+  it('errors with invalid_options when --html-file - and --text-file - both read stdin', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -420,7 +420,7 @@ describe('broadcasts update command', () => {
     expect(output).toContain('invalid_options');
   });
 
-  test('updates broadcast html with --react-email flag', async () => {
+  it('updates broadcast html with --react-email flag', async () => {
     spies = setupOutputSpies();
 
     const { updateBroadcastCommand } = await import(
@@ -443,7 +443,7 @@ describe('broadcasts update command', () => {
     expect(payload.html).toBe('<html><body>Rendered</body></html>');
   });
 
-  test('errors with react_email_build_error when --react-email is empty', async () => {
+  it('errors with react_email_build_error when --react-email is empty', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -480,7 +480,7 @@ describe('broadcasts update command', () => {
     expect(mockUpdate).not.toHaveBeenCalled();
   });
 
-  test('errors with invalid_options when --react-email and --html used together', async () => {
+  it('errors with invalid_options when --react-email and --html used together', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -505,7 +505,7 @@ describe('broadcasts update command', () => {
     expect(output).toContain('invalid_options');
   });
 
-  test('errors with file_read_error when --html-file path is unreadable', async () => {
+  it('errors with file_read_error when --html-file path is unreadable', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     stderrSpy = vi

--- a/tests/commands/commands.test.ts
+++ b/tests/commands/commands.test.ts
@@ -1,5 +1,5 @@
 import { Command } from '@commander-js/extra-typings';
-import { afterEach, describe, expect, test } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { listCommandsCommand } from '../../src/commands/commands';
 import { captureTestEnv, setupOutputSpies } from '../helpers';
 
@@ -10,7 +10,7 @@ describe('commands', () => {
     restoreEnv();
   });
 
-  test('prints JSON tree with root name and subcommands', async () => {
+  it('prints JSON tree with root name and subcommands', async () => {
     const spies = setupOutputSpies();
     const program = new Command('resend')
       .description('Resend CLI')

--- a/tests/commands/completion.test.ts
+++ b/tests/commands/completion.test.ts
@@ -1,5 +1,5 @@
 import { Command, Option } from '@commander-js/extra-typings';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import {
   type CommandNode,
   collectCommandTree,
@@ -48,7 +48,7 @@ function buildTestProgram(): Command {
 }
 
 describe('collectCommandTree', () => {
-  test('collects commands and subcommands', () => {
+  it('collects commands and subcommands', () => {
     const tree = collectCommandTree(buildTestProgram());
     expect(tree.name).toBe('myapp');
     const names = tree.subcommands.map((s) => s.name);
@@ -56,13 +56,13 @@ describe('collectCommandTree', () => {
     expect(names).toContain('domains');
   });
 
-  test('excludes hidden commands', () => {
+  it('excludes hidden commands', () => {
     const tree = collectCommandTree(buildTestProgram());
     const names = tree.subcommands.map((s) => s.name);
     expect(names).not.toContain('secret');
   });
 
-  test('collects aliases', () => {
+  it('collects aliases', () => {
     const tree = collectCommandTree(buildTestProgram());
     const emails = tree.subcommands.find((s) => s.name === 'emails');
     expect(emails).toBeDefined();
@@ -71,7 +71,7 @@ describe('collectCommandTree', () => {
     expect(list?.aliases).toContain('ls');
   });
 
-  test('collects options with choices', () => {
+  it('collects options with choices', () => {
     const tree = collectCommandTree(buildTestProgram());
     const emails = tree.subcommands.find((s) => s.name === 'emails');
     expect(emails).toBeDefined();
@@ -83,14 +83,14 @@ describe('collectCommandTree', () => {
     expect(priority?.takesValue).toBe(true);
   });
 
-  test('collects global options', () => {
+  it('collects global options', () => {
     const tree = collectCommandTree(buildTestProgram());
     const verbose = tree.options.find((o) => o.long === '--verbose');
     expect(verbose).toBeDefined();
     expect(verbose?.takesValue).toBe(false);
   });
 
-  test('excludes hidden options', () => {
+  it('excludes hidden options', () => {
     const program = new Command('test').description('Test');
     const hiddenOpt = new Option('--secret', 'Hidden option');
     hiddenOpt.hidden = true;
@@ -109,36 +109,36 @@ function getTestTree(): CommandNode {
 }
 
 describe('generateBashCompletion', () => {
-  test('outputs valid bash completion script', () => {
+  it('outputs valid bash completion script', () => {
     const output = generateBashCompletion(getTestTree());
     expect(output).toContain('_myapp_completions');
     expect(output).toContain('complete -o default -F _myapp_completions myapp');
   });
 
-  test('includes top-level commands', () => {
+  it('includes top-level commands', () => {
     const output = generateBashCompletion(getTestTree());
     expect(output).toContain('emails');
     expect(output).toContain('domains');
   });
 
-  test('excludes hidden commands', () => {
+  it('excludes hidden commands', () => {
     const output = generateBashCompletion(getTestTree());
     expect(output).not.toContain('secret');
   });
 
-  test('includes subcommands', () => {
+  it('includes subcommands', () => {
     const output = generateBashCompletion(getTestTree());
     expect(output).toContain('send');
     expect(output).toContain('list');
   });
 
-  test('includes aliases', () => {
+  it('includes aliases', () => {
     const output = generateBashCompletion(getTestTree());
     expect(output).toMatch(/\bls\b/);
     expect(output).toMatch(/\brm\b/);
   });
 
-  test('includes option choices', () => {
+  it('includes option choices', () => {
     const output = generateBashCompletion(getTestTree());
     expect(output).toContain('low');
     expect(output).toContain('normal');
@@ -146,19 +146,19 @@ describe('generateBashCompletion', () => {
     expect(output).toContain('--priority');
   });
 
-  test('includes global options', () => {
+  it('includes global options', () => {
     const output = generateBashCompletion(getTestTree());
     expect(output).toContain('--verbose');
     expect(output).toContain('--profile');
   });
 
-  test('skips option values when building cmd_path', () => {
+  it('skips option values when building cmd_path', () => {
     const output = generateBashCompletion(getTestTree());
     expect(output).toContain('--profile|-p|--from|--to|--priority)');
     expect(output).toContain('i=$((i + 1)) ;;');
   });
 
-  test('falls back to file completion for value flags without choices', () => {
+  it('falls back to file completion for value flags without choices', () => {
     const output = generateBashCompletion(getTestTree());
     expect(output).toContain('--from|--to) return ;;');
     expect(output).toContain('--profile|-p) return ;;');
@@ -166,32 +166,32 @@ describe('generateBashCompletion', () => {
 });
 
 describe('generateZshCompletion', () => {
-  test('outputs valid zsh completion script', () => {
+  it('outputs valid zsh completion script', () => {
     const output = generateZshCompletion(getTestTree());
     expect(output).toContain('#compdef myapp');
     expect(output).toContain('compdef _myapp myapp');
     expect(output).toContain('_myapp()');
   });
 
-  test('includes commands and options', () => {
+  it('includes commands and options', () => {
     const output = generateZshCompletion(getTestTree());
     expect(output).toContain('emails');
     expect(output).toContain('--verbose');
     expect(output).toContain('--priority');
   });
 
-  test('excludes hidden commands', () => {
+  it('excludes hidden commands', () => {
     const output = generateZshCompletion(getTestTree());
     expect(output).not.toContain('secret');
   });
 
-  test('falls back to _files for value flags without choices', () => {
+  it('falls back to _files for value flags without choices', () => {
     const output = generateZshCompletion(getTestTree());
     expect(output).toContain('--from|--to) _files; return ;;');
     expect(output).toContain('--profile|-p) _files; return ;;');
   });
 
-  test('falls back to _files for leaf commands without subcommands', () => {
+  it('falls back to _files for leaf commands without subcommands', () => {
     const output = generateZshCompletion(getTestTree());
     const lines = output.split('\n');
     const start = lines.findIndex((l) => l.includes('"emails send")'));
@@ -203,58 +203,58 @@ describe('generateZshCompletion', () => {
 });
 
 describe('generateFishCompletion', () => {
-  test('outputs fish completion commands', () => {
+  it('outputs fish completion commands', () => {
     const output = generateFishCompletion(getTestTree());
     expect(output).toContain('complete -c myapp');
     expect(output).toContain('__fish_use_subcommand');
   });
 
-  test('includes subcommand completions', () => {
+  it('includes subcommand completions', () => {
     const output = generateFishCompletion(getTestTree());
     expect(output).toContain('__fish_seen_subcommand_from');
     expect(output).toContain('send');
   });
 
-  test('includes option choices', () => {
+  it('includes option choices', () => {
     const output = generateFishCompletion(getTestTree());
     expect(output).toContain('low normal high');
   });
 
-  test('excludes hidden commands', () => {
+  it('excludes hidden commands', () => {
     const output = generateFishCompletion(getTestTree());
     expect(output).not.toContain('secret');
   });
 });
 
 describe('generatePowerShellCompletion', () => {
-  test('outputs PowerShell completion script', () => {
+  it('outputs PowerShell completion script', () => {
     const output = generatePowerShellCompletion(getTestTree());
     expect(output).toContain('Register-ArgumentCompleter');
     expect(output).toContain('-CommandName myapp');
   });
 
-  test('includes commands and options', () => {
+  it('includes commands and options', () => {
     const output = generatePowerShellCompletion(getTestTree());
     expect(output).toContain('"emails"');
     expect(output).toContain('"--verbose"');
   });
 
-  test('excludes hidden commands', () => {
+  it('excludes hidden commands', () => {
     const output = generatePowerShellCompletion(getTestTree());
     expect(output).not.toContain('secret');
   });
 
-  test('groups choice values per flag in switch', () => {
+  it('groups choice values per flag in switch', () => {
     const output = generatePowerShellCompletion(getTestTree());
     expect(output).toContain('"--priority" { @("low", "normal", "high")');
   });
 
-  test('skips option values when building cmdPath', () => {
+  it('skips option values when building cmdPath', () => {
     const output = generatePowerShellCompletion(getTestTree());
     expect(output).toContain('$valueFlags -contains $words[$i]');
   });
 
-  test('falls back to default completion for value flags without choices', () => {
+  it('falls back to default completion for value flags without choices', () => {
     const output = generatePowerShellCompletion(getTestTree());
     expect(output).toContain('{ $_ -in @("--from", "--to") } { return }');
   });

--- a/tests/commands/contact-properties/create.test.ts
+++ b/tests/commands/contact-properties/create.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -54,7 +54,7 @@ describe('contact-properties create command', () => {
     exitSpy = undefined;
   });
 
-  test('creates property with --key and --type', async () => {
+  it('creates property with --key and --type', async () => {
     spies = setupOutputSpies();
 
     const { createContactPropertyCommand } = await import(
@@ -71,7 +71,7 @@ describe('contact-properties create command', () => {
     expect(args.type).toBe('string');
   });
 
-  test('creates number-type property', async () => {
+  it('creates number-type property', async () => {
     spies = setupOutputSpies();
 
     const { createContactPropertyCommand } = await import(
@@ -87,7 +87,7 @@ describe('contact-properties create command', () => {
     expect(args.type).toBe('number');
   });
 
-  test('passes string fallback-value to SDK', async () => {
+  it('passes string fallback-value to SDK', async () => {
     spies = setupOutputSpies();
 
     const { createContactPropertyCommand } = await import(
@@ -109,7 +109,7 @@ describe('contact-properties create command', () => {
     expect(args.fallbackValue).toBe('Unknown');
   });
 
-  test('coerces fallback-value to number for number-type properties', async () => {
+  it('coerces fallback-value to number for number-type properties', async () => {
     spies = setupOutputSpies();
 
     const { createContactPropertyCommand } = await import(
@@ -124,7 +124,7 @@ describe('contact-properties create command', () => {
     expect(args.fallbackValue).toBe(42);
   });
 
-  test('outputs JSON id when non-interactive', async () => {
+  it('outputs JSON id when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { createContactPropertyCommand } = await import(
@@ -141,7 +141,7 @@ describe('contact-properties create command', () => {
     expect(parsed.id).toBe('b4a3c2d1-6e5f-8a7b-0c9d-2e1f4a3b6c5d');
   });
 
-  test('errors with missing_key in non-interactive mode', async () => {
+  it('errors with missing_key in non-interactive mode', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -159,7 +159,7 @@ describe('contact-properties create command', () => {
     expect(output).toContain('missing_key');
   });
 
-  test('errors with missing_type in non-interactive mode', async () => {
+  it('errors with missing_type in non-interactive mode', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -177,7 +177,7 @@ describe('contact-properties create command', () => {
     expect(output).toContain('missing_type');
   });
 
-  test('errors with invalid_fallback_value when number-type gets a non-numeric fallback', async () => {
+  it('errors with invalid_fallback_value when number-type gets a non-numeric fallback', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -203,7 +203,7 @@ describe('contact-properties create command', () => {
     expect(output).toContain('invalid_fallback_value');
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -224,7 +224,7 @@ describe('contact-properties create command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with create_error when SDK returns an error', async () => {
+  it('errors with create_error when SDK returns an error', async () => {
     setNonInteractive();
     mockCreate.mockResolvedValueOnce(
       mockSdkError('Key already exists', 'validation_error'),

--- a/tests/commands/contact-properties/delete.test.ts
+++ b/tests/commands/contact-properties/delete.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -55,7 +55,7 @@ describe('contact-properties delete command', () => {
     exitSpy = undefined;
   });
 
-  test('deletes property with --yes', async () => {
+  it('deletes property with --yes', async () => {
     spies = setupOutputSpies();
 
     const { deleteContactPropertyCommand } = await import(
@@ -74,7 +74,7 @@ describe('contact-properties delete command', () => {
     );
   });
 
-  test('outputs synthesized JSON result when non-interactive', async () => {
+  it('outputs synthesized JSON result when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { deleteContactPropertyCommand } = await import(
@@ -94,7 +94,7 @@ describe('contact-properties delete command', () => {
     expect(parsed.deleted).toBe(true);
   });
 
-  test('errors with confirmation_required when --yes absent in non-interactive mode', async () => {
+  it('errors with confirmation_required when --yes absent in non-interactive mode', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -115,7 +115,7 @@ describe('contact-properties delete command', () => {
     expect(output).toContain('confirmation_required');
   });
 
-  test('does not call SDK when confirmation_required error is raised', async () => {
+  it('does not call SDK when confirmation_required error is raised', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -135,7 +135,7 @@ describe('contact-properties delete command', () => {
     expect(mockRemove).not.toHaveBeenCalled();
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -158,7 +158,7 @@ describe('contact-properties delete command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with delete_error when SDK returns an error', async () => {
+  it('errors with delete_error when SDK returns an error', async () => {
     setNonInteractive();
     mockRemove.mockResolvedValueOnce(
       mockSdkError('Property not found', 'not_found'),

--- a/tests/commands/contact-properties/get.test.ts
+++ b/tests/commands/contact-properties/get.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -58,7 +58,7 @@ describe('contact-properties get command', () => {
     exitSpy = undefined;
   });
 
-  test('calls SDK with the given ID', async () => {
+  it('calls SDK with the given ID', async () => {
     spies = setupOutputSpies();
 
     const { getContactPropertyCommand } = await import(
@@ -77,7 +77,7 @@ describe('contact-properties get command', () => {
     );
   });
 
-  test('outputs JSON when non-interactive', async () => {
+  it('outputs JSON when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { getContactPropertyCommand } = await import(
@@ -98,7 +98,7 @@ describe('contact-properties get command', () => {
     expect(parsed.type).toBe('string');
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -119,7 +119,7 @@ describe('contact-properties get command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with fetch_error when SDK returns an error', async () => {
+  it('errors with fetch_error when SDK returns an error', async () => {
     setNonInteractive();
     mockGet.mockResolvedValueOnce(
       mockSdkError('Property not found', 'not_found'),

--- a/tests/commands/contact-properties/list.test.ts
+++ b/tests/commands/contact-properties/list.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -63,7 +63,7 @@ describe('contact-properties list command', () => {
     exitSpy = undefined;
   });
 
-  test('calls SDK with default limit of 10', async () => {
+  it('calls SDK with default limit of 10', async () => {
     spies = setupOutputSpies();
 
     const { listContactPropertiesCommand } = await import(
@@ -76,7 +76,7 @@ describe('contact-properties list command', () => {
     expect(args.limit).toBe(10);
   });
 
-  test('calls SDK with custom --limit', async () => {
+  it('calls SDK with custom --limit', async () => {
     spies = setupOutputSpies();
 
     const { listContactPropertiesCommand } = await import(
@@ -90,7 +90,7 @@ describe('contact-properties list command', () => {
     expect(args.limit).toBe(25);
   });
 
-  test('calls SDK with --after cursor', async () => {
+  it('calls SDK with --after cursor', async () => {
     spies = setupOutputSpies();
 
     const { listContactPropertiesCommand } = await import(
@@ -105,7 +105,7 @@ describe('contact-properties list command', () => {
     expect(args.after).toBe('c0c0c0c0-d1d1-e2e2-f3f3-b5b5b5b5b5b5');
   });
 
-  test('outputs JSON list when non-interactive', async () => {
+  it('outputs JSON list when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { listContactPropertiesCommand } = await import(
@@ -121,7 +121,7 @@ describe('contact-properties list command', () => {
     expect(parsed.data[0].type).toBe('string');
   });
 
-  test('errors with invalid_limit when --limit is out of range', async () => {
+  it('errors with invalid_limit when --limit is out of range', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -139,7 +139,7 @@ describe('contact-properties list command', () => {
     expect(output).toContain('invalid_limit');
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -157,7 +157,7 @@ describe('contact-properties list command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with list_error when SDK returns an error', async () => {
+  it('errors with list_error when SDK returns an error', async () => {
     setNonInteractive();
     mockList.mockResolvedValueOnce(
       mockSdkError('Server error', 'server_error'),

--- a/tests/commands/contacts/add-segment.test.ts
+++ b/tests/commands/contacts/add-segment.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -58,7 +58,7 @@ describe('contacts add-segment command', () => {
     }
   });
 
-  test('adds contact to segment by contact ID', async () => {
+  it('adds contact to segment by contact ID', async () => {
     spies = setupOutputSpies();
 
     const { addContactSegmentCommand } = await import(
@@ -79,7 +79,7 @@ describe('contacts add-segment command', () => {
     expect(args.segmentId).toBe('7b1e0a3d-4c5f-4e8a-9b2d-1a3c5e7f9b2d');
   });
 
-  test('adds contact to segment by email', async () => {
+  it('adds contact to segment by email', async () => {
     spies = setupOutputSpies();
 
     const { addContactSegmentCommand } = await import(
@@ -99,7 +99,7 @@ describe('contacts add-segment command', () => {
     expect(args.segmentId).toBe('7b1e0a3d-4c5f-4e8a-9b2d-1a3c5e7f9b2d');
   });
 
-  test('outputs JSON result when non-interactive', async () => {
+  it('outputs JSON result when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { addContactSegmentCommand } = await import(
@@ -119,7 +119,7 @@ describe('contacts add-segment command', () => {
     expect(parsed.id).toBe('7b1e0a3d-4c5f-4e8a-9b2d-1a3c5e7f9b2d');
   });
 
-  test('errors with missing_id when --segment-id absent in non-interactive mode', async () => {
+  it('errors with missing_id when --segment-id absent in non-interactive mode', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -138,7 +138,7 @@ describe('contacts add-segment command', () => {
     expect(output).toContain('missing_id');
   });
 
-  test('errors with missing_id when --json is set even in TTY', async () => {
+  it('errors with missing_id when --json is set even in TTY', async () => {
     Object.defineProperty(process.stdin, 'isTTY', {
       value: true,
       writable: true,
@@ -174,7 +174,7 @@ describe('contacts add-segment command', () => {
     expect(output).toContain('missing_id');
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -199,7 +199,7 @@ describe('contacts add-segment command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with add_segment_error when SDK returns an error', async () => {
+  it('errors with add_segment_error when SDK returns an error', async () => {
     setNonInteractive();
     mockAddSegment.mockResolvedValueOnce(
       mockSdkError('Segment not found', 'not_found'),

--- a/tests/commands/contacts/create.test.ts
+++ b/tests/commands/contacts/create.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -59,7 +59,7 @@ describe('contacts create command', () => {
     }
   });
 
-  test('creates contact with --email flag', async () => {
+  it('creates contact with --email flag', async () => {
     spies = setupOutputSpies();
 
     const { createContactCommand } = await import(
@@ -74,7 +74,7 @@ describe('contacts create command', () => {
     expect(args.email).toBe('jane@example.com');
   });
 
-  test('outputs JSON id when non-interactive', async () => {
+  it('outputs JSON id when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { createContactCommand } = await import(
@@ -90,7 +90,7 @@ describe('contacts create command', () => {
     expect(parsed.object).toBe('contact');
   });
 
-  test('passes --first-name and --last-name to SDK', async () => {
+  it('passes --first-name and --last-name to SDK', async () => {
     spies = setupOutputSpies();
 
     const { createContactCommand } = await import(
@@ -113,7 +113,7 @@ describe('contacts create command', () => {
     expect(args.lastName).toBe('Smith');
   });
 
-  test('passes --unsubscribed flag to SDK', async () => {
+  it('passes --unsubscribed flag to SDK', async () => {
     spies = setupOutputSpies();
 
     const { createContactCommand } = await import(
@@ -128,7 +128,7 @@ describe('contacts create command', () => {
     expect(args.unsubscribed).toBe(true);
   });
 
-  test('parses --properties JSON and passes to SDK', async () => {
+  it('parses --properties JSON and passes to SDK', async () => {
     spies = setupOutputSpies();
 
     const { createContactCommand } = await import(
@@ -148,7 +148,7 @@ describe('contacts create command', () => {
     expect(args.properties).toEqual({ company: 'Acme', plan: 'pro' });
   });
 
-  test('passes --segment-id (single) to SDK as segments array', async () => {
+  it('passes --segment-id (single) to SDK as segments array', async () => {
     spies = setupOutputSpies();
 
     const { createContactCommand } = await import(
@@ -170,7 +170,7 @@ describe('contacts create command', () => {
     ]);
   });
 
-  test('passes multiple --segment-id values to SDK', async () => {
+  it('passes multiple --segment-id values to SDK', async () => {
     spies = setupOutputSpies();
 
     const { createContactCommand } = await import(
@@ -195,7 +195,7 @@ describe('contacts create command', () => {
     ]);
   });
 
-  test('suppresses name prompts when --json is set even in TTY', async () => {
+  it('suppresses name prompts when --json is set even in TTY', async () => {
     Object.defineProperty(process.stdin, 'isTTY', {
       value: true,
       writable: true,
@@ -237,7 +237,7 @@ describe('contacts create command', () => {
     stderrWriteSpy.mockRestore();
   });
 
-  test('errors with missing_email in non-interactive mode', async () => {
+  it('errors with missing_email in non-interactive mode', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -253,7 +253,7 @@ describe('contacts create command', () => {
     expect(output).toContain('missing_email');
   });
 
-  test('errors with invalid_properties when --properties is not valid JSON', async () => {
+  it('errors with invalid_properties when --properties is not valid JSON', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -272,7 +272,7 @@ describe('contacts create command', () => {
     expect(output).toContain('invalid_properties');
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -292,7 +292,7 @@ describe('contacts create command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with create_error when SDK returns an error', async () => {
+  it('errors with create_error when SDK returns an error', async () => {
     setNonInteractive();
     mockCreate.mockResolvedValueOnce(
       mockSdkError('Contact already exists', 'validation_error'),

--- a/tests/commands/contacts/delete.test.ts
+++ b/tests/commands/contacts/delete.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -55,7 +55,7 @@ describe('contacts delete command', () => {
     exitSpy = undefined;
   });
 
-  test('deletes contact by ID with --yes', async () => {
+  it('deletes contact by ID with --yes', async () => {
     spies = setupOutputSpies();
 
     const { deleteContactCommand } = await import(
@@ -74,7 +74,7 @@ describe('contacts delete command', () => {
     );
   });
 
-  test('deletes contact by email with --yes', async () => {
+  it('deletes contact by email with --yes', async () => {
     spies = setupOutputSpies();
 
     const { deleteContactCommand } = await import(
@@ -87,7 +87,7 @@ describe('contacts delete command', () => {
     expect(mockRemove.mock.calls[0][0]).toBe('jane@example.com');
   });
 
-  test('outputs synthesized JSON result when non-interactive', async () => {
+  it('outputs synthesized JSON result when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { deleteContactCommand } = await import(
@@ -107,7 +107,7 @@ describe('contacts delete command', () => {
     expect(parsed.deleted).toBe(true);
   });
 
-  test('errors with confirmation_required when --yes absent in non-interactive mode', async () => {
+  it('errors with confirmation_required when --yes absent in non-interactive mode', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -126,7 +126,7 @@ describe('contacts delete command', () => {
     expect(output).toContain('confirmation_required');
   });
 
-  test('does not call SDK when confirmation_required error is raised', async () => {
+  it('does not call SDK when confirmation_required error is raised', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -144,7 +144,7 @@ describe('contacts delete command', () => {
     expect(mockRemove).not.toHaveBeenCalled();
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -167,7 +167,7 @@ describe('contacts delete command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with delete_error when SDK returns an error', async () => {
+  it('errors with delete_error when SDK returns an error', async () => {
     setNonInteractive();
     mockRemove.mockResolvedValueOnce(
       mockSdkError('Contact not found', 'not_found'),

--- a/tests/commands/contacts/get.test.ts
+++ b/tests/commands/contacts/get.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -60,7 +60,7 @@ describe('contacts get command', () => {
     exitSpy = undefined;
   });
 
-  test('calls SDK with contact ID', async () => {
+  it('calls SDK with contact ID', async () => {
     spies = setupOutputSpies();
 
     const { getContactCommand } = await import(
@@ -77,7 +77,7 @@ describe('contacts get command', () => {
     );
   });
 
-  test('calls SDK with email address', async () => {
+  it('calls SDK with email address', async () => {
     spies = setupOutputSpies();
 
     const { getContactCommand } = await import(
@@ -88,7 +88,7 @@ describe('contacts get command', () => {
     expect(mockGet.mock.calls[0][0]).toBe('jane@example.com');
   });
 
-  test('outputs JSON when non-interactive', async () => {
+  it('outputs JSON when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { getContactCommand } = await import(
@@ -105,7 +105,7 @@ describe('contacts get command', () => {
     expect(parsed.email).toBe('jane@example.com');
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -125,7 +125,7 @@ describe('contacts get command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with fetch_error when SDK returns an error', async () => {
+  it('errors with fetch_error when SDK returns an error', async () => {
     setNonInteractive();
     mockGet.mockResolvedValueOnce(
       mockSdkError('Contact not found', 'not_found'),

--- a/tests/commands/contacts/list.test.ts
+++ b/tests/commands/contacts/list.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -64,7 +64,7 @@ describe('contacts list command', () => {
     exitSpy = undefined;
   });
 
-  test('calls SDK with default limit of 10', async () => {
+  it('calls SDK with default limit of 10', async () => {
     spies = setupOutputSpies();
 
     const { listContactsCommand } = await import(
@@ -77,7 +77,7 @@ describe('contacts list command', () => {
     expect(args.limit).toBe(10);
   });
 
-  test('calls SDK with custom --limit', async () => {
+  it('calls SDK with custom --limit', async () => {
     spies = setupOutputSpies();
 
     const { listContactsCommand } = await import(
@@ -89,7 +89,7 @@ describe('contacts list command', () => {
     expect(args.limit).toBe(25);
   });
 
-  test('calls SDK with --after cursor', async () => {
+  it('calls SDK with --after cursor', async () => {
     spies = setupOutputSpies();
 
     const { listContactsCommand } = await import(
@@ -103,7 +103,7 @@ describe('contacts list command', () => {
     expect(args.after).toBe('cursor_xyz');
   });
 
-  test('outputs JSON list when non-interactive', async () => {
+  it('outputs JSON list when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { listContactsCommand } = await import(
@@ -118,7 +118,7 @@ describe('contacts list command', () => {
     expect(parsed.data[0].email).toBe('jane@example.com');
   });
 
-  test('errors with invalid_limit when --limit is out of range', async () => {
+  it('errors with invalid_limit when --limit is out of range', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -134,7 +134,7 @@ describe('contacts list command', () => {
     expect(output).toContain('invalid_limit');
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -152,7 +152,7 @@ describe('contacts list command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with list_error when SDK returns an error', async () => {
+  it('errors with list_error when SDK returns an error', async () => {
     setNonInteractive();
     mockList.mockResolvedValueOnce(
       mockSdkError('Server error', 'server_error'),

--- a/tests/commands/contacts/remove-segment.test.ts
+++ b/tests/commands/contacts/remove-segment.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -53,7 +53,7 @@ describe('contacts remove-segment command', () => {
     exitSpy = undefined;
   });
 
-  test('removes contact from segment by contact ID', async () => {
+  it('removes contact from segment by contact ID', async () => {
     spies = setupOutputSpies();
 
     const { removeContactSegmentCommand } = await import(
@@ -73,7 +73,7 @@ describe('contacts remove-segment command', () => {
     expect(args.segmentId).toBe('7b1e0a3d-4c5f-4e8a-9b2d-1a3c5e7f9b2d');
   });
 
-  test('removes contact from segment by email', async () => {
+  it('removes contact from segment by email', async () => {
     spies = setupOutputSpies();
 
     const { removeContactSegmentCommand } = await import(
@@ -89,7 +89,7 @@ describe('contacts remove-segment command', () => {
     expect(args.segmentId).toBe('7b1e0a3d-4c5f-4e8a-9b2d-1a3c5e7f9b2d');
   });
 
-  test('outputs JSON result when non-interactive', async () => {
+  it('outputs JSON result when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { removeContactSegmentCommand } = await import(
@@ -109,7 +109,7 @@ describe('contacts remove-segment command', () => {
     expect(parsed.deleted).toBe(true);
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -135,7 +135,7 @@ describe('contacts remove-segment command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with remove_segment_error when SDK returns an error', async () => {
+  it('errors with remove_segment_error when SDK returns an error', async () => {
     setNonInteractive();
     mockRemoveSegment.mockResolvedValueOnce(
       mockSdkError('Not found', 'not_found'),

--- a/tests/commands/contacts/segments.test.ts
+++ b/tests/commands/contacts/segments.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -63,7 +63,7 @@ describe('contacts segments command', () => {
     exitSpy = undefined;
   });
 
-  test('lists segments by contact ID', async () => {
+  it('lists segments by contact ID', async () => {
     spies = setupOutputSpies();
 
     const { listContactSegmentsCommand } = await import(
@@ -82,7 +82,7 @@ describe('contacts segments command', () => {
     expect(args.email).toBeUndefined();
   });
 
-  test('lists segments by contact email', async () => {
+  it('lists segments by contact email', async () => {
     spies = setupOutputSpies();
 
     const { listContactSegmentsCommand } = await import(
@@ -97,7 +97,7 @@ describe('contacts segments command', () => {
     expect(args.contactId).toBeUndefined();
   });
 
-  test('outputs JSON list when non-interactive', async () => {
+  it('outputs JSON list when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { listContactSegmentsCommand } = await import(
@@ -116,7 +116,7 @@ describe('contacts segments command', () => {
     expect(parsed.data[0].name).toBe('Newsletter');
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -139,7 +139,7 @@ describe('contacts segments command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with list_error when SDK returns an error', async () => {
+  it('errors with list_error when SDK returns an error', async () => {
     setNonInteractive();
     mockListSegments.mockResolvedValueOnce(
       mockSdkError('Not found', 'not_found'),

--- a/tests/commands/contacts/topics.test.ts
+++ b/tests/commands/contacts/topics.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -64,7 +64,7 @@ describe('contacts topics command', () => {
     exitSpy = undefined;
   });
 
-  test('lists topics by contact ID', async () => {
+  it('lists topics by contact ID', async () => {
     spies = setupOutputSpies();
 
     const { listContactTopicsCommand } = await import(
@@ -82,7 +82,7 @@ describe('contacts topics command', () => {
     expect(args.id).toBe('a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6');
   });
 
-  test('lists topics by contact email', async () => {
+  it('lists topics by contact email', async () => {
     spies = setupOutputSpies();
 
     const { listContactTopicsCommand } = await import(
@@ -96,7 +96,7 @@ describe('contacts topics command', () => {
     expect(args.email).toBe('jane@example.com');
   });
 
-  test('outputs JSON list when non-interactive', async () => {
+  it('outputs JSON list when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { listContactTopicsCommand } = await import(
@@ -116,7 +116,7 @@ describe('contacts topics command', () => {
     expect(parsed.data[0].subscription).toBe('opt_in');
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -137,7 +137,7 @@ describe('contacts topics command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with list_error when SDK returns an error', async () => {
+  it('errors with list_error when SDK returns an error', async () => {
     setNonInteractive();
     mockListTopics.mockResolvedValueOnce(
       mockSdkError('Not found', 'not_found'),

--- a/tests/commands/contacts/update-topics.test.ts
+++ b/tests/commands/contacts/update-topics.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -58,7 +58,7 @@ describe('contacts update-topics command', () => {
     }
   });
 
-  test('updates topics by contact ID', async () => {
+  it('updates topics by contact ID', async () => {
     spies = setupOutputSpies();
 
     const { updateContactTopicsCommand } = await import(
@@ -79,7 +79,7 @@ describe('contacts update-topics command', () => {
     expect(args.topics).toEqual([{ id: 'topic_abc', subscription: 'opt_in' }]);
   });
 
-  test('updates topics by contact email', async () => {
+  it('updates topics by contact email', async () => {
     spies = setupOutputSpies();
 
     const { updateContactTopicsCommand } = await import(
@@ -99,7 +99,7 @@ describe('contacts update-topics command', () => {
     expect(args.topics[0].subscription).toBe('opt_out');
   });
 
-  test('passes multiple topics in array', async () => {
+  it('passes multiple topics in array', async () => {
     spies = setupOutputSpies();
 
     const { updateContactTopicsCommand } = await import(
@@ -118,7 +118,7 @@ describe('contacts update-topics command', () => {
     expect(args.topics).toHaveLength(2);
   });
 
-  test('outputs JSON result when non-interactive', async () => {
+  it('outputs JSON result when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { updateContactTopicsCommand } = await import(
@@ -138,7 +138,7 @@ describe('contacts update-topics command', () => {
     expect(parsed.id).toBe('a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6');
   });
 
-  test('errors with missing_topics when --topics absent in non-interactive mode', async () => {
+  it('errors with missing_topics when --topics absent in non-interactive mode', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -159,7 +159,7 @@ describe('contacts update-topics command', () => {
     expect(output).toContain('missing_topics');
   });
 
-  test('errors with missing_topics when --json is set even in TTY', async () => {
+  it('errors with missing_topics when --json is set even in TTY', async () => {
     Object.defineProperty(process.stdin, 'isTTY', {
       value: true,
       writable: true,
@@ -195,7 +195,7 @@ describe('contacts update-topics command', () => {
     expect(output).toContain('missing_topics');
   });
 
-  test('errors with invalid_topics when --topics is not valid JSON', async () => {
+  it('errors with invalid_topics when --topics is not valid JSON', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -214,7 +214,7 @@ describe('contacts update-topics command', () => {
     expect(output).toContain('invalid_topics');
   });
 
-  test('errors with invalid_topics when --topics is not an array', async () => {
+  it('errors with invalid_topics when --topics is not an array', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -233,7 +233,7 @@ describe('contacts update-topics command', () => {
     expect(output).toContain('invalid_topics');
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -258,7 +258,7 @@ describe('contacts update-topics command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with update_topics_error when SDK returns an error', async () => {
+  it('errors with update_topics_error when SDK returns an error', async () => {
     setNonInteractive();
     mockUpdateTopics.mockResolvedValueOnce(
       mockSdkError('Topic not found', 'not_found'),

--- a/tests/commands/contacts/update.test.ts
+++ b/tests/commands/contacts/update.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -54,7 +54,7 @@ describe('contacts update command', () => {
     exitSpy = undefined;
   });
 
-  test('updates contact by ID with --unsubscribed', async () => {
+  it('updates contact by ID with --unsubscribed', async () => {
     spies = setupOutputSpies();
 
     const { updateContactCommand } = await import(
@@ -71,7 +71,7 @@ describe('contacts update command', () => {
     expect(args.unsubscribed).toBe(true);
   });
 
-  test('updates contact by email with --no-unsubscribed', async () => {
+  it('updates contact by email with --no-unsubscribed', async () => {
     spies = setupOutputSpies();
 
     const { updateContactCommand } = await import(
@@ -87,7 +87,7 @@ describe('contacts update command', () => {
     expect(args.unsubscribed).toBe(false);
   });
 
-  test('parses --properties JSON and passes to SDK', async () => {
+  it('parses --properties JSON and passes to SDK', async () => {
     spies = setupOutputSpies();
 
     const { updateContactCommand } = await import(
@@ -106,7 +106,7 @@ describe('contacts update command', () => {
     expect(args.properties).toEqual({ plan: 'pro' });
   });
 
-  test('does not include unsubscribed when neither flag is passed', async () => {
+  it('does not include unsubscribed when neither flag is passed', async () => {
     spies = setupOutputSpies();
 
     const { updateContactCommand } = await import(
@@ -121,7 +121,7 @@ describe('contacts update command', () => {
     expect(args.unsubscribed).toBeUndefined();
   });
 
-  test('outputs JSON result when non-interactive', async () => {
+  it('outputs JSON result when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { updateContactCommand } = await import(
@@ -138,7 +138,7 @@ describe('contacts update command', () => {
     expect(parsed.object).toBe('contact');
   });
 
-  test('errors with invalid_properties when --properties is not valid JSON', async () => {
+  it('errors with invalid_properties when --properties is not valid JSON', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -157,7 +157,7 @@ describe('contacts update command', () => {
     expect(output).toContain('invalid_properties');
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -180,7 +180,7 @@ describe('contacts update command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with update_error when SDK returns an error', async () => {
+  it('errors with update_error when SDK returns an error', async () => {
     setNonInteractive();
     mockUpdate.mockResolvedValueOnce(
       mockSdkError('Contact not found', 'not_found'),

--- a/tests/commands/docs.test.ts
+++ b/tests/commands/docs.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as browser from '../../src/lib/browser';
 
 describe('resend docs command', () => {
@@ -10,7 +10,7 @@ describe('resend docs command', () => {
     vi.restoreAllMocks();
   });
 
-  test('opens documentation URL in browser', async () => {
+  it('opens documentation URL in browser', async () => {
     const { docsCommand } = await import('../../src/commands/docs');
 
     await docsCommand.parseAsync([], { from: 'user' });

--- a/tests/commands/domains/create.test.ts
+++ b/tests/commands/domains/create.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -69,7 +69,7 @@ describe('domains create command', () => {
     exitSpy = undefined;
   });
 
-  test('creates domain with --name flag', async () => {
+  it('creates domain with --name flag', async () => {
     spies = setupOutputSpies();
 
     const { createDomainCommand } = await import(
@@ -84,7 +84,7 @@ describe('domains create command', () => {
     expect(args.name).toBe('example.com');
   });
 
-  test('passes region and tls flags to SDK', async () => {
+  it('passes region and tls flags to SDK', async () => {
     spies = setupOutputSpies();
 
     const { createDomainCommand } = await import(
@@ -100,7 +100,7 @@ describe('domains create command', () => {
     expect(args.tls).toBe('enforced');
   });
 
-  test('passes receiving capability when --receiving flag is set', async () => {
+  it('passes receiving capability when --receiving flag is set', async () => {
     spies = setupOutputSpies();
 
     const { createDomainCommand } = await import(
@@ -115,7 +115,7 @@ describe('domains create command', () => {
     expect(args.capabilities?.receiving).toBe('enabled');
   });
 
-  test('outputs JSON result when non-interactive', async () => {
+  it('outputs JSON result when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { createDomainCommand } = await import(
@@ -131,7 +131,7 @@ describe('domains create command', () => {
     expect(parsed.name).toBe('example.com');
   });
 
-  test('errors with missing_name when --name absent in non-interactive mode', async () => {
+  it('errors with missing_name when --name absent in non-interactive mode', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -147,7 +147,7 @@ describe('domains create command', () => {
     expect(output).toContain('missing_name');
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -167,7 +167,7 @@ describe('domains create command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with create_error when SDK returns an error', async () => {
+  it('errors with create_error when SDK returns an error', async () => {
     setNonInteractive();
     mockCreate.mockResolvedValueOnce(
       mockSdkError('Domain already exists', 'validation_error'),

--- a/tests/commands/domains/delete.test.ts
+++ b/tests/commands/domains/delete.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -51,7 +51,7 @@ describe('domains delete command', () => {
     exitSpy = undefined;
   });
 
-  test('deletes domain with --yes flag', async () => {
+  it('deletes domain with --yes flag', async () => {
     spies = setupOutputSpies();
 
     const { deleteDomainCommand } = await import(
@@ -64,7 +64,7 @@ describe('domains delete command', () => {
     expect(mockRemove).toHaveBeenCalledWith('test-domain-id');
   });
 
-  test('outputs deleted domain JSON on success', async () => {
+  it('outputs deleted domain JSON on success', async () => {
     spies = setupOutputSpies();
 
     const { deleteDomainCommand } = await import(
@@ -80,7 +80,7 @@ describe('domains delete command', () => {
     expect(parsed.id).toBe('test-domain-id');
   });
 
-  test('errors with confirmation_required when --yes absent in non-interactive mode', async () => {
+  it('errors with confirmation_required when --yes absent in non-interactive mode', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -96,7 +96,7 @@ describe('domains delete command', () => {
     expect(output).toContain('confirmation_required');
   });
 
-  test('does not call SDK when confirmation is required but not given', async () => {
+  it('does not call SDK when confirmation is required but not given', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -111,7 +111,7 @@ describe('domains delete command', () => {
     expect(mockRemove).not.toHaveBeenCalled();
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -131,7 +131,7 @@ describe('domains delete command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with delete_error when SDK returns an error', async () => {
+  it('errors with delete_error when SDK returns an error', async () => {
     setNonInteractive();
     mockRemove.mockResolvedValueOnce(
       mockSdkError('Domain not found', 'not_found'),

--- a/tests/commands/domains/get.test.ts
+++ b/tests/commands/domains/get.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -70,7 +70,7 @@ describe('domains get command', () => {
     exitSpy = undefined;
   });
 
-  test('calls SDK get with correct id', async () => {
+  it('calls SDK get with correct id', async () => {
     spies = setupOutputSpies();
 
     const { getDomainCommand } = await import(
@@ -81,7 +81,7 @@ describe('domains get command', () => {
     expect(mockGet).toHaveBeenCalledWith('test-domain-id');
   });
 
-  test('outputs full domain JSON in non-interactive mode', async () => {
+  it('outputs full domain JSON in non-interactive mode', async () => {
     spies = setupOutputSpies();
 
     const { getDomainCommand } = await import(
@@ -96,7 +96,7 @@ describe('domains get command', () => {
     expect(parsed.records).toHaveLength(1);
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -114,7 +114,7 @@ describe('domains get command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with fetch_error when SDK returns an error', async () => {
+  it('errors with fetch_error when SDK returns an error', async () => {
     setNonInteractive();
     mockGet.mockResolvedValueOnce(
       mockSdkError('Domain not found', 'not_found'),

--- a/tests/commands/domains/list.test.ts
+++ b/tests/commands/domains/list.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -80,7 +80,7 @@ describe('domains list command', () => {
     return firstCall[0];
   }
 
-  test('calls SDK list and outputs domains as JSON', async () => {
+  it('calls SDK list and outputs domains as JSON', async () => {
     spies = setupOutputSpies();
 
     const { listDomainsCommand } = await import(
@@ -95,7 +95,7 @@ describe('domains list command', () => {
     expect(parsed.data).toHaveLength(2);
   });
 
-  test('passes limit to SDK', async () => {
+  it('passes limit to SDK', async () => {
     spies = setupOutputSpies();
 
     const { listDomainsCommand } = await import(
@@ -106,7 +106,7 @@ describe('domains list command', () => {
     expect(getFirstCallArgs()).toMatchObject({ limit: 25 });
   });
 
-  test('passes after cursor to SDK', async () => {
+  it('passes after cursor to SDK', async () => {
     spies = setupOutputSpies();
 
     const { listDomainsCommand } = await import(
@@ -121,7 +121,7 @@ describe('domains list command', () => {
     });
   });
 
-  test('passes before cursor to SDK', async () => {
+  it('passes before cursor to SDK', async () => {
     spies = setupOutputSpies();
 
     const { listDomainsCommand } = await import(
@@ -136,7 +136,7 @@ describe('domains list command', () => {
     });
   });
 
-  test('errors when both after and before cursors are provided', async () => {
+  it('errors when both after and before cursors are provided', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -156,7 +156,7 @@ describe('domains list command', () => {
     expect(output).toContain('invalid_pagination');
   });
 
-  test('uses default limit of 10 when not specified', async () => {
+  it('uses default limit of 10 when not specified', async () => {
     spies = setupOutputSpies();
 
     const { listDomainsCommand } = await import(
@@ -167,7 +167,7 @@ describe('domains list command', () => {
     expect(getFirstCallArgs()).toMatchObject({ limit: 10 });
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -185,7 +185,7 @@ describe('domains list command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with list_error when SDK returns an error', async () => {
+  it('errors with list_error when SDK returns an error', async () => {
     setNonInteractive();
     mockList.mockResolvedValueOnce(mockSdkError('Unauthorized', 'auth_error'));
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/tests/commands/domains/update.test.ts
+++ b/tests/commands/domains/update.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -51,7 +51,7 @@ describe('domains update command', () => {
     exitSpy = undefined;
   });
 
-  test('calls SDK update with correct id', async () => {
+  it('calls SDK update with correct id', async () => {
     spies = setupOutputSpies();
 
     const { updateDomainCommand } = await import(
@@ -68,7 +68,7 @@ describe('domains update command', () => {
     expect(args.tls).toBe('enforced');
   });
 
-  test('passes openTracking=true when --open-tracking is set', async () => {
+  it('passes openTracking=true when --open-tracking is set', async () => {
     spies = setupOutputSpies();
 
     const { updateDomainCommand } = await import(
@@ -83,7 +83,7 @@ describe('domains update command', () => {
     expect(args.openTracking).toBe(true);
   });
 
-  test('passes openTracking=false when --no-open-tracking is set', async () => {
+  it('passes openTracking=false when --no-open-tracking is set', async () => {
     spies = setupOutputSpies();
 
     const { updateDomainCommand } = await import(
@@ -98,7 +98,7 @@ describe('domains update command', () => {
     expect(args.openTracking).toBe(false);
   });
 
-  test('does not include tracking keys in payload when no tracking flags are passed', async () => {
+  it('does not include tracking keys in payload when no tracking flags are passed', async () => {
     spies = setupOutputSpies();
 
     const { updateDomainCommand } = await import(
@@ -114,7 +114,7 @@ describe('domains update command', () => {
     expect(args.clickTracking).toBeUndefined();
   });
 
-  test('passes clickTracking=true when --click-tracking is set', async () => {
+  it('passes clickTracking=true when --click-tracking is set', async () => {
     spies = setupOutputSpies();
 
     const { updateDomainCommand } = await import(
@@ -129,7 +129,7 @@ describe('domains update command', () => {
     expect(args.clickTracking).toBe(true);
   });
 
-  test('passes clickTracking=false when --no-click-tracking is set', async () => {
+  it('passes clickTracking=false when --no-click-tracking is set', async () => {
     spies = setupOutputSpies();
 
     const { updateDomainCommand } = await import(
@@ -144,7 +144,7 @@ describe('domains update command', () => {
     expect(args.clickTracking).toBe(false);
   });
 
-  test('errors with no_changes when no update flags are provided', async () => {
+  it('errors with no_changes when no update flags are provided', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -161,7 +161,7 @@ describe('domains update command', () => {
     expect(mockUpdate).not.toHaveBeenCalled();
   });
 
-  test('outputs domain JSON on success', async () => {
+  it('outputs domain JSON on success', async () => {
     spies = setupOutputSpies();
 
     const { updateDomainCommand } = await import(
@@ -178,7 +178,7 @@ describe('domains update command', () => {
     expect(parsed.id).toBe('test-domain-id');
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -198,7 +198,7 @@ describe('domains update command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with update_error when SDK returns an error', async () => {
+  it('errors with update_error when SDK returns an error', async () => {
     setNonInteractive();
     mockUpdate.mockResolvedValueOnce(
       mockSdkError('Domain not found', 'not_found'),

--- a/tests/commands/domains/utils.test.ts
+++ b/tests/commands/domains/utils.test.ts
@@ -1,12 +1,12 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { renderDnsRecordsTable } from '../../../src/commands/domains/utils';
 
 describe('renderDnsRecordsTable', () => {
-  test('returns empty message when no records', () => {
+  it('returns empty message when no records', () => {
     expect(renderDnsRecordsTable([], 'example.com')).toBe('(no DNS records)');
   });
 
-  test('renders a card per record with type separator', () => {
+  it('renders a card per record with type separator', () => {
     const output = renderDnsRecordsTable(
       [
         {
@@ -28,7 +28,7 @@ describe('renderDnsRecordsTable', () => {
     expect(output).toContain('Value  feedback-smtp.us-east-1.amazonses.com');
   });
 
-  test('expands short name with domain suffix', () => {
+  it('expands short name with domain suffix', () => {
     const output = renderDnsRecordsTable(
       [
         {
@@ -47,7 +47,7 @@ describe('renderDnsRecordsTable', () => {
     expect(output).toContain('Name   dkim.send.example.com');
   });
 
-  test('keeps FQDN name as-is', () => {
+  it('keeps FQDN name as-is', () => {
     const output = renderDnsRecordsTable(
       [
         {
@@ -66,7 +66,7 @@ describe('renderDnsRecordsTable', () => {
     expect(output).toContain('Name   send.example.com');
   });
 
-  test('uses domain name when record name is empty', () => {
+  it('uses domain name when record name is empty', () => {
     const output = renderDnsRecordsTable(
       [
         {
@@ -85,7 +85,7 @@ describe('renderDnsRecordsTable', () => {
     expect(output).toContain('Name   example.com');
   });
 
-  test('separates multiple records with blank line', () => {
+  it('separates multiple records with blank line', () => {
     const output = renderDnsRecordsTable(
       [
         {

--- a/tests/commands/domains/verify.test.ts
+++ b/tests/commands/domains/verify.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -51,7 +51,7 @@ describe('domains verify command', () => {
     exitSpy = undefined;
   });
 
-  test('calls SDK verify with correct id', async () => {
+  it('calls SDK verify with correct id', async () => {
     spies = setupOutputSpies();
 
     const { verifyDomainCommand } = await import(
@@ -62,7 +62,7 @@ describe('domains verify command', () => {
     expect(mockVerify).toHaveBeenCalledWith('test-domain-id');
   });
 
-  test('outputs JSON object in non-interactive mode (stdout not a TTY)', async () => {
+  it('outputs JSON object in non-interactive mode (stdout not a TTY)', async () => {
     spies = setupOutputSpies();
 
     const { verifyDomainCommand } = await import(
@@ -76,7 +76,7 @@ describe('domains verify command', () => {
     expect(parsed.object).toBe('domain');
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -94,7 +94,7 @@ describe('domains verify command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with verify_error when SDK returns an error', async () => {
+  it('errors with verify_error when SDK returns an error', async () => {
     setNonInteractive();
     mockVerify.mockResolvedValueOnce(
       mockSdkError('Domain not found', 'not_found'),

--- a/tests/commands/emails/attachment.test.ts
+++ b/tests/commands/emails/attachment.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -61,7 +61,7 @@ describe('emails attachment command', () => {
     exitSpy = undefined;
   });
 
-  test('calls SDK get with emailId and attachmentId', async () => {
+  it('calls SDK get with emailId and attachmentId', async () => {
     spies = setupOutputSpies();
 
     const { getAttachmentCommand } = await import(
@@ -77,7 +77,7 @@ describe('emails attachment command', () => {
     expect(args.id).toBe('attach_abc123');
   });
 
-  test('outputs JSON with attachment fields when non-interactive', async () => {
+  it('outputs JSON with attachment fields when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { getAttachmentCommand } = await import(
@@ -97,7 +97,7 @@ describe('emails attachment command', () => {
     );
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -117,7 +117,7 @@ describe('emails attachment command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with fetch_error when SDK returns an error', async () => {
+  it('errors with fetch_error when SDK returns an error', async () => {
     setNonInteractive();
     mockGet.mockResolvedValueOnce(mockSdkError('Not found', 'not_found'));
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/tests/commands/emails/attachments.test.ts
+++ b/tests/commands/emails/attachments.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -66,7 +66,7 @@ describe('emails attachments command', () => {
     exitSpy = undefined;
   });
 
-  test('calls SDK list with emailId and default pagination', async () => {
+  it('calls SDK list with emailId and default pagination', async () => {
     spies = setupOutputSpies();
 
     const { listAttachmentsCommand } = await import(
@@ -80,7 +80,7 @@ describe('emails attachments command', () => {
     expect(args.limit).toBe(10);
   });
 
-  test('passes --limit to pagination options', async () => {
+  it('passes --limit to pagination options', async () => {
     spies = setupOutputSpies();
 
     const { listAttachmentsCommand } = await import(
@@ -94,7 +94,7 @@ describe('emails attachments command', () => {
     expect(args.limit).toBe(5);
   });
 
-  test('outputs JSON list with attachment data when non-interactive', async () => {
+  it('outputs JSON list with attachment data when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { listAttachmentsCommand } = await import(
@@ -111,7 +111,7 @@ describe('emails attachments command', () => {
     expect(parsed.has_more).toBe(false);
   });
 
-  test('errors with invalid_limit for out-of-range limit', async () => {
+  it('errors with invalid_limit for out-of-range limit', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -129,7 +129,7 @@ describe('emails attachments command', () => {
     expect(output).toContain('invalid_limit');
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -147,7 +147,7 @@ describe('emails attachments command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with list_error when SDK returns an error', async () => {
+  it('errors with list_error when SDK returns an error', async () => {
     setNonInteractive();
     mockList.mockResolvedValueOnce(mockSdkError('Not found', 'not_found'));
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/tests/commands/emails/batch.test.ts
+++ b/tests/commands/emails/batch.test.ts
@@ -7,8 +7,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import * as files from '../../../src/lib/files';
@@ -100,7 +100,7 @@ describe('batch command', () => {
     return path;
   }
 
-  test('sends emails from a JSON file', async () => {
+  it('sends emails from a JSON file', async () => {
     spies = setupOutputSpies();
 
     const file = await writeTmpJson(VALID_EMAILS);
@@ -112,7 +112,7 @@ describe('batch command', () => {
     expect(emails).toHaveLength(2);
   });
 
-  test('outputs array of IDs on success in JSON mode', async () => {
+  it('outputs array of IDs on success in JSON mode', async () => {
     // Non-interactive mode (no TTY) automatically triggers JSON output via outputResult
     spies = setupOutputSpies();
 
@@ -125,7 +125,7 @@ describe('batch command', () => {
     expect(parsed).toEqual([{ id: 'abc123' }, { id: 'def456' }]);
   });
 
-  test('errors with missing_file when no --file in non-interactive mode', async () => {
+  it('errors with missing_file when no --file in non-interactive mode', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -137,7 +137,7 @@ describe('batch command', () => {
     expect(output).toContain('missing_file');
   });
 
-  test('errors with file_read_error when file does not exist', async () => {
+  it('errors with file_read_error when file does not exist', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -154,7 +154,7 @@ describe('batch command', () => {
     expect(output).toContain('file_read_error');
   });
 
-  test('errors with invalid_json when file is not valid JSON', async () => {
+  it('errors with invalid_json when file is not valid JSON', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -175,7 +175,7 @@ describe('batch command', () => {
     expect(output).toContain('invalid_json');
   });
 
-  test('errors with invalid_format when file content is not an array', async () => {
+  it('errors with invalid_format when file content is not an array', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -196,7 +196,7 @@ describe('batch command', () => {
     expect(output).not.toContain('invalid_json');
   });
 
-  test('errors with invalid_format when an entry is not an object', async () => {
+  it('errors with invalid_format when an entry is not an object', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -212,7 +212,7 @@ describe('batch command', () => {
     expect(output).toContain('Email at index 0 must be a JSON object.');
   });
 
-  test('rejects entries with attachments', async () => {
+  it('rejects entries with attachments', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -233,7 +233,7 @@ describe('batch command', () => {
     expect(output).toContain('attachments');
   });
 
-  test('rejects entries with scheduled_at', async () => {
+  it('rejects entries with scheduled_at', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -251,7 +251,7 @@ describe('batch command', () => {
     expect(output).toContain('scheduled_at');
   });
 
-  test('warns but continues when array length exceeds 100', async () => {
+  it('warns but continues when array length exceeds 100', async () => {
     spies = setupOutputSpies();
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
@@ -270,7 +270,7 @@ describe('batch command', () => {
     warnSpy.mockRestore();
   });
 
-  test('passes idempotency key to batch.send', async () => {
+  it('passes idempotency key to batch.send', async () => {
     spies = setupOutputSpies();
 
     const file = await writeTmpJson(VALID_EMAILS);
@@ -285,7 +285,7 @@ describe('batch command', () => {
     expect(opts?.idempotencyKey).toBe('my-key-123');
   });
 
-  test('passes batchValidation to batch.send options', async () => {
+  it('passes batchValidation to batch.send options', async () => {
     spies = setupOutputSpies();
 
     const file = await writeTmpJson(VALID_EMAILS);
@@ -300,7 +300,7 @@ describe('batch command', () => {
     expect(opts?.batchValidation).toBe('permissive');
   });
 
-  test('errors with auth_error when no API key in non-interactive mode', async () => {
+  it('errors with auth_error when no API key in non-interactive mode', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = join(
@@ -320,7 +320,7 @@ describe('batch command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('outputs human-readable summary in terminal mode', async () => {
+  it('outputs human-readable summary in terminal mode', async () => {
     // Make it look like a TTY so outputResult uses human-readable format
     Object.defineProperty(process.stdin, 'isTTY', {
       value: true,
@@ -347,7 +347,7 @@ describe('batch command', () => {
     logSpy.mockRestore();
   });
 
-  test('surfaces partial errors in permissive mode (JSON output)', async () => {
+  it('surfaces partial errors in permissive mode (JSON output)', async () => {
     spies = setupOutputSpies();
 
     mockBatchSend.mockImplementationOnce(async () => ({
@@ -373,7 +373,7 @@ describe('batch command', () => {
     ]);
   });
 
-  test('does not include errors key in JSON output when no batch errors', async () => {
+  it('does not include errors key in JSON output when no batch errors', async () => {
     spies = setupOutputSpies();
 
     const file = await writeTmpJson(VALID_EMAILS);
@@ -387,7 +387,7 @@ describe('batch command', () => {
     expect(parsed).toEqual([{ id: 'abc123' }, { id: 'def456' }]);
   });
 
-  test('--file - passes stdin to readFile', async () => {
+  it('--file - passes stdin to readFile', async () => {
     spies = setupOutputSpies();
     readFileSpy = vi
       .spyOn(files, 'readFile')
@@ -400,7 +400,7 @@ describe('batch command', () => {
     expect(mockBatchSend).toHaveBeenCalledTimes(1);
   });
 
-  test('injects rendered HTML from --react-email into all batch emails', async () => {
+  it('injects rendered HTML from --react-email into all batch emails', async () => {
     spies = setupOutputSpies();
 
     const emailsWithoutHtml = [
@@ -435,7 +435,7 @@ describe('batch command', () => {
     }
   });
 
-  test('errors with batch_error when SDK returns an error', async () => {
+  it('errors with batch_error when SDK returns an error', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     stderrSpy = vi

--- a/tests/commands/emails/cancel.test.ts
+++ b/tests/commands/emails/cancel.test.ts
@@ -5,8 +5,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -53,7 +53,7 @@ describe('emails cancel command', () => {
     exitSpy = undefined;
   });
 
-  test('calls SDK cancel with correct id', async () => {
+  it('calls SDK cancel with correct id', async () => {
     spies = setupOutputSpies();
 
     const { cancelCommand } = await import(
@@ -64,7 +64,7 @@ describe('emails cancel command', () => {
     expect(mockCancel).toHaveBeenCalledWith('test-email-id');
   });
 
-  test('outputs JSON object in non-interactive mode', async () => {
+  it('outputs JSON object in non-interactive mode', async () => {
     spies = setupOutputSpies();
 
     const { cancelCommand } = await import(
@@ -78,7 +78,7 @@ describe('emails cancel command', () => {
     expect(parsed.object).toBe('email');
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = join(
@@ -99,7 +99,7 @@ describe('emails cancel command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with cancel_error when SDK returns an error', async () => {
+  it('errors with cancel_error when SDK returns an error', async () => {
     setNonInteractive();
     mockCancel.mockResolvedValueOnce(
       mockSdkError('Email not found', 'not_found'),

--- a/tests/commands/emails/get.test.ts
+++ b/tests/commands/emails/get.test.ts
@@ -5,8 +5,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -67,7 +67,7 @@ describe('emails get command', () => {
     exitSpy = undefined;
   });
 
-  test('calls SDK get with the provided id', async () => {
+  it('calls SDK get with the provided id', async () => {
     spies = setupOutputSpies();
 
     const { getEmailCommand } = await import(
@@ -78,7 +78,7 @@ describe('emails get command', () => {
     expect(mockGet).toHaveBeenCalledWith('email_abc123');
   });
 
-  test('outputs JSON with full email fields when non-interactive', async () => {
+  it('outputs JSON with full email fields when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { getEmailCommand } = await import(
@@ -94,7 +94,7 @@ describe('emails get command', () => {
     expect(parsed.last_event).toBe('delivered');
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = join(
@@ -115,7 +115,7 @@ describe('emails get command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with fetch_error when SDK returns an error', async () => {
+  it('errors with fetch_error when SDK returns an error', async () => {
     setNonInteractive();
     mockGet.mockResolvedValueOnce(mockSdkError('Not found', 'not_found'));
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/tests/commands/emails/receiving/attachment.test.ts
+++ b/tests/commands/emails/receiving/attachment.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -61,7 +61,7 @@ describe('emails receiving attachment command', () => {
     exitSpy = undefined;
   });
 
-  test('calls SDK get with emailId and attachmentId', async () => {
+  it('calls SDK get with emailId and attachmentId', async () => {
     spies = setupOutputSpies();
 
     const { getAttachmentCommand } = await import(
@@ -77,7 +77,7 @@ describe('emails receiving attachment command', () => {
     expect(args.id).toBe('attach_abc123');
   });
 
-  test('outputs JSON with attachment fields when non-interactive', async () => {
+  it('outputs JSON with attachment fields when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { getAttachmentCommand } = await import(
@@ -97,7 +97,7 @@ describe('emails receiving attachment command', () => {
     );
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -117,7 +117,7 @@ describe('emails receiving attachment command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with fetch_error when SDK returns an error', async () => {
+  it('errors with fetch_error when SDK returns an error', async () => {
     setNonInteractive();
     mockGet.mockResolvedValueOnce(mockSdkError('Not found', 'not_found'));
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/tests/commands/emails/receiving/attachments.test.ts
+++ b/tests/commands/emails/receiving/attachments.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -66,7 +66,7 @@ describe('emails receiving attachments command', () => {
     exitSpy = undefined;
   });
 
-  test('calls SDK list with emailId and default pagination', async () => {
+  it('calls SDK list with emailId and default pagination', async () => {
     spies = setupOutputSpies();
 
     const { listAttachmentsCommand } = await import(
@@ -80,7 +80,7 @@ describe('emails receiving attachments command', () => {
     expect(args.limit).toBe(10);
   });
 
-  test('passes --limit to pagination options', async () => {
+  it('passes --limit to pagination options', async () => {
     spies = setupOutputSpies();
 
     const { listAttachmentsCommand } = await import(
@@ -94,7 +94,7 @@ describe('emails receiving attachments command', () => {
     expect(args.limit).toBe(5);
   });
 
-  test('outputs JSON list with attachment data when non-interactive', async () => {
+  it('outputs JSON list with attachment data when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { listAttachmentsCommand } = await import(
@@ -111,7 +111,7 @@ describe('emails receiving attachments command', () => {
     expect(parsed.has_more).toBe(false);
   });
 
-  test('errors with invalid_limit for out-of-range limit', async () => {
+  it('errors with invalid_limit for out-of-range limit', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -129,7 +129,7 @@ describe('emails receiving attachments command', () => {
     expect(output).toContain('invalid_limit');
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -147,7 +147,7 @@ describe('emails receiving attachments command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with list_error when SDK returns an error', async () => {
+  it('errors with list_error when SDK returns an error', async () => {
     setNonInteractive();
     mockList.mockResolvedValueOnce(mockSdkError('Not found', 'not_found'));
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/tests/commands/emails/receiving/forward.test.ts
+++ b/tests/commands/emails/receiving/forward.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -51,7 +51,7 @@ describe('emails receiving forward command', () => {
     exitSpy = undefined;
   });
 
-  test('calls SDK forward with correct emailId, to, and from', async () => {
+  it('calls SDK forward with correct emailId, to, and from', async () => {
     spies = setupOutputSpies();
 
     const { forwardCommand } = await import(
@@ -69,7 +69,7 @@ describe('emails receiving forward command', () => {
     });
   });
 
-  test('outputs JSON object in non-interactive mode', async () => {
+  it('outputs JSON object in non-interactive mode', async () => {
     spies = setupOutputSpies();
 
     const { forwardCommand } = await import(
@@ -85,7 +85,7 @@ describe('emails receiving forward command', () => {
     expect(parsed.id).toBe('fwd-email-id');
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -106,7 +106,7 @@ describe('emails receiving forward command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with create_error when SDK returns an error', async () => {
+  it('errors with create_error when SDK returns an error', async () => {
     setNonInteractive();
     mockForward.mockResolvedValueOnce(
       mockSdkError('Email not found', 'not_found'),

--- a/tests/commands/emails/receiving/get.test.ts
+++ b/tests/commands/emails/receiving/get.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -70,7 +70,7 @@ describe('emails receiving get command', () => {
     exitSpy = undefined;
   });
 
-  test('calls SDK get with the provided id', async () => {
+  it('calls SDK get with the provided id', async () => {
     spies = setupOutputSpies();
 
     const { getReceivingCommand } = await import(
@@ -82,7 +82,7 @@ describe('emails receiving get command', () => {
     expect(mockGet.mock.calls[0][0]).toBe('rcv_abc123');
   });
 
-  test('outputs JSON with full email fields when non-interactive', async () => {
+  it('outputs JSON with full email fields when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { getReceivingCommand } = await import(
@@ -101,7 +101,7 @@ describe('emails receiving get command', () => {
     );
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -119,7 +119,7 @@ describe('emails receiving get command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with fetch_error when SDK returns an error', async () => {
+  it('errors with fetch_error when SDK returns an error', async () => {
     setNonInteractive();
     mockGet.mockResolvedValueOnce(mockSdkError('Not found', 'not_found'));
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/tests/commands/emails/receiving/list.test.ts
+++ b/tests/commands/emails/receiving/list.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -68,7 +68,7 @@ describe('emails receiving list command', () => {
     exitSpy = undefined;
   });
 
-  test('calls SDK list with default pagination', async () => {
+  it('calls SDK list with default pagination', async () => {
     spies = setupOutputSpies();
 
     const { listReceivingCommand } = await import(
@@ -81,7 +81,7 @@ describe('emails receiving list command', () => {
     expect(args.limit).toBe(10);
   });
 
-  test('passes --limit to pagination options', async () => {
+  it('passes --limit to pagination options', async () => {
     spies = setupOutputSpies();
 
     const { listReceivingCommand } = await import(
@@ -93,7 +93,7 @@ describe('emails receiving list command', () => {
     expect(args.limit).toBe(5);
   });
 
-  test('passes --after cursor to pagination options', async () => {
+  it('passes --after cursor to pagination options', async () => {
     spies = setupOutputSpies();
 
     const { listReceivingCommand } = await import(
@@ -107,7 +107,7 @@ describe('emails receiving list command', () => {
     expect(args.after).toBe('rcv_cursor123');
   });
 
-  test('outputs JSON list with received email data when non-interactive', async () => {
+  it('outputs JSON list with received email data when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { listReceivingCommand } = await import(
@@ -124,7 +124,7 @@ describe('emails receiving list command', () => {
     expect(parsed.has_more).toBe(false);
   });
 
-  test('errors with invalid_limit for out-of-range limit', async () => {
+  it('errors with invalid_limit for out-of-range limit', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -140,7 +140,7 @@ describe('emails receiving list command', () => {
     expect(output).toContain('invalid_limit');
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -158,7 +158,7 @@ describe('emails receiving list command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with list_error when SDK returns an error', async () => {
+  it('errors with list_error when SDK returns an error', async () => {
     setNonInteractive();
     mockList.mockResolvedValueOnce(
       mockSdkError('Server error', 'server_error'),

--- a/tests/commands/emails/receiving/listen.test.ts
+++ b/tests/commands/emails/receiving/listen.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -69,7 +69,7 @@ describe('emails receiving listen command', () => {
     exitSpy = undefined;
   });
 
-  test('errors with invalid_interval for interval below 2', async () => {
+  it('errors with invalid_interval for interval below 2', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -85,7 +85,7 @@ describe('emails receiving listen command', () => {
     expect(output).toContain('invalid_interval');
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -103,7 +103,7 @@ describe('emails receiving listen command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with list_error when SDK returns an error', async () => {
+  it('errors with list_error when SDK returns an error', async () => {
     setNonInteractive();
     mockList.mockResolvedValueOnce(
       mockSdkError('Server error', 'server_error'),
@@ -125,7 +125,7 @@ describe('emails receiving listen command', () => {
     expect(output).toContain('list_error');
   });
 
-  test('initial fetch calls SDK with correct limit', async () => {
+  it('initial fetch calls SDK with correct limit', async () => {
     vi.useFakeTimers();
     setupOutputSpies();
 

--- a/tests/commands/emails/send.test.ts
+++ b/tests/commands/emails/send.test.ts
@@ -7,8 +7,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -72,7 +72,7 @@ describe('send command', () => {
     exitSpy = undefined;
   });
 
-  test('sends email with all flags provided', async () => {
+  it('sends email with all flags provided', async () => {
     spies = setupOutputSpies();
 
     const { sendCommand } = await import('../../../src/commands/emails/send');
@@ -98,7 +98,7 @@ describe('send command', () => {
     expect(callArgs.text).toBe('Hello');
   });
 
-  test('dry-run does not call API and prints request summary', async () => {
+  it('dry-run does not call API and prints request summary', async () => {
     spies = setupOutputSpies();
 
     const { sendCommand } = await import('../../../src/commands/emails/send');
@@ -125,7 +125,7 @@ describe('send command', () => {
     expect(out.request.to).toEqual(['b@test.com']);
   });
 
-  test('dry-run does not require API key or call domains API', async () => {
+  it('dry-run does not require API key or call domains API', async () => {
     spies = setupOutputSpies();
     delete process.env.RESEND_API_KEY;
 
@@ -151,7 +151,7 @@ describe('send command', () => {
     expect(out.dryRun).toBe(true);
   });
 
-  test('outputs JSON with email ID on success', async () => {
+  it('outputs JSON with email ID on success', async () => {
     spies = setupOutputSpies();
 
     const { sendCommand } = await import('../../../src/commands/emails/send');
@@ -174,7 +174,7 @@ describe('send command', () => {
     expect(parsed.id).toBe('test-email-id-123');
   });
 
-  test('sends HTML email when --html provided', async () => {
+  it('sends HTML email when --html provided', async () => {
     spies = setupOutputSpies();
 
     const { sendCommand } = await import('../../../src/commands/emails/send');
@@ -197,7 +197,7 @@ describe('send command', () => {
     expect(callArgs.text).toBeUndefined();
   });
 
-  test('supports multiple --to addresses', async () => {
+  it('supports multiple --to addresses', async () => {
     spies = setupOutputSpies();
 
     const { sendCommand } = await import('../../../src/commands/emails/send');
@@ -220,7 +220,7 @@ describe('send command', () => {
     expect(callArgs.to).toEqual(['b@test.com', 'c@test.com']);
   });
 
-  test('errors when no API key and non-interactive', async () => {
+  it('errors when no API key and non-interactive', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = join(
@@ -248,7 +248,7 @@ describe('send command', () => {
     );
   });
 
-  test('errors listing missing flags in non-interactive mode', async () => {
+  it('errors listing missing flags in non-interactive mode', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -263,7 +263,7 @@ describe('send command', () => {
     expect(allErrors).toContain('--subject');
   });
 
-  test('errors when no body and non-interactive', async () => {
+  it('errors when no body and non-interactive', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -277,7 +277,7 @@ describe('send command', () => {
     );
   });
 
-  test('reads HTML body from --html-file', async () => {
+  it('reads HTML body from --html-file', async () => {
     spies = setupOutputSpies();
 
     const tmpFile = join(
@@ -309,7 +309,7 @@ describe('send command', () => {
     }
   });
 
-  test('passes cc, bcc, reply-to when provided', async () => {
+  it('passes cc, bcc, reply-to when provided', async () => {
     spies = setupOutputSpies();
 
     const { sendCommand } = await import('../../../src/commands/emails/send');
@@ -339,7 +339,7 @@ describe('send command', () => {
     expect(callArgs.replyTo).toBe('reply@test.com');
   });
 
-  test('does not call domains.list when --from is provided', async () => {
+  it('does not call domains.list when --from is provided', async () => {
     spies = setupOutputSpies();
 
     const { sendCommand } = await import('../../../src/commands/emails/send');
@@ -361,7 +361,7 @@ describe('send command', () => {
     expect(mockSend).toHaveBeenCalledTimes(1);
   });
 
-  test('passes scheduledAt to SDK when --scheduled-at provided', async () => {
+  it('passes scheduledAt to SDK when --scheduled-at provided', async () => {
     spies = setupOutputSpies();
 
     const { sendCommand } = await import('../../../src/commands/emails/send');
@@ -385,7 +385,7 @@ describe('send command', () => {
     expect(callArgs.scheduledAt).toBe('2024-08-05T11:52:01.858Z');
   });
 
-  test('reads attachment file and passes filename and content to SDK', async () => {
+  it('reads attachment file and passes filename and content to SDK', async () => {
     spies = setupOutputSpies();
 
     const tmpFile = join(
@@ -425,7 +425,7 @@ describe('send command', () => {
     }
   });
 
-  test('errors with file_read_error for missing attachment', async () => {
+  it('errors with file_read_error for missing attachment', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -453,7 +453,7 @@ describe('send command', () => {
     expect(output).toContain('file_read_error');
   });
 
-  test('parses key=value headers correctly', async () => {
+  it('parses key=value headers correctly', async () => {
     spies = setupOutputSpies();
 
     const { sendCommand } = await import('../../../src/commands/emails/send');
@@ -481,7 +481,7 @@ describe('send command', () => {
     });
   });
 
-  test('errors with invalid_header for malformed header', async () => {
+  it('errors with invalid_header for malformed header', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -509,7 +509,7 @@ describe('send command', () => {
     expect(output).toContain('invalid_header');
   });
 
-  test('parses name=value tags correctly', async () => {
+  it('parses name=value tags correctly', async () => {
     spies = setupOutputSpies();
 
     const { sendCommand } = await import('../../../src/commands/emails/send');
@@ -537,7 +537,7 @@ describe('send command', () => {
     ]);
   });
 
-  test('errors with invalid_tag for malformed tag', async () => {
+  it('errors with invalid_tag for malformed tag', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -565,7 +565,7 @@ describe('send command', () => {
     expect(output).toContain('invalid_tag');
   });
 
-  test('passes idempotencyKey as second arg to emails.send', async () => {
+  it('passes idempotencyKey as second arg to emails.send', async () => {
     spies = setupOutputSpies();
 
     const { sendCommand } = await import('../../../src/commands/emails/send');
@@ -590,7 +590,7 @@ describe('send command', () => {
     expect(opts?.idempotencyKey).toBe('my-key-123');
   });
 
-  test('errors with missing_flags when --json is set and --from is missing', async () => {
+  it('errors with missing_flags when --json is set and --from is missing', async () => {
     Object.defineProperty(process.stdin, 'isTTY', {
       value: true,
       writable: true,
@@ -635,7 +635,7 @@ describe('send command', () => {
     sendCommand.parent = null;
   });
 
-  test('reads plain text body from --text-file', async () => {
+  it('reads plain text body from --text-file', async () => {
     spies = setupOutputSpies();
 
     const tmpFile = join(
@@ -667,7 +667,7 @@ describe('send command', () => {
     }
   });
 
-  test('--text-file - reads from stdin', async () => {
+  it('--text-file - reads from stdin', async () => {
     spies = setupOutputSpies();
 
     const files = await import('../../../src/lib/files');
@@ -699,7 +699,7 @@ describe('send command', () => {
     }
   });
 
-  test('--html-file - reads from stdin', async () => {
+  it('--html-file - reads from stdin', async () => {
     spies = setupOutputSpies();
 
     const files = await import('../../../src/lib/files');
@@ -731,7 +731,7 @@ describe('send command', () => {
     }
   });
 
-  test('sends both html and text when both provided', async () => {
+  it('sends both html and text when both provided', async () => {
     spies = setupOutputSpies();
 
     const { sendCommand } = await import('../../../src/commands/emails/send');
@@ -756,7 +756,7 @@ describe('send command', () => {
     expect(callArgs.text).toBe('Hello');
   });
 
-  test('warns to stderr when --html and --html-file both provided', async () => {
+  it('warns to stderr when --html and --html-file both provided', async () => {
     spies = setupOutputSpies();
 
     const tmpFile = join(
@@ -792,7 +792,7 @@ describe('send command', () => {
     }
   });
 
-  test('warns to stderr when --text and --text-file both provided', async () => {
+  it('warns to stderr when --text and --text-file both provided', async () => {
     spies = setupOutputSpies();
 
     const tmpFile = join(
@@ -828,7 +828,7 @@ describe('send command', () => {
     }
   });
 
-  test('errors when --html-file - and --text-file - both read stdin', async () => {
+  it('errors when --html-file - and --text-file - both read stdin', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -856,7 +856,7 @@ describe('send command', () => {
     expect(output).toContain('invalid_options');
   });
 
-  test('errors with invalid_options when --subject is empty string', async () => {
+  it('errors with invalid_options when --subject is empty string', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -882,7 +882,7 @@ describe('send command', () => {
     expect(output).toContain('invalid_options');
   });
 
-  test('errors with invalid_options when --from is empty string', async () => {
+  it('errors with invalid_options when --from is empty string', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -908,7 +908,7 @@ describe('send command', () => {
     expect(output).toContain('invalid_options');
   });
 
-  test('sends with --template and --to only', async () => {
+  it('sends with --template and --to only', async () => {
     spies = setupOutputSpies();
 
     const { sendCommand } = await import('../../../src/commands/emails/send');
@@ -927,7 +927,7 @@ describe('send command', () => {
     expect(callArgs.text).toBeUndefined();
   });
 
-  test('sends with --template and --var key=value pairs', async () => {
+  it('sends with --template and --var key=value pairs', async () => {
     spies = setupOutputSpies();
 
     const { sendCommand } = await import('../../../src/commands/emails/send');
@@ -952,7 +952,7 @@ describe('send command', () => {
     });
   });
 
-  test('preserves leading zeros in --var values', async () => {
+  it('preserves leading zeros in --var values', async () => {
     spies = setupOutputSpies();
 
     const { sendCommand } = await import('../../../src/commands/emails/send');
@@ -969,7 +969,7 @@ describe('send command', () => {
     });
   });
 
-  test('preserves large numeric strings beyond MAX_SAFE_INTEGER in --var values', async () => {
+  it('preserves large numeric strings beyond MAX_SAFE_INTEGER in --var values', async () => {
     spies = setupOutputSpies();
 
     const { sendCommand } = await import('../../../src/commands/emails/send');
@@ -993,7 +993,7 @@ describe('send command', () => {
     });
   });
 
-  test('preserves scientific notation strings in --var values', async () => {
+  it('preserves scientific notation strings in --var values', async () => {
     spies = setupOutputSpies();
 
     const { sendCommand } = await import('../../../src/commands/emails/send');
@@ -1010,7 +1010,7 @@ describe('send command', () => {
     });
   });
 
-  test('sends with --template plus --from and --subject overrides', async () => {
+  it('sends with --template plus --from and --subject overrides', async () => {
     spies = setupOutputSpies();
 
     const { sendCommand } = await import('../../../src/commands/emails/send');
@@ -1035,7 +1035,7 @@ describe('send command', () => {
     expect(callArgs.subject).toBe('Override');
   });
 
-  test('errors with invalid_var when --var used without --template', async () => {
+  it('errors with invalid_var when --var used without --template', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -1064,7 +1064,7 @@ describe('send command', () => {
     expect(output).toContain('--template');
   });
 
-  test('errors with invalid_var for malformed --var', async () => {
+  it('errors with invalid_var for malformed --var', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -1081,7 +1081,7 @@ describe('send command', () => {
     expect(output).toContain('invalid_var');
   });
 
-  test('errors with template_body_conflict when --template and --html used together', async () => {
+  it('errors with template_body_conflict when --template and --html used together', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -1105,7 +1105,7 @@ describe('send command', () => {
     expect(output).toContain('template_body_conflict');
   });
 
-  test('errors with template_body_conflict when --template and --html-file used together', async () => {
+  it('errors with template_body_conflict when --template and --html-file used together', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -1129,7 +1129,7 @@ describe('send command', () => {
     expect(output).toContain('template_body_conflict');
   });
 
-  test('errors with template_body_conflict when --template and --text used together', async () => {
+  it('errors with template_body_conflict when --template and --text used together', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -1146,7 +1146,7 @@ describe('send command', () => {
     expect(output).toContain('template_body_conflict');
   });
 
-  test('errors with template_body_conflict when --template and --text-file used together', async () => {
+  it('errors with template_body_conflict when --template and --text-file used together', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -1170,7 +1170,7 @@ describe('send command', () => {
     expect(output).toContain('template_body_conflict');
   });
 
-  test('errors with template_attachment_conflict when --template and --attachment used together', async () => {
+  it('errors with template_attachment_conflict when --template and --attachment used together', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -1194,7 +1194,7 @@ describe('send command', () => {
     expect(output).toContain('template_attachment_conflict');
   });
 
-  test('sends email with --react-email flag', async () => {
+  it('sends email with --react-email flag', async () => {
     spies = setupOutputSpies();
 
     const { sendCommand } = await import('../../../src/commands/emails/send');
@@ -1221,7 +1221,7 @@ describe('send command', () => {
     expect(callArgs.html).toBe('<html><body>Rendered</body></html>');
   });
 
-  test('errors with invalid_options when --react-email and --html used together', async () => {
+  it('errors with invalid_options when --react-email and --html used together', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -1249,7 +1249,7 @@ describe('send command', () => {
     expect(output).toContain('invalid_options');
   });
 
-  test('errors with invalid_options when --react-email and --html-file used together', async () => {
+  it('errors with invalid_options when --react-email and --html-file used together', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -1277,7 +1277,7 @@ describe('send command', () => {
     expect(output).toContain('invalid_options');
   });
 
-  test('allows --react-email with --text for plain-text fallback', async () => {
+  it('allows --react-email with --text for plain-text fallback', async () => {
     spies = setupOutputSpies();
 
     const { sendCommand } = await import('../../../src/commands/emails/send');
@@ -1303,7 +1303,7 @@ describe('send command', () => {
     expect(callArgs.text).toBe('Plain text fallback');
   });
 
-  test('errors with invalid_options when --react-email and --template used together', async () => {
+  it('errors with invalid_options when --react-email and --template used together', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -1327,7 +1327,7 @@ describe('send command', () => {
     expect(output).toContain('invalid_options');
   });
 
-  test('exits when buildReactEmailHtml fails', async () => {
+  it('exits when buildReactEmailHtml fails', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     stderrSpy = vi
@@ -1353,7 +1353,7 @@ describe('send command', () => {
     );
   });
 
-  test('degrades gracefully when domain fetch fails', async () => {
+  it('degrades gracefully when domain fetch fails', async () => {
     const { fetchVerifiedDomains } = await import('../../../src/lib/domains');
     const failingResend = {
       domains: {

--- a/tests/commands/emails/update.test.ts
+++ b/tests/commands/emails/update.test.ts
@@ -5,8 +5,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -53,7 +53,7 @@ describe('emails update command', () => {
     exitSpy = undefined;
   });
 
-  test('calls SDK update with correct id and scheduledAt', async () => {
+  it('calls SDK update with correct id and scheduledAt', async () => {
     spies = setupOutputSpies();
 
     const { updateCommand } = await import(
@@ -70,7 +70,7 @@ describe('emails update command', () => {
     });
   });
 
-  test('outputs JSON object in non-interactive mode', async () => {
+  it('outputs JSON object in non-interactive mode', async () => {
     spies = setupOutputSpies();
 
     const { updateCommand } = await import(
@@ -87,7 +87,7 @@ describe('emails update command', () => {
     expect(parsed.object).toBe('email');
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = join(
@@ -111,7 +111,7 @@ describe('emails update command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with update_error when SDK returns an error', async () => {
+  it('errors with update_error when SDK returns an error', async () => {
     setNonInteractive();
     mockUpdate.mockResolvedValueOnce(
       mockSdkError('Email not found', 'not_found'),

--- a/tests/commands/logs/get.test.ts
+++ b/tests/commands/logs/get.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -61,7 +61,7 @@ describe('logs get command', () => {
     exitSpy = undefined;
   });
 
-  test('calls SDK get with the provided id', async () => {
+  it('calls SDK get with the provided id', async () => {
     spies = setupOutputSpies();
 
     const { getLogCommand } = await import('../../../src/commands/logs/get');
@@ -75,7 +75,7 @@ describe('logs get command', () => {
     );
   });
 
-  test('outputs JSON with log fields when non-interactive', async () => {
+  it('outputs JSON with log fields when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { getLogCommand } = await import('../../../src/commands/logs/get');
@@ -91,7 +91,7 @@ describe('logs get command', () => {
     expect(parsed.response_status).toBe(200);
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -109,7 +109,7 @@ describe('logs get command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with fetch_error when SDK returns an error', async () => {
+  it('errors with fetch_error when SDK returns an error', async () => {
     setNonInteractive();
     mockGet.mockResolvedValueOnce(mockSdkError('Not found', 'not_found'));
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/tests/commands/logs/list.test.ts
+++ b/tests/commands/logs/list.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -64,7 +64,7 @@ describe('logs list command', () => {
     exitSpy = undefined;
   });
 
-  test('calls SDK list method with default pagination', async () => {
+  it('calls SDK list method with default pagination', async () => {
     spies = setupOutputSpies();
 
     const { listLogsCommand } = await import('../../../src/commands/logs/list');
@@ -75,7 +75,7 @@ describe('logs list command', () => {
     expect(args.limit).toBe(10);
   });
 
-  test('passes --limit to pagination options', async () => {
+  it('passes --limit to pagination options', async () => {
     spies = setupOutputSpies();
 
     const { listLogsCommand } = await import('../../../src/commands/logs/list');
@@ -85,7 +85,7 @@ describe('logs list command', () => {
     expect(args.limit).toBe(5);
   });
 
-  test('passes --after cursor to pagination options', async () => {
+  it('passes --after cursor to pagination options', async () => {
     spies = setupOutputSpies();
 
     const { listLogsCommand } = await import('../../../src/commands/logs/list');
@@ -98,7 +98,7 @@ describe('logs list command', () => {
     expect(args.after).toBe('3d4a472d-bc6d-4dd2-aa9d-d3d11b549e55');
   });
 
-  test('outputs JSON list with log data when non-interactive', async () => {
+  it('outputs JSON list with log data when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { listLogsCommand } = await import('../../../src/commands/logs/list');
@@ -112,7 +112,7 @@ describe('logs list command', () => {
     expect(parsed.has_more).toBe(false);
   });
 
-  test('errors with invalid_limit for out-of-range limit', async () => {
+  it('errors with invalid_limit for out-of-range limit', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -126,7 +126,7 @@ describe('logs list command', () => {
     expect(output).toContain('invalid_limit');
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -140,7 +140,7 @@ describe('logs list command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with list_error when SDK returns an error', async () => {
+  it('errors with list_error when SDK returns an error', async () => {
     setNonInteractive();
     mockList.mockResolvedValueOnce(
       mockSdkError('Server error', 'server_error'),

--- a/tests/commands/logs/open.test.ts
+++ b/tests/commands/logs/open.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as browser from '../../../src/lib/browser';
 
 describe('logs open command', () => {
@@ -10,7 +10,7 @@ describe('logs open command', () => {
     vi.restoreAllMocks();
   });
 
-  test('with no args opens logs list', async () => {
+  it('with no args opens logs list', async () => {
     const { openLogsCommand } = await import('../../../src/commands/logs/open');
     await openLogsCommand.parseAsync([], { from: 'user' });
 
@@ -21,7 +21,7 @@ describe('logs open command', () => {
     );
   });
 
-  test('with id opens log detail URL', async () => {
+  it('with id opens log detail URL', async () => {
     const { openLogsCommand } = await import('../../../src/commands/logs/open');
     await openLogsCommand.parseAsync(['3d4a472d-bc6d-4dd2-aa9d-d3d11b549e55'], {
       from: 'user',

--- a/tests/commands/open.test.ts
+++ b/tests/commands/open.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as browser from '../../src/lib/browser';
 
 describe('resend open command', () => {
@@ -10,7 +10,7 @@ describe('resend open command', () => {
     vi.restoreAllMocks();
   });
 
-  test('opens emails URL in browser', async () => {
+  it('opens emails URL in browser', async () => {
     const { openCommand } = await import('../../src/commands/open');
     await openCommand.parseAsync([], { from: 'user' });
 

--- a/tests/commands/segments/create.test.ts
+++ b/tests/commands/segments/create.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -55,7 +55,7 @@ describe('segments create command', () => {
     exitSpy = undefined;
   });
 
-  test('creates segment with --name flag', async () => {
+  it('creates segment with --name flag', async () => {
     spies = setupOutputSpies();
 
     const { createSegmentCommand } = await import(
@@ -71,7 +71,7 @@ describe('segments create command', () => {
     expect(args.name).toBe('Newsletter Subscribers');
   });
 
-  test('outputs JSON with id and object when non-interactive', async () => {
+  it('outputs JSON with id and object when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { createSegmentCommand } = await import(
@@ -89,7 +89,7 @@ describe('segments create command', () => {
     expect(parsed.name).toBe('Newsletter Subscribers');
   });
 
-  test('errors with missing_name in non-interactive mode when --name absent', async () => {
+  it('errors with missing_name in non-interactive mode when --name absent', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -105,7 +105,7 @@ describe('segments create command', () => {
     expect(output).toContain('missing_name');
   });
 
-  test('does not call SDK when missing_name error is raised', async () => {
+  it('does not call SDK when missing_name error is raised', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -120,7 +120,7 @@ describe('segments create command', () => {
     expect(mockCreate).not.toHaveBeenCalled();
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -138,7 +138,7 @@ describe('segments create command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with create_error when SDK returns an error', async () => {
+  it('errors with create_error when SDK returns an error', async () => {
     setNonInteractive();
     mockCreate.mockResolvedValueOnce(
       mockSdkError('Segment already exists', 'validation_error'),

--- a/tests/commands/segments/delete.test.ts
+++ b/tests/commands/segments/delete.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -55,7 +55,7 @@ describe('segments delete command', () => {
     exitSpy = undefined;
   });
 
-  test('deletes segment with --yes flag', async () => {
+  it('deletes segment with --yes flag', async () => {
     spies = setupOutputSpies();
 
     const { deleteSegmentCommand } = await import(
@@ -74,7 +74,7 @@ describe('segments delete command', () => {
     );
   });
 
-  test('outputs synthesized JSON result when non-interactive', async () => {
+  it('outputs synthesized JSON result when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { deleteSegmentCommand } = await import(
@@ -94,7 +94,7 @@ describe('segments delete command', () => {
     expect(parsed.deleted).toBe(true);
   });
 
-  test('errors with confirmation_required when --yes absent in non-interactive mode', async () => {
+  it('errors with confirmation_required when --yes absent in non-interactive mode', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -113,7 +113,7 @@ describe('segments delete command', () => {
     expect(output).toContain('confirmation_required');
   });
 
-  test('does not call SDK when confirmation_required error is raised', async () => {
+  it('does not call SDK when confirmation_required error is raised', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -131,7 +131,7 @@ describe('segments delete command', () => {
     expect(mockRemove).not.toHaveBeenCalled();
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -154,7 +154,7 @@ describe('segments delete command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with delete_error when SDK returns an error', async () => {
+  it('errors with delete_error when SDK returns an error', async () => {
     setNonInteractive();
     mockRemove.mockResolvedValueOnce(
       mockSdkError('Segment not found', 'not_found'),

--- a/tests/commands/segments/get.test.ts
+++ b/tests/commands/segments/get.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -56,7 +56,7 @@ describe('segments get command', () => {
     exitSpy = undefined;
   });
 
-  test('calls SDK with the provided segment ID', async () => {
+  it('calls SDK with the provided segment ID', async () => {
     spies = setupOutputSpies();
 
     const { getSegmentCommand } = await import(
@@ -73,7 +73,7 @@ describe('segments get command', () => {
     );
   });
 
-  test('outputs JSON segment data when non-interactive', async () => {
+  it('outputs JSON segment data when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { getSegmentCommand } = await import(
@@ -92,7 +92,7 @@ describe('segments get command', () => {
     expect(parsed.created_at).toBe('2026-01-01T00:00:00.000Z');
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -112,7 +112,7 @@ describe('segments get command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with fetch_error when SDK returns an error', async () => {
+  it('errors with fetch_error when SDK returns an error', async () => {
     setNonInteractive();
     mockGet.mockResolvedValueOnce(
       mockSdkError('Segment not found', 'not_found'),

--- a/tests/commands/segments/list.test.ts
+++ b/tests/commands/segments/list.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -61,7 +61,7 @@ describe('segments list command', () => {
     exitSpy = undefined;
   });
 
-  test('calls SDK with default limit of 10', async () => {
+  it('calls SDK with default limit of 10', async () => {
     spies = setupOutputSpies();
 
     const { listSegmentsCommand } = await import(
@@ -74,7 +74,7 @@ describe('segments list command', () => {
     expect(args.limit).toBe(10);
   });
 
-  test('calls SDK with custom --limit', async () => {
+  it('calls SDK with custom --limit', async () => {
     spies = setupOutputSpies();
 
     const { listSegmentsCommand } = await import(
@@ -86,7 +86,7 @@ describe('segments list command', () => {
     expect(args.limit).toBe(25);
   });
 
-  test('calls SDK with --after cursor', async () => {
+  it('calls SDK with --after cursor', async () => {
     spies = setupOutputSpies();
 
     const { listSegmentsCommand } = await import(
@@ -100,7 +100,7 @@ describe('segments list command', () => {
     expect(args.after).toBe('cursor_xyz');
   });
 
-  test('outputs JSON list when non-interactive', async () => {
+  it('outputs JSON list when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { listSegmentsCommand } = await import(
@@ -116,7 +116,7 @@ describe('segments list command', () => {
     expect(parsed.has_more).toBe(false);
   });
 
-  test('errors with invalid_limit when --limit is out of range', async () => {
+  it('errors with invalid_limit when --limit is out of range', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -132,7 +132,7 @@ describe('segments list command', () => {
     expect(output).toContain('invalid_limit');
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -150,7 +150,7 @@ describe('segments list command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with list_error when SDK returns an error', async () => {
+  it('errors with list_error when SDK returns an error', async () => {
     setNonInteractive();
     mockList.mockResolvedValueOnce(
       mockSdkError('Server error', 'server_error'),

--- a/tests/commands/templates/create.test.ts
+++ b/tests/commands/templates/create.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import * as files from '../../../src/lib/files';
@@ -69,7 +69,7 @@ describe('templates create command', () => {
     }
   });
 
-  test('creates template with required flags', async () => {
+  it('creates template with required flags', async () => {
     spies = setupOutputSpies();
 
     const { createTemplateCommand } = await import(
@@ -86,7 +86,7 @@ describe('templates create command', () => {
     expect(args.html).toBe('<h1>Hello</h1>');
   });
 
-  test('outputs JSON result when non-interactive', async () => {
+  it('outputs JSON result when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { createTemplateCommand } = await import(
@@ -102,7 +102,7 @@ describe('templates create command', () => {
     expect(parsed.id).toBe('tmpl_abc123');
   });
 
-  test('errors with missing_name when --name absent in non-interactive mode', async () => {
+  it('errors with missing_name when --name absent in non-interactive mode', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -120,7 +120,7 @@ describe('templates create command', () => {
     expect(output).toContain('missing_name');
   });
 
-  test('errors with missing_body when no body flag in non-interactive mode', async () => {
+  it('errors with missing_body when no body flag in non-interactive mode', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -138,7 +138,7 @@ describe('templates create command', () => {
     expect(output).toContain('missing_body');
   });
 
-  test('errors with missing_name when --json is set even in TTY', async () => {
+  it('errors with missing_name when --json is set even in TTY', async () => {
     Object.defineProperty(process.stdin, 'isTTY', {
       value: true,
       writable: true,
@@ -173,7 +173,7 @@ describe('templates create command', () => {
     expect(output).toContain('missing_name');
   });
 
-  test('reads text body from --text-file and passes it to SDK', async () => {
+  it('reads text body from --text-file and passes it to SDK', async () => {
     spies = setupOutputSpies();
     readFileSpy = vi
       .spyOn(files, 'readFile')
@@ -202,7 +202,7 @@ describe('templates create command', () => {
     expect(args.text).toBe('Plain text from file');
   });
 
-  test('warns to stderr when --text and --text-file both provided, text-file wins', async () => {
+  it('warns to stderr when --text and --text-file both provided, text-file wins', async () => {
     spies = setupOutputSpies();
     readFileSpy = vi.spyOn(files, 'readFile').mockReturnValue('From file');
 
@@ -229,7 +229,7 @@ describe('templates create command', () => {
     expect(args.text).toBe('From file');
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -250,7 +250,7 @@ describe('templates create command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('creates template with --react-email flag', async () => {
+  it('creates template with --react-email flag', async () => {
     spies = setupOutputSpies();
 
     const { createTemplateCommand } = await import(
@@ -269,7 +269,7 @@ describe('templates create command', () => {
     expect(args.html).toBe('<html><body>Rendered</body></html>');
   });
 
-  test('errors with invalid_options when --react-email and --html used together', async () => {
+  it('errors with invalid_options when --react-email and --html used together', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -295,7 +295,7 @@ describe('templates create command', () => {
     expect(output).toContain('invalid_options');
   });
 
-  test('errors with create_error when SDK returns an error', async () => {
+  it('errors with create_error when SDK returns an error', async () => {
     setNonInteractive();
     mockCreate.mockResolvedValueOnce(
       mockSdkError('Template name taken', 'validation_error'),

--- a/tests/commands/templates/open.test.ts
+++ b/tests/commands/templates/open.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as browser from '../../../src/lib/browser';
 
 describe('templates open command', () => {
@@ -10,7 +10,7 @@ describe('templates open command', () => {
     vi.restoreAllMocks();
   });
 
-  test('with no args opens templates list', async () => {
+  it('with no args opens templates list', async () => {
     const { openTemplateCommand } = await import(
       '../../../src/commands/templates/open'
     );
@@ -23,7 +23,7 @@ describe('templates open command', () => {
     );
   });
 
-  test('with id opens template URL', async () => {
+  it('with id opens template URL', async () => {
     const { openTemplateCommand } = await import(
       '../../../src/commands/templates/open'
     );

--- a/tests/commands/templates/update.test.ts
+++ b/tests/commands/templates/update.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import * as files from '../../../src/lib/files';
@@ -84,7 +84,7 @@ describe('templates update command', () => {
     return firstCall[1];
   }
 
-  test('updates template name', async () => {
+  it('updates template name', async () => {
     spies = setupOutputSpies();
 
     const { updateTemplateCommand } = await import(
@@ -101,7 +101,7 @@ describe('templates update command', () => {
     expect(payload.name).toBe('Updated Name');
   });
 
-  test('omits fields not provided from SDK payload', async () => {
+  it('omits fields not provided from SDK payload', async () => {
     spies = setupOutputSpies();
 
     const { updateTemplateCommand } = await import(
@@ -120,7 +120,7 @@ describe('templates update command', () => {
     expect(payload).not.toHaveProperty('from');
   });
 
-  test('errors with no_changes before trying to pick an id', async () => {
+  it('errors with no_changes before trying to pick an id', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -140,7 +140,7 @@ describe('templates update command', () => {
     expect(output).not.toContain('missing_id');
   });
 
-  test('errors when --react-email and empty --html are used together', async () => {
+  it('errors when --react-email and empty --html are used together', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -161,7 +161,7 @@ describe('templates update command', () => {
     expect(output).toContain('invalid_options');
   });
 
-  test('errors when empty --html and --html-file are used together', async () => {
+  it('errors when empty --html and --html-file are used together', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -181,7 +181,7 @@ describe('templates update command', () => {
     expect(output).toContain('invalid_options');
   });
 
-  test('warns when empty --text and --text-file are used together', async () => {
+  it('warns when empty --text and --text-file are used together', async () => {
     spies = setupOutputSpies();
     readFileSpy = vi.spyOn(files, 'readFile').mockReturnValue('From file');
 

--- a/tests/commands/topics/create.test.ts
+++ b/tests/commands/topics/create.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -51,7 +51,7 @@ describe('topics create command', () => {
     exitSpy = undefined;
   });
 
-  test('creates topic with --name and default subscription', async () => {
+  it('creates topic with --name and default subscription', async () => {
     spies = setupOutputSpies();
 
     const { createTopicCommand } = await import(
@@ -67,7 +67,7 @@ describe('topics create command', () => {
     expect(args.defaultSubscription).toBe('opt_in');
   });
 
-  test('creates topic with explicit --default-subscription opt_out', async () => {
+  it('creates topic with explicit --default-subscription opt_out', async () => {
     spies = setupOutputSpies();
 
     const { createTopicCommand } = await import(
@@ -82,7 +82,7 @@ describe('topics create command', () => {
     expect(args.defaultSubscription).toBe('opt_out');
   });
 
-  test('includes description when --description is provided', async () => {
+  it('includes description when --description is provided', async () => {
     spies = setupOutputSpies();
 
     const { createTopicCommand } = await import(
@@ -102,7 +102,7 @@ describe('topics create command', () => {
     expect(args.description).toBe('Get notified about new features');
   });
 
-  test('outputs JSON with id when non-interactive', async () => {
+  it('outputs JSON with id when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { createTopicCommand } = await import(
@@ -117,7 +117,7 @@ describe('topics create command', () => {
     expect(parsed.id).toBe('top_abc123');
   });
 
-  test('errors with missing_name in non-interactive mode when --name absent', async () => {
+  it('errors with missing_name in non-interactive mode when --name absent', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -133,7 +133,7 @@ describe('topics create command', () => {
     expect(output).toContain('missing_name');
   });
 
-  test('does not call SDK when missing_name error is raised', async () => {
+  it('does not call SDK when missing_name error is raised', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -148,7 +148,7 @@ describe('topics create command', () => {
     expect(mockCreate).not.toHaveBeenCalled();
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -166,7 +166,7 @@ describe('topics create command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with create_error when SDK returns an error', async () => {
+  it('errors with create_error when SDK returns an error', async () => {
     setNonInteractive();
     mockCreate.mockResolvedValueOnce(
       mockSdkError('Topic already exists', 'validation_error'),

--- a/tests/commands/topics/delete.test.ts
+++ b/tests/commands/topics/delete.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -51,7 +51,7 @@ describe('topics delete command', () => {
     exitSpy = undefined;
   });
 
-  test('deletes topic with --yes flag', async () => {
+  it('deletes topic with --yes flag', async () => {
     spies = setupOutputSpies();
 
     const { deleteTopicCommand } = await import(
@@ -65,7 +65,7 @@ describe('topics delete command', () => {
     expect(mockRemove.mock.calls[0][0]).toBe('top_abc123');
   });
 
-  test('outputs synthesized JSON result when non-interactive', async () => {
+  it('outputs synthesized JSON result when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { deleteTopicCommand } = await import(
@@ -82,7 +82,7 @@ describe('topics delete command', () => {
     expect(parsed.deleted).toBe(true);
   });
 
-  test('errors with confirmation_required when --yes absent in non-interactive mode', async () => {
+  it('errors with confirmation_required when --yes absent in non-interactive mode', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -98,7 +98,7 @@ describe('topics delete command', () => {
     expect(output).toContain('confirmation_required');
   });
 
-  test('does not call SDK when confirmation_required error is raised', async () => {
+  it('does not call SDK when confirmation_required error is raised', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -113,7 +113,7 @@ describe('topics delete command', () => {
     expect(mockRemove).not.toHaveBeenCalled();
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -131,7 +131,7 @@ describe('topics delete command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with delete_error when SDK returns an error', async () => {
+  it('errors with delete_error when SDK returns an error', async () => {
     setNonInteractive();
     mockRemove.mockResolvedValueOnce(
       mockSdkError('Topic not found', 'not_found'),

--- a/tests/commands/topics/get.test.ts
+++ b/tests/commands/topics/get.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -57,7 +57,7 @@ describe('topics get command', () => {
     exitSpy = undefined;
   });
 
-  test('calls SDK with the provided topic ID', async () => {
+  it('calls SDK with the provided topic ID', async () => {
     spies = setupOutputSpies();
 
     const { getTopicCommand } = await import(
@@ -69,7 +69,7 @@ describe('topics get command', () => {
     expect(mockGet.mock.calls[0][0]).toBe('top_abc123');
   });
 
-  test('outputs JSON topic data when non-interactive', async () => {
+  it('outputs JSON topic data when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { getTopicCommand } = await import(
@@ -86,7 +86,7 @@ describe('topics get command', () => {
     expect(parsed.created_at).toBe('2026-01-01T00:00:00.000Z');
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -104,7 +104,7 @@ describe('topics get command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with fetch_error when SDK returns an error', async () => {
+  it('errors with fetch_error when SDK returns an error', async () => {
     setNonInteractive();
     mockGet.mockResolvedValueOnce(mockSdkError('Topic not found', 'not_found'));
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/tests/commands/topics/list.test.ts
+++ b/tests/commands/topics/list.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -61,7 +61,7 @@ describe('topics list command', () => {
     exitSpy = undefined;
   });
 
-  test('calls SDK list method', async () => {
+  it('calls SDK list method', async () => {
     spies = setupOutputSpies();
 
     const { listTopicsCommand } = await import(
@@ -72,7 +72,7 @@ describe('topics list command', () => {
     expect(mockList).toHaveBeenCalledTimes(1);
   });
 
-  test('outputs JSON list when non-interactive', async () => {
+  it('outputs JSON list when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { listTopicsCommand } = await import(
@@ -87,7 +87,7 @@ describe('topics list command', () => {
     expect(parsed.data[0].id).toBe('top_abc123');
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -103,7 +103,7 @@ describe('topics list command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with list_error when SDK returns an error', async () => {
+  it('errors with list_error when SDK returns an error', async () => {
     setNonInteractive();
     mockList.mockResolvedValueOnce(
       mockSdkError('Server error', 'server_error'),

--- a/tests/commands/topics/update.test.ts
+++ b/tests/commands/topics/update.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -51,7 +51,7 @@ describe('topics update command', () => {
     exitSpy = undefined;
   });
 
-  test('calls SDK with id and name when --name is provided', async () => {
+  it('calls SDK with id and name when --name is provided', async () => {
     spies = setupOutputSpies();
 
     const { updateTopicCommand } = await import(
@@ -68,7 +68,7 @@ describe('topics update command', () => {
     expect(payload.name).toBe('Security Alerts');
   });
 
-  test('calls SDK with id and description when --description is provided', async () => {
+  it('calls SDK with id and description when --description is provided', async () => {
     spies = setupOutputSpies();
 
     const { updateTopicCommand } = await import(
@@ -85,7 +85,7 @@ describe('topics update command', () => {
     expect(payload.name).toBeUndefined();
   });
 
-  test('outputs JSON with id when non-interactive', async () => {
+  it('outputs JSON with id when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { updateTopicCommand } = await import(
@@ -101,7 +101,7 @@ describe('topics update command', () => {
     expect(parsed.id).toBe('top_abc123');
   });
 
-  test('errors with no_changes when neither --name nor --description provided', async () => {
+  it('errors with no_changes when neither --name nor --description provided', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -117,7 +117,7 @@ describe('topics update command', () => {
     expect(output).toContain('no_changes');
   });
 
-  test('does not call SDK when no_changes error is raised', async () => {
+  it('does not call SDK when no_changes error is raised', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -132,7 +132,7 @@ describe('topics update command', () => {
     expect(mockUpdate).not.toHaveBeenCalled();
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -152,7 +152,7 @@ describe('topics update command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with update_error when SDK returns an error', async () => {
+  it('errors with update_error when SDK returns an error', async () => {
     setNonInteractive();
     mockUpdate.mockResolvedValueOnce(
       mockSdkError('Topic not found', 'not_found'),

--- a/tests/commands/webhooks/create.test.ts
+++ b/tests/commands/webhooks/create.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -60,7 +60,7 @@ describe('webhooks create command', () => {
     }
   });
 
-  test('creates webhook with --endpoint and explicit --events', async () => {
+  it('creates webhook with --endpoint and explicit --events', async () => {
     spies = setupOutputSpies();
 
     const { createWebhookCommand } = await import(
@@ -83,7 +83,7 @@ describe('webhooks create command', () => {
     expect(args.events).toEqual(['email.sent', 'email.bounced']);
   });
 
-  test('expands "all" shorthand to all 17 events', async () => {
+  it('expands "all" shorthand to all 17 events', async () => {
     spies = setupOutputSpies();
 
     const { createWebhookCommand } = await import(
@@ -101,7 +101,7 @@ describe('webhooks create command', () => {
     expect(args.events).toContain('domain.deleted');
   });
 
-  test('outputs JSON with id and signing_secret when non-interactive', async () => {
+  it('outputs JSON with id and signing_secret when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { createWebhookCommand } = await import(
@@ -118,7 +118,7 @@ describe('webhooks create command', () => {
     expect(parsed.signing_secret).toBe('whsec_test1234');
   });
 
-  test('splits comma-separated events', async () => {
+  it('splits comma-separated events', async () => {
     spies = setupOutputSpies();
 
     const { createWebhookCommand } = await import(
@@ -139,7 +139,7 @@ describe('webhooks create command', () => {
     expect(args.events).toEqual(['email.sent', 'email.bounced']);
   });
 
-  test('handles mixed comma and space-separated events', async () => {
+  it('handles mixed comma and space-separated events', async () => {
     spies = setupOutputSpies();
 
     const { createWebhookCommand } = await import(
@@ -165,7 +165,7 @@ describe('webhooks create command', () => {
     ]);
   });
 
-  test('trims spaces around comma-separated events', async () => {
+  it('trims spaces around comma-separated events', async () => {
     spies = setupOutputSpies();
 
     const { createWebhookCommand } = await import(
@@ -186,7 +186,7 @@ describe('webhooks create command', () => {
     expect(args.events).toEqual(['email.sent', 'email.bounced']);
   });
 
-  test('errors with missing_endpoint in non-interactive mode when --endpoint absent', async () => {
+  it('errors with missing_endpoint in non-interactive mode when --endpoint absent', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -204,7 +204,7 @@ describe('webhooks create command', () => {
     expect(output).toContain('missing_endpoint');
   });
 
-  test('errors with missing_events in non-interactive mode when --events absent', async () => {
+  it('errors with missing_events in non-interactive mode when --events absent', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -223,7 +223,7 @@ describe('webhooks create command', () => {
     expect(output).toContain('missing_events');
   });
 
-  test('errors with missing_events when --json is set even in TTY', async () => {
+  it('errors with missing_events when --json is set even in TTY', async () => {
     Object.defineProperty(process.stdin, 'isTTY', {
       value: true,
       writable: true,
@@ -259,7 +259,7 @@ describe('webhooks create command', () => {
     expect(output).toContain('missing_events');
   });
 
-  test('does not call SDK when missing_endpoint error is raised', async () => {
+  it('does not call SDK when missing_endpoint error is raised', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -276,7 +276,7 @@ describe('webhooks create command', () => {
     expect(mockCreate).not.toHaveBeenCalled();
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -302,7 +302,7 @@ describe('webhooks create command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with create_error when SDK returns an error', async () => {
+  it('errors with create_error when SDK returns an error', async () => {
     setNonInteractive();
     mockCreate.mockResolvedValueOnce(
       mockSdkError('Invalid endpoint', 'validation_error'),

--- a/tests/commands/webhooks/delete.test.ts
+++ b/tests/commands/webhooks/delete.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -51,7 +51,7 @@ describe('webhooks delete command', () => {
     exitSpy = undefined;
   });
 
-  test('deletes webhook with --yes flag', async () => {
+  it('deletes webhook with --yes flag', async () => {
     spies = setupOutputSpies();
 
     const { deleteWebhookCommand } = await import(
@@ -65,7 +65,7 @@ describe('webhooks delete command', () => {
     expect(mockRemove.mock.calls[0][0]).toBe('wh_abc123');
   });
 
-  test('outputs synthesized JSON result when non-interactive', async () => {
+  it('outputs synthesized JSON result when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { deleteWebhookCommand } = await import(
@@ -82,7 +82,7 @@ describe('webhooks delete command', () => {
     expect(parsed.deleted).toBe(true);
   });
 
-  test('errors with confirmation_required when --yes absent in non-interactive mode', async () => {
+  it('errors with confirmation_required when --yes absent in non-interactive mode', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -98,7 +98,7 @@ describe('webhooks delete command', () => {
     expect(output).toContain('confirmation_required');
   });
 
-  test('does not call SDK when confirmation_required error is raised', async () => {
+  it('does not call SDK when confirmation_required error is raised', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -113,7 +113,7 @@ describe('webhooks delete command', () => {
     expect(mockRemove).not.toHaveBeenCalled();
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -131,7 +131,7 @@ describe('webhooks delete command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with delete_error when SDK returns an error', async () => {
+  it('errors with delete_error when SDK returns an error', async () => {
     setNonInteractive();
     mockRemove.mockResolvedValueOnce(
       mockSdkError('Webhook not found', 'not_found'),

--- a/tests/commands/webhooks/get.test.ts
+++ b/tests/commands/webhooks/get.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -59,7 +59,7 @@ describe('webhooks get command', () => {
     exitSpy = undefined;
   });
 
-  test('calls SDK get with the provided id', async () => {
+  it('calls SDK get with the provided id', async () => {
     spies = setupOutputSpies();
 
     const { getWebhookCommand } = await import(
@@ -71,7 +71,7 @@ describe('webhooks get command', () => {
     expect(mockGet.mock.calls[0][0]).toBe('wh_abc123');
   });
 
-  test('outputs JSON with webhook fields when non-interactive', async () => {
+  it('outputs JSON with webhook fields when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { getWebhookCommand } = await import(
@@ -86,7 +86,7 @@ describe('webhooks get command', () => {
     expect(parsed.status).toBe('enabled');
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -104,7 +104,7 @@ describe('webhooks get command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with fetch_error when SDK returns an error', async () => {
+  it('errors with fetch_error when SDK returns an error', async () => {
     setNonInteractive();
     mockGet.mockResolvedValueOnce(mockSdkError('Not found', 'not_found'));
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/tests/commands/webhooks/list.test.ts
+++ b/tests/commands/webhooks/list.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -63,7 +63,7 @@ describe('webhooks list command', () => {
     exitSpy = undefined;
   });
 
-  test('calls SDK list method with default pagination', async () => {
+  it('calls SDK list method with default pagination', async () => {
     spies = setupOutputSpies();
 
     const { listWebhooksCommand } = await import(
@@ -76,7 +76,7 @@ describe('webhooks list command', () => {
     expect(args.limit).toBe(10);
   });
 
-  test('passes --limit to pagination options', async () => {
+  it('passes --limit to pagination options', async () => {
     spies = setupOutputSpies();
 
     const { listWebhooksCommand } = await import(
@@ -88,7 +88,7 @@ describe('webhooks list command', () => {
     expect(args.limit).toBe(5);
   });
 
-  test('passes --after cursor to pagination options', async () => {
+  it('passes --after cursor to pagination options', async () => {
     spies = setupOutputSpies();
 
     const { listWebhooksCommand } = await import(
@@ -102,7 +102,7 @@ describe('webhooks list command', () => {
     expect(args.after).toBe('wh_cursor123');
   });
 
-  test('outputs JSON list with webhook data when non-interactive', async () => {
+  it('outputs JSON list with webhook data when non-interactive', async () => {
     spies = setupOutputSpies();
 
     const { listWebhooksCommand } = await import(
@@ -120,7 +120,7 @@ describe('webhooks list command', () => {
     expect(parsed.has_more).toBe(false);
   });
 
-  test('errors with invalid_limit for out-of-range limit', async () => {
+  it('errors with invalid_limit for out-of-range limit', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -136,7 +136,7 @@ describe('webhooks list command', () => {
     expect(output).toContain('invalid_limit');
   });
 
-  test('errors with auth_error when no API key', async () => {
+  it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
@@ -154,7 +154,7 @@ describe('webhooks list command', () => {
     expect(output).toContain('auth_error');
   });
 
-  test('errors with list_error when SDK returns an error', async () => {
+  it('errors with list_error when SDK returns an error', async () => {
     setNonInteractive();
     mockList.mockResolvedValueOnce(
       mockSdkError('Server error', 'server_error'),

--- a/tests/commands/whoami.test.ts
+++ b/tests/commands/whoami.test.ts
@@ -6,8 +6,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -46,7 +46,7 @@ describe('whoami command', () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  test('exits 1 when not authenticated (non-interactive)', async () => {
+  it('exits 1 when not authenticated (non-interactive)', async () => {
     spies = setupOutputSpies();
     exitSpy = mockExitThrow();
 
@@ -60,7 +60,7 @@ describe('whoami command', () => {
     }
   });
 
-  test('shows authenticated JSON when key exists in config', async () => {
+  it('shows authenticated JSON when key exists in config', async () => {
     const configDir = join(tmpDir, 'resend');
     mkdirSync(configDir, { recursive: true });
     writeFileSync(
@@ -85,7 +85,7 @@ describe('whoami command', () => {
     expect(parsed.config_path).toBe(join(tmpDir, 'resend', 'credentials.json'));
   });
 
-  test('shows env source when RESEND_API_KEY is set', async () => {
+  it('shows env source when RESEND_API_KEY is set', async () => {
     process.env.RESEND_API_KEY = 're_env_key_5678';
 
     spies = setupOutputSpies();
@@ -100,7 +100,7 @@ describe('whoami command', () => {
     expect(parsed.config_path).toBe(join(tmpDir, 'resend', 'credentials.json'));
   });
 
-  test('shows authenticated for keychain user (async resolve)', async () => {
+  it('shows authenticated for keychain user (async resolve)', async () => {
     const configDir = join(tmpDir, 'resend');
     mkdirSync(configDir, { recursive: true });
     writeFileSync(
@@ -141,7 +141,7 @@ describe('whoami command', () => {
     expect(parsed.config_path).toBe(join(tmpDir, 'resend', 'credentials.json'));
   });
 
-  test('shows permission in JSON output when stored', async () => {
+  it('shows permission in JSON output when stored', async () => {
     const configDir = join(tmpDir, 'resend');
     mkdirSync(configDir, { recursive: true });
     writeFileSync(
@@ -168,7 +168,7 @@ describe('whoami command', () => {
     expect(parsed.permission).toBe('sending_access');
   });
 
-  test('omits permission from JSON when not stored', async () => {
+  it('omits permission from JSON when not stored', async () => {
     const configDir = join(tmpDir, 'resend');
     mkdirSync(configDir, { recursive: true });
     writeFileSync(

--- a/tests/e2e/smoke.test.ts
+++ b/tests/e2e/smoke.test.ts
@@ -14,7 +14,7 @@
 
 import { execFileSync } from 'node:child_process';
 import { resolve } from 'node:path';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 const CLI = resolve(import.meta.dirname, '../../src/cli.ts');
 
@@ -42,7 +42,7 @@ function parseJson(stdout: string): unknown {
 }
 
 describe('e2e smoke', () => {
-  test('doctor reports check results', () => {
+  it('doctor reports check results', () => {
     const { stdout } = run('doctor');
     const data = parseJson(stdout) as { checks: unknown[] };
     expect(data.checks).toBeInstanceOf(Array);
@@ -51,7 +51,7 @@ describe('e2e smoke', () => {
     expect(data).toHaveProperty('ok');
   });
 
-  test('domains list returns valid json', () => {
+  it('domains list returns valid json', () => {
     const { stdout, exitCode } = run('domains', 'list');
     expect(exitCode).toBe(0);
     const data = parseJson(stdout) as { object: string; data: unknown[] };
@@ -59,7 +59,7 @@ describe('e2e smoke', () => {
     expect(data.data).toBeInstanceOf(Array);
   });
 
-  test('api-keys list returns valid json', () => {
+  it('api-keys list returns valid json', () => {
     const { stdout, exitCode } = run('api-keys', 'list');
     expect(exitCode).toBe(0);
     const data = parseJson(stdout) as { object: string; data: unknown[] };
@@ -67,7 +67,7 @@ describe('e2e smoke', () => {
     expect(data.data).toBeInstanceOf(Array);
   });
 
-  test('broadcasts list returns valid json', () => {
+  it('broadcasts list returns valid json', () => {
     const { stdout, exitCode } = run('broadcasts', 'list');
     expect(exitCode).toBe(0);
     const data = parseJson(stdout) as { object: string; data: unknown[] };
@@ -75,7 +75,7 @@ describe('e2e smoke', () => {
     expect(data.data).toBeInstanceOf(Array);
   });
 
-  test('webhooks list returns valid json', () => {
+  it('webhooks list returns valid json', () => {
     const { stdout, exitCode } = run('webhooks', 'list');
     expect(exitCode).toBe(0);
     const data = parseJson(stdout) as { object: string; data: unknown[] };
@@ -83,7 +83,7 @@ describe('e2e smoke', () => {
     expect(data.data).toBeInstanceOf(Array);
   });
 
-  test('topics list returns valid json', () => {
+  it('topics list returns valid json', () => {
     const { stdout, exitCode } = run('topics', 'list');
     expect(exitCode).toBe(0);
     const data = parseJson(stdout) as { object: string; data: unknown[] };

--- a/tests/lib/client.test.ts
+++ b/tests/lib/client.test.ts
@@ -7,8 +7,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -25,7 +25,7 @@ describe('createClient', () => {
     restoreEnv();
   });
 
-  test('returns Resend instance when flag value provided', async () => {
+  it('returns Resend instance when flag value provided', async () => {
     // Force file backend so tests don't interact with real OS keychain
     process.env.RESEND_CREDENTIAL_STORE = 'file';
     const { createClient } = await import('../../src/lib/client');
@@ -33,7 +33,7 @@ describe('createClient', () => {
     expect(client).toBeInstanceOf(Resend);
   });
 
-  test('returns Resend instance when env var set', async () => {
+  it('returns Resend instance when env var set', async () => {
     process.env.RESEND_API_KEY = 're_env_key';
     process.env.RESEND_CREDENTIAL_STORE = 'file';
     const { createClient } = await import('../../src/lib/client');
@@ -41,7 +41,7 @@ describe('createClient', () => {
     expect(client).toBeInstanceOf(Resend);
   });
 
-  test('throws when no API key available', async () => {
+  it('throws when no API key available', async () => {
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend-test';
     process.env.RESEND_CREDENTIAL_STORE = 'file';
@@ -49,7 +49,7 @@ describe('createClient', () => {
     await expect(createClient()).rejects.toThrow('No API key found');
   });
 
-  test('flag value takes priority over env var', async () => {
+  it('flag value takes priority over env var', async () => {
     process.env.RESEND_API_KEY = 're_env_key';
     process.env.RESEND_CREDENTIAL_STORE = 'file';
     const { createClient } = await import('../../src/lib/client');
@@ -57,7 +57,7 @@ describe('createClient', () => {
     expect(client).toBeInstanceOf(Resend);
   });
 
-  test('profile name is threaded through to resolveApiKey', async () => {
+  it('profile name is threaded through to resolveApiKey', async () => {
     delete process.env.RESEND_API_KEY;
     process.env.RESEND_CREDENTIAL_STORE = 'file';
     const tmpDir = join(
@@ -112,7 +112,7 @@ describe('requireClient permission check', () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  test('blocks sending_access key from full_access command', async () => {
+  it('blocks sending_access key from full_access command', async () => {
     const configDir = join(tmpDir, 'resend');
     mkdirSync(configDir, { recursive: true });
     writeFileSync(
@@ -138,7 +138,7 @@ describe('requireClient permission check', () => {
     errSpy.mockRestore();
   });
 
-  test('allows sending_access key for sending_access command', async () => {
+  it('allows sending_access key for sending_access command', async () => {
     const configDir = join(tmpDir, 'resend');
     mkdirSync(configDir, { recursive: true });
     writeFileSync(
@@ -156,7 +156,7 @@ describe('requireClient permission check', () => {
     expect(client).toBeInstanceOf(Resend);
   });
 
-  test('allows full_access key for any command', async () => {
+  it('allows full_access key for any command', async () => {
     const configDir = join(tmpDir, 'resend');
     mkdirSync(configDir, { recursive: true });
     writeFileSync(
@@ -174,7 +174,7 @@ describe('requireClient permission check', () => {
     expect(client).toBeInstanceOf(Resend);
   });
 
-  test('skips permission check when permission is not stored', async () => {
+  it('skips permission check when permission is not stored', async () => {
     const configDir = join(tmpDir, 'resend');
     mkdirSync(configDir, { recursive: true });
     writeFileSync(

--- a/tests/lib/config.test.ts
+++ b/tests/lib/config.test.ts
@@ -7,7 +7,7 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   getConfigDir,
   listProfiles,
@@ -29,12 +29,12 @@ describe('getConfigDir', () => {
     restoreEnv();
   });
 
-  test('respects XDG_CONFIG_HOME', () => {
+  it('respects XDG_CONFIG_HOME', () => {
     process.env.XDG_CONFIG_HOME = '/custom/config';
     expect(getConfigDir()).toBe('/custom/config/resend');
   });
 
-  test('falls back to ~/.config/resend on non-Windows', () => {
+  it('falls back to ~/.config/resend on non-Windows', () => {
     delete process.env.XDG_CONFIG_HOME;
     const dir = getConfigDir();
     expect(dir).toMatch(/\.config\/resend$/);
@@ -58,19 +58,19 @@ describe('resolveApiKey', () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  test('flag value takes highest priority', () => {
+  it('flag value takes highest priority', () => {
     process.env.RESEND_API_KEY = 're_env_key';
     const result = resolveApiKey('re_flag_key');
     expect(result).toEqual({ key: 're_flag_key', source: 'flag' });
   });
 
-  test('env var is second priority', () => {
+  it('env var is second priority', () => {
     process.env.RESEND_API_KEY = 're_env_key';
     const result = resolveApiKey();
     expect(result).toEqual({ key: 're_env_key', source: 'env' });
   });
 
-  test('config file is third priority (new format)', () => {
+  it('config file is third priority (new format)', () => {
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = tmpDir;
     const configDir = join(tmpDir, 'resend');
@@ -91,7 +91,7 @@ describe('resolveApiKey', () => {
     });
   });
 
-  test('config file is third priority (legacy teams format)', () => {
+  it('config file is third priority (legacy teams format)', () => {
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = tmpDir;
     const configDir = join(tmpDir, 'resend');
@@ -112,7 +112,7 @@ describe('resolveApiKey', () => {
     });
   });
 
-  test('reads legacy format (api_key at root)', () => {
+  it('reads legacy format (api_key at root)', () => {
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = tmpDir;
     const configDir = join(tmpDir, 'resend');
@@ -130,7 +130,7 @@ describe('resolveApiKey', () => {
     });
   });
 
-  test('resolves specific profile from config', () => {
+  it('resolves specific profile from config', () => {
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = tmpDir;
     const configDir = join(tmpDir, 'resend');
@@ -154,14 +154,14 @@ describe('resolveApiKey', () => {
     });
   });
 
-  test('returns null when no key found', () => {
+  it('returns null when no key found', () => {
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = tmpDir;
     const result = resolveApiKey();
     expect(result).toBeNull();
   });
 
-  test('returns null on malformed config JSON', () => {
+  it('returns null on malformed config JSON', () => {
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = tmpDir;
     const configDir = join(tmpDir, 'resend');
@@ -172,7 +172,7 @@ describe('resolveApiKey', () => {
     expect(result).toBeNull();
   });
 
-  test('returns null when profile does not exist in config', () => {
+  it('returns null when profile does not exist in config', () => {
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = tmpDir;
     const configDir = join(tmpDir, 'resend');
@@ -208,23 +208,23 @@ describe('resolveProfileName', () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  test('flag value takes highest priority', () => {
+  it('flag value takes highest priority', () => {
     process.env.RESEND_PROFILE = 'env_profile';
     expect(resolveProfileName('flag_profile')).toBe('flag_profile');
   });
 
-  test('RESEND_PROFILE env var is second priority', () => {
+  it('RESEND_PROFILE env var is second priority', () => {
     process.env.RESEND_PROFILE = 'env_profile';
     expect(resolveProfileName()).toBe('env_profile');
   });
 
-  test('RESEND_TEAM env var is fallback for RESEND_PROFILE', () => {
+  it('RESEND_TEAM env var is fallback for RESEND_PROFILE', () => {
     delete process.env.RESEND_PROFILE;
     process.env.RESEND_TEAM = 'env_team';
     expect(resolveProfileName()).toBe('env_team');
   });
 
-  test('active_profile from config is third priority', () => {
+  it('active_profile from config is third priority', () => {
     delete process.env.RESEND_PROFILE;
     delete process.env.RESEND_TEAM;
     const configDir = join(tmpDir, 'resend');
@@ -240,7 +240,7 @@ describe('resolveProfileName', () => {
     expect(resolveProfileName()).toBe('production');
   });
 
-  test('defaults to "default" when nothing configured', () => {
+  it('defaults to "default" when nothing configured', () => {
     delete process.env.RESEND_PROFILE;
     delete process.env.RESEND_TEAM;
     expect(resolveProfileName()).toBe('default');
@@ -264,7 +264,7 @@ describe('storeApiKey', () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  test('writes credentials.json with profile structure', () => {
+  it('writes credentials.json with profile structure', () => {
     const configPath = storeApiKey('re_test_key_123');
     expect(configPath).toContain('credentials.json');
 
@@ -273,13 +273,13 @@ describe('storeApiKey', () => {
     expect(data.profiles.default.api_key).toBe('re_test_key_123');
   });
 
-  test('stores key under specific profile name', () => {
+  it('stores key under specific profile name', () => {
     const configPath = storeApiKey('re_staging_key', 'staging');
     const data = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(data.profiles.staging.api_key).toBe('re_staging_key');
   });
 
-  test('preserves existing profiles when adding new one', () => {
+  it('preserves existing profiles when adding new one', () => {
     storeApiKey('re_default_key');
     storeApiKey('re_staging_key', 'staging');
 
@@ -289,21 +289,21 @@ describe('storeApiKey', () => {
     expect(data.profiles.staging.api_key).toBe('re_staging_key');
   });
 
-  test('creates config directory if it does not exist', () => {
+  it('creates config directory if it does not exist', () => {
     storeApiKey('re_test_key');
     const configDir = join(tmpDir, 'resend');
     const stat = statSync(configDir);
     expect(stat.isDirectory()).toBe(true);
   });
 
-  test('sets file permissions to 0600', () => {
+  it('sets file permissions to 0600', () => {
     const configPath = storeApiKey('re_test_key');
     const stat = statSync(configPath);
     const mode = stat.mode & 0o777;
     expect(mode).toBe(0o600);
   });
 
-  test('overwrites existing profile key', () => {
+  it('overwrites existing profile key', () => {
     storeApiKey('re_first_key');
     storeApiKey('re_second_key');
 
@@ -312,7 +312,7 @@ describe('storeApiKey', () => {
     expect(data.profiles.default.api_key).toBe('re_second_key');
   });
 
-  test('sets first profile as active', () => {
+  it('sets first profile as active', () => {
     storeApiKey('re_first_key', 'myprofile');
 
     const configPath = join(tmpDir, 'resend', 'credentials.json');
@@ -338,11 +338,11 @@ describe('listProfiles', () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  test('returns empty array when no config', () => {
+  it('returns empty array when no config', () => {
     expect(listProfiles()).toEqual([]);
   });
 
-  test('returns profiles with active flag', () => {
+  it('returns profiles with active flag', () => {
     storeApiKey('re_default', 'default');
     storeApiKey('re_staging', 'staging');
 
@@ -371,7 +371,7 @@ describe('setActiveProfile', () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  test('switches active profile', () => {
+  it('switches active profile', () => {
     storeApiKey('re_default', 'default');
     storeApiKey('re_staging', 'staging');
 
@@ -382,12 +382,12 @@ describe('setActiveProfile', () => {
     expect(data.active_profile).toBe('staging');
   });
 
-  test('throws when profile does not exist', () => {
+  it('throws when profile does not exist', () => {
     storeApiKey('re_default');
     expect(() => setActiveProfile('nonexistent')).toThrow('not found');
   });
 
-  test('throws when no credentials file', () => {
+  it('throws when no credentials file', () => {
     expect(() => setActiveProfile('any')).toThrow('No credentials file');
   });
 });
@@ -409,7 +409,7 @@ describe('removeApiKey', () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  test('removes a profile entry', () => {
+  it('removes a profile entry', () => {
     storeApiKey('re_default', 'default');
     storeApiKey('re_staging', 'staging');
 
@@ -419,7 +419,7 @@ describe('removeApiKey', () => {
     expect(profiles).toEqual([{ name: 'default', active: true }]);
   });
 
-  test('adjusts active_profile when active is removed', () => {
+  it('adjusts active_profile when active is removed', () => {
     storeApiKey('re_default', 'default');
     storeApiKey('re_staging', 'staging');
     setActiveProfile('staging');
@@ -431,7 +431,7 @@ describe('removeApiKey', () => {
     expect(data.active_profile).toBe('default');
   });
 
-  test('deletes file when last profile removed', () => {
+  it('deletes file when last profile removed', () => {
     storeApiKey('re_only', 'only');
 
     removeApiKey('only');
@@ -441,12 +441,12 @@ describe('removeApiKey', () => {
     expect(existsSync(configPath)).toBe(false);
   });
 
-  test('throws when profile does not exist', () => {
+  it('throws when profile does not exist', () => {
     storeApiKey('re_default');
     expect(() => removeApiKey('nonexistent')).toThrow('not found');
   });
 
-  test('throws when no credentials file', () => {
+  it('throws when no credentials file', () => {
     expect(() => removeApiKey('any')).toThrow('No credentials file');
   });
 });
@@ -468,7 +468,7 @@ describe('renameProfile', () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  test('renames a profile and preserves its API key', () => {
+  it('renames a profile and preserves its API key', () => {
     storeApiKey('re_key', 'old-name');
 
     renameProfile('old-name', 'new-name');
@@ -479,7 +479,7 @@ describe('renameProfile', () => {
     expect(resolved?.key).toBe('re_key');
   });
 
-  test('updates active_profile when renaming the active profile', () => {
+  it('updates active_profile when renaming the active profile', () => {
     storeApiKey('re_a', 'alpha');
     storeApiKey('re_b', 'beta');
     setActiveProfile('beta');
@@ -491,7 +491,7 @@ describe('renameProfile', () => {
     expect(data.active_profile).toBe('gamma');
   });
 
-  test('does not change active_profile when renaming a non-active profile', () => {
+  it('does not change active_profile when renaming a non-active profile', () => {
     storeApiKey('re_a', 'alpha');
     storeApiKey('re_b', 'beta');
 
@@ -502,7 +502,7 @@ describe('renameProfile', () => {
     expect(data.active_profile).toBe('alpha');
   });
 
-  test('renames a legacy profile with spaces', () => {
+  it('renames a legacy profile with spaces', () => {
     // Simulate a legacy profile created before validation was added
     writeCredentials({
       active_profile: 'my team',
@@ -517,29 +517,29 @@ describe('renameProfile', () => {
     expect(resolved?.key).toBe('re_legacy');
   });
 
-  test('throws when new name is invalid', () => {
+  it('throws when new name is invalid', () => {
     storeApiKey('re_key', 'valid');
     expect(() => renameProfile('valid', 'has spaces')).toThrow('letters');
   });
 
-  test('throws when old profile does not exist', () => {
+  it('throws when old profile does not exist', () => {
     storeApiKey('re_key', 'exists');
     expect(() => renameProfile('nope', 'new-name')).toThrow('not found');
   });
 
-  test('throws when new name already exists', () => {
+  it('throws when new name already exists', () => {
     storeApiKey('re_a', 'alpha');
     storeApiKey('re_b', 'beta');
     expect(() => renameProfile('alpha', 'beta')).toThrow('already exists');
   });
 
-  test('throws when no credentials file', () => {
+  it('throws when no credentials file', () => {
     expect(() => renameProfile('any', 'new')).toThrow('No credentials file');
   });
 });
 
 describe('validateProfileName', () => {
-  test('accepts valid names', () => {
+  it('accepts valid names', () => {
     expect(validateProfileName('default')).toBeUndefined();
     expect(validateProfileName('my-profile')).toBeUndefined();
     expect(validateProfileName('profile_1')).toBeUndefined();
@@ -550,21 +550,21 @@ describe('validateProfileName', () => {
     expect(validateProfileName('my.profile')).toBeUndefined();
   });
 
-  test('rejects spaces and special characters', () => {
+  it('rejects spaces and special characters', () => {
     expect(validateProfileName('my profile')).toContain('dots');
     expect(validateProfileName('profile@org')).toContain('dots');
   });
 
-  test('rejects empty name', () => {
+  it('rejects empty name', () => {
     expect(validateProfileName('')).toContain('empty');
   });
 
-  test('rejects names longer than 64 characters', () => {
+  it('rejects names longer than 64 characters', () => {
     const longName = 'a'.repeat(65);
     expect(validateProfileName(longName)).toContain('64');
   });
 
-  test('accepts name exactly 64 characters', () => {
+  it('accepts name exactly 64 characters', () => {
     const maxName = 'a'.repeat(64);
     expect(validateProfileName(maxName)).toBeUndefined();
   });

--- a/tests/lib/credential-backends/windows.test.ts
+++ b/tests/lib/credential-backends/windows.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // We mock child_process to verify stdin usage without requiring Windows
 vi.mock('node:child_process', () => {
@@ -45,7 +45,7 @@ describe('WindowsBackend', () => {
     vi.clearAllMocks();
   });
 
-  test('set() passes secret via stdin, NOT in PowerShell script args', async () => {
+  it('set() passes secret via stdin, NOT in PowerShell script args', async () => {
     const { spawn } = await import('node:child_process');
     const { WindowsBackend } = await import(
       '../../../src/lib/credential-backends/windows'
@@ -71,7 +71,7 @@ describe('WindowsBackend', () => {
     expect(mockChild.stdin.write).toHaveBeenCalledWith('re_secret_key_1234');
   });
 
-  test('get() does not use stdin', async () => {
+  it('get() does not use stdin', async () => {
     const { execFile } = await import('node:child_process');
     const { WindowsBackend } = await import(
       '../../../src/lib/credential-backends/windows'

--- a/tests/lib/files.test.ts
+++ b/tests/lib/files.test.ts
@@ -1,14 +1,7 @@
 import { unlinkSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import {
-  afterEach,
-  describe,
-  expect,
-  type MockInstance,
-  test,
-  vi,
-} from 'vitest';
+import { afterEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 import { expectExit1, mockExitThrow } from '../helpers';
 
 const globalOpts = { json: false, apiKey: undefined };
@@ -31,21 +24,21 @@ describe('readFile', () => {
     }
   });
 
-  test('reads file content and returns it as a string', async () => {
+  it('reads file content and returns it as a string', async () => {
     writeFileSync(tmpFile, '<h1>Hello</h1>', 'utf-8');
     const { readFile } = await import('../../src/lib/files');
     const content = readFile(tmpFile, globalOpts);
     expect(content).toBe('<h1>Hello</h1>');
   });
 
-  test('reads JSON file content and returns it as a string', async () => {
+  it('reads JSON file content and returns it as a string', async () => {
     writeFileSync(tmpFile, '[{"id":1}]', 'utf-8');
     const { readFile } = await import('../../src/lib/files');
     const content = readFile(tmpFile, globalOpts);
     expect(content).toBe('[{"id":1}]');
   });
 
-  test('exits with file_read_error when file does not exist', async () => {
+  it('exits with file_read_error when file does not exist', async () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
@@ -58,7 +51,7 @@ describe('readFile', () => {
     expect(output).toContain('Failed to read file:');
   });
 
-  test('outputs JSON error with file_read_error code when json option is true', async () => {
+  it('outputs JSON error with file_read_error code when json option is true', async () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 

--- a/tests/lib/logo.test.ts
+++ b/tests/lib/logo.test.ts
@@ -1,11 +1,4 @@
-import {
-  afterEach,
-  describe,
-  expect,
-  type MockInstance,
-  test,
-  vi,
-} from 'vitest';
+import { afterEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 import { printBannerPlain } from '../../src/lib/logo';
 
 describe('printBannerPlain', () => {
@@ -15,7 +8,7 @@ describe('printBannerPlain', () => {
     writeSpy?.mockRestore();
   });
 
-  test('writes ASCII logo to stdout', () => {
+  it('writes ASCII logo to stdout', () => {
     const chunks: string[] = [];
     writeSpy = vi
       .spyOn(process.stdout, 'write')

--- a/tests/lib/output.test.ts
+++ b/tests/lib/output.test.ts
@@ -1,11 +1,4 @@
-import {
-  afterEach,
-  describe,
-  expect,
-  type MockInstance,
-  test,
-  vi,
-} from 'vitest';
+import { afterEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 import { outputError, outputResult } from '../../src/lib/output';
 
 describe('outputResult', () => {
@@ -20,13 +13,13 @@ describe('outputResult', () => {
     });
   });
 
-  test('outputs JSON when json option is true', () => {
+  it('outputs JSON when json option is true', () => {
     logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     outputResult({ id: '123' }, { json: true });
     expect(logSpy).toHaveBeenCalledWith(JSON.stringify({ id: '123' }, null, 2));
   });
 
-  test('outputs JSON when stdout is not TTY', () => {
+  it('outputs JSON when stdout is not TTY', () => {
     Object.defineProperty(process.stdout, 'isTTY', {
       value: undefined,
       writable: true,
@@ -36,7 +29,7 @@ describe('outputResult', () => {
     expect(logSpy).toHaveBeenCalledWith(JSON.stringify({ id: '123' }, null, 2));
   });
 
-  test('outputs string directly for human-readable mode', () => {
+  it('outputs string directly for human-readable mode', () => {
     Object.defineProperty(process.stdout, 'isTTY', {
       value: true,
       writable: true,
@@ -46,7 +39,7 @@ describe('outputResult', () => {
     expect(logSpy).toHaveBeenCalledWith('Email sent successfully');
   });
 
-  test('outputs JSON for objects in human mode (fallback)', () => {
+  it('outputs JSON for objects in human mode (fallback)', () => {
     Object.defineProperty(process.stdout, 'isTTY', {
       value: true,
       writable: true,
@@ -71,7 +64,7 @@ describe('outputError', () => {
     });
   });
 
-  test('outputs JSON error to stderr when json is true', () => {
+  it('outputs JSON error to stderr when json is true', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = vi
       .spyOn(process, 'exit')
@@ -88,7 +81,7 @@ describe('outputError', () => {
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
-  test('outputs text error when TTY and no json flag', () => {
+  it('outputs text error when TTY and no json flag', () => {
     Object.defineProperty(process.stdout, 'isTTY', {
       value: true,
       writable: true,
@@ -106,7 +99,7 @@ describe('outputError', () => {
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
-  test('uses custom exit code', () => {
+  it('uses custom exit code', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = vi
       .spyOn(process, 'exit')
@@ -117,7 +110,7 @@ describe('outputError', () => {
     expect(exitSpy).toHaveBeenCalledWith(2);
   });
 
-  test('defaults error code to "unknown" when not provided', () => {
+  it('defaults error code to "unknown" when not provided', () => {
     Object.defineProperty(process.stdout, 'isTTY', {
       value: undefined,
       writable: true,

--- a/tests/lib/pagination.test.ts
+++ b/tests/lib/pagination.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import type { GlobalOpts } from '../../src/lib/client';
@@ -29,13 +29,13 @@ describe('buildPaginationOpts', () => {
 
   const globalOpts = {} as GlobalOpts;
 
-  test('returns limit only when no cursors are provided', () => {
+  it('returns limit only when no cursors are provided', () => {
     expect(buildPaginationOpts(10, undefined, undefined, globalOpts)).toEqual({
       limit: 10,
     });
   });
 
-  test('returns after cursor when provided', () => {
+  it('returns after cursor when provided', () => {
     expect(
       buildPaginationOpts(10, 'cursor_after', undefined, globalOpts),
     ).toEqual({
@@ -44,7 +44,7 @@ describe('buildPaginationOpts', () => {
     });
   });
 
-  test('returns before cursor when provided', () => {
+  it('returns before cursor when provided', () => {
     expect(
       buildPaginationOpts(10, undefined, 'cursor_before', globalOpts),
     ).toEqual({
@@ -53,7 +53,7 @@ describe('buildPaginationOpts', () => {
     });
   });
 
-  test('errors when both after and before cursors are provided', () => {
+  it('errors when both after and before cursors are provided', () => {
     setNonInteractive();
     logSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
@@ -78,7 +78,7 @@ describe('printPaginationHint', () => {
     vi.restoreAllMocks();
   });
 
-  test('does not print when has_more is false', () => {
+  it('does not print when has_more is false', () => {
     printPaginationHint(
       { has_more: false, data: [{ id: 'item_1' }] },
       'emails list',
@@ -87,12 +87,12 @@ describe('printPaginationHint', () => {
     expect(logSpy).not.toHaveBeenCalled();
   });
 
-  test('does not print when data is empty', () => {
+  it('does not print when data is empty', () => {
     printPaginationHint({ has_more: true, data: [] }, 'emails list', {});
     expect(logSpy).not.toHaveBeenCalled();
   });
 
-  test('prints forward pagination hint with --after flag', () => {
+  it('prints forward pagination hint with --after flag', () => {
     printPaginationHint(
       {
         has_more: true,
@@ -106,7 +106,7 @@ describe('printPaginationHint', () => {
     );
   });
 
-  test('prints backward pagination hint with --before flag when before is set', () => {
+  it('prints backward pagination hint with --before flag when before is set', () => {
     printPaginationHint(
       {
         has_more: true,
@@ -120,7 +120,7 @@ describe('printPaginationHint', () => {
     );
   });
 
-  test('includes --limit flag when limit is set', () => {
+  it('includes --limit flag when limit is set', () => {
     printPaginationHint(
       { has_more: true, data: [{ id: 'item_1' }] },
       'emails list',
@@ -131,7 +131,7 @@ describe('printPaginationHint', () => {
     );
   });
 
-  test('masks the API key in the hint', () => {
+  it('masks the API key in the hint', () => {
     printPaginationHint(
       { has_more: true, data: [{ id: 'item_1' }] },
       'emails list',
@@ -142,7 +142,7 @@ describe('printPaginationHint', () => {
     expect(output).toContain('--api-key re_...cdef');
   });
 
-  test('includes --profile flag when profile is set', () => {
+  it('includes --profile flag when profile is set', () => {
     printPaginationHint(
       { has_more: true, data: [{ id: 'item_1' }] },
       'emails list',
@@ -153,7 +153,7 @@ describe('printPaginationHint', () => {
     );
   });
 
-  test('includes all flags together', () => {
+  it('includes all flags together', () => {
     printPaginationHint(
       {
         has_more: true,

--- a/tests/lib/prompts.test.ts
+++ b/tests/lib/prompts.test.ts
@@ -1,12 +1,4 @@
-import {
-  afterEach,
-  describe,
-  expect,
-  it,
-  type MockInstance,
-  test,
-  vi,
-} from 'vitest';
+import { afterEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 import { expectExit1, mockExitThrow } from '../helpers';
 
 const originalStdinIsTTY = process.stdin.isTTY;
@@ -44,7 +36,7 @@ afterEach(() => {
 });
 
 describe('promptForMissing', () => {
-  test('returns options unchanged when nothing is missing', async () => {
+  it('returns options unchanged when nothing is missing', async () => {
     const { promptForMissing } = await import('../../src/lib/prompts');
     const opts = { from: 'a@b.com', to: 'c@d.com', subject: 'Hi' };
     const result = await promptForMissing(
@@ -59,7 +51,7 @@ describe('promptForMissing', () => {
     expect(result).toEqual(opts);
   });
 
-  test('exits with missing_flags error in non-interactive mode', async () => {
+  it('exits with missing_flags error in non-interactive mode', async () => {
     setTTY(undefined);
     setupSpies();
 
@@ -83,7 +75,7 @@ describe('promptForMissing', () => {
     expect(spyOutput()).not.toContain('--to,');
   });
 
-  test('errors output includes missing_flags code', async () => {
+  it('errors output includes missing_flags code', async () => {
     setTTY(undefined);
     setupSpies();
 
@@ -100,7 +92,7 @@ describe('promptForMissing', () => {
     expect(spyOutput()).toContain('missing_flags');
   });
 
-  test('exits with missing_flags error when --json is set even in TTY', async () => {
+  it('exits with missing_flags error when --json is set even in TTY', async () => {
     setTTY(true);
     setupSpies();
 
@@ -117,7 +109,7 @@ describe('promptForMissing', () => {
     expect(spyOutput()).toContain('missing_flags');
   });
 
-  test('skips fields marked as required=false', async () => {
+  it('skips fields marked as required=false', async () => {
     const { promptForMissing } = await import('../../src/lib/prompts');
     const opts = { from: 'a@b.com', to: undefined };
     const result = await promptForMissing(
@@ -133,13 +125,13 @@ describe('promptForMissing', () => {
 });
 
 describe('pickId', () => {
-  test('returns id immediately when provided', async () => {
+  it('returns id immediately when provided', async () => {
     const { pickId } = await import('../../src/lib/prompts');
     const result = await pickId('test-id', {} as never, {});
     expect(result).toBe('test-id');
   });
 
-  test('exits with missing_id error in non-interactive mode', async () => {
+  it('exits with missing_id error in non-interactive mode', async () => {
     setTTY(undefined);
     setupSpies();
 
@@ -150,7 +142,7 @@ describe('pickId', () => {
     expect(spyOutput()).toContain('missing_id');
   });
 
-  test('exits with missing_id error when --json is set even in TTY', async () => {
+  it('exits with missing_id error when --json is set even in TTY', async () => {
     setTTY(true);
     setupSpies();
 
@@ -162,7 +154,7 @@ describe('pickId', () => {
     expect(parsed.error.code).toBe('missing_id');
   });
 
-  test('returns undefined in non-interactive mode when optional', async () => {
+  it('returns undefined in non-interactive mode when optional', async () => {
     setTTY(undefined);
 
     const { pickId } = await import('../../src/lib/prompts');
@@ -170,7 +162,7 @@ describe('pickId', () => {
     expect(result).toBeUndefined();
   });
 
-  test('returns undefined when --json is set and optional', async () => {
+  it('returns undefined when --json is set and optional', async () => {
     setTTY(true);
 
     const { pickId } = await import('../../src/lib/prompts');
@@ -183,7 +175,7 @@ describe('pickId', () => {
     expect(result).toBeUndefined();
   });
 
-  test('returns id immediately when provided and optional', async () => {
+  it('returns id immediately when provided and optional', async () => {
     const { pickId } = await import('../../src/lib/prompts');
     const result = await pickId('test-id', {} as never, {}, { optional: true });
     expect(result).toBe('test-id');
@@ -234,7 +226,7 @@ describe('pickItem', () => {
 });
 
 describe('confirmDelete', () => {
-  test('exits with confirmation_required when non-interactive', async () => {
+  it('exits with confirmation_required when non-interactive', async () => {
     setTTY(undefined);
     setupSpies();
 
@@ -247,7 +239,7 @@ describe('confirmDelete', () => {
     expect(spyOutput()).toContain('confirmation_required');
   });
 
-  test('outputs JSON confirmation_required error when json option is true', async () => {
+  it('outputs JSON confirmation_required error when json option is true', async () => {
     setTTY(undefined);
     setupSpies();
 
@@ -260,7 +252,7 @@ describe('confirmDelete', () => {
     expect(parsed.error.code).toBe('confirmation_required');
   });
 
-  test('exits with confirmation_required when --json is set even in TTY', async () => {
+  it('exits with confirmation_required when --json is set even in TTY', async () => {
     setTTY(true);
     setupSpies();
 

--- a/tests/lib/spinner.test.ts
+++ b/tests/lib/spinner.test.ts
@@ -3,8 +3,8 @@ import {
   beforeEach,
   describe,
   expect,
+  it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import { withSpinner } from '../../src/lib/spinner';
@@ -44,7 +44,7 @@ describe('withSpinner retry on rate_limit_exceeded', () => {
     stderrSpy.mockRestore();
   });
 
-  test('retries on rate_limit_exceeded and succeeds', async () => {
+  it('retries on rate_limit_exceeded and succeeds', async () => {
     let calls = 0;
     const call = async () => {
       calls++;
@@ -66,7 +66,7 @@ describe('withSpinner retry on rate_limit_exceeded', () => {
     expect(calls).toBe(2);
   });
 
-  test('exhausts retries and errors after max attempts', async () => {
+  it('exhausts retries and errors after max attempts', async () => {
     let calls = 0;
     const call = async () => {
       calls++;
@@ -93,7 +93,7 @@ describe('withSpinner retry on rate_limit_exceeded', () => {
     expect(calls).toBe(4);
   });
 
-  test('does not retry non-retryable errors', async () => {
+  it('does not retry non-retryable errors', async () => {
     let calls = 0;
     const call = async () => {
       calls++;
@@ -115,7 +115,7 @@ describe('withSpinner retry on rate_limit_exceeded', () => {
     expect(calls).toBe(1);
   });
 
-  test('does not retry daily_quota_exceeded', async () => {
+  it('does not retry daily_quota_exceeded', async () => {
     let calls = 0;
     const call = async () => {
       calls++;
@@ -140,7 +140,7 @@ describe('withSpinner retry on rate_limit_exceeded', () => {
     expect(calls).toBe(1);
   });
 
-  test('uses retry-after header for delay', async () => {
+  it('uses retry-after header for delay', async () => {
     let calls = 0;
     const start = Date.now();
     const call = async () => {
@@ -164,7 +164,7 @@ describe('withSpinner retry on rate_limit_exceeded', () => {
     expect(Date.now() - start).toBeLessThan(500);
   });
 
-  test('falls back to default delay without retry-after', async () => {
+  it('falls back to default delay without retry-after', async () => {
     let calls = 0;
     const call = async () => {
       calls++;
@@ -211,7 +211,7 @@ describe('createSpinner', () => {
     delete process.env.CI;
   });
 
-  test('returns no-op spinner in non-interactive mode', async () => {
+  it('returns no-op spinner in non-interactive mode', async () => {
     Object.defineProperty(process.stdin, 'isTTY', {
       value: undefined,
       writable: true,
@@ -231,7 +231,7 @@ describe('createSpinner', () => {
     expect(() => spinner.update('updating')).not.toThrow();
   });
 
-  test('returns functional spinner in interactive mode', async () => {
+  it('returns functional spinner in interactive mode', async () => {
     Object.defineProperty(process.stdin, 'isTTY', {
       value: true,
       writable: true,
@@ -261,7 +261,7 @@ describe('createSpinner', () => {
     expect(stderrSpy).toHaveBeenCalled();
   });
 
-  test('stop writes checkmark to stderr', async () => {
+  it('stop writes checkmark to stderr', async () => {
     Object.defineProperty(process.stdin, 'isTTY', {
       value: true,
       writable: true,
@@ -289,7 +289,7 @@ describe('createSpinner', () => {
     expect(lastCall).toContain('completed');
   });
 
-  test('fail writes cross mark to stderr', async () => {
+  it('fail writes cross mark to stderr', async () => {
     Object.defineProperty(process.stdin, 'isTTY', {
       value: true,
       writable: true,
@@ -317,7 +317,7 @@ describe('createSpinner', () => {
     expect(lastCall).toContain('error occurred');
   });
 
-  test('warn writes warning icon to stderr', async () => {
+  it('warn writes warning icon to stderr', async () => {
     Object.defineProperty(process.stdin, 'isTTY', {
       value: true,
       writable: true,

--- a/tests/lib/table.test.ts
+++ b/tests/lib/table.test.ts
@@ -1,8 +1,8 @@
-import { afterEach, describe, expect, test } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { renderTable } from '../../src/lib/table';
 
 describe('renderTable', () => {
-  test('renders a table with correct border characters', () => {
+  it('renders a table with correct border characters', () => {
     const output = renderTable(['Name', 'ID'], [['Alice', 'abc-123']]);
     expect(output).toContain('┌');
     expect(output).toContain('┐');
@@ -11,7 +11,7 @@ describe('renderTable', () => {
     expect(output).toContain('│');
   });
 
-  test('includes headers in output', () => {
+  it('includes headers in output', () => {
     const output = renderTable(
       ['Name', 'Status'],
       [['my-domain.com', 'verified']],
@@ -20,7 +20,7 @@ describe('renderTable', () => {
     expect(output).toContain('Status');
   });
 
-  test('includes row data in output', () => {
+  it('includes row data in output', () => {
     const output = renderTable(
       ['Name', 'Status'],
       [['my-domain.com', 'verified']],
@@ -29,7 +29,7 @@ describe('renderTable', () => {
     expect(output).toContain('verified');
   });
 
-  test('pads columns to the widest cell in each column', () => {
+  it('pads columns to the widest cell in each column', () => {
     const output = renderTable(
       ['Key', 'Value'],
       [
@@ -42,7 +42,7 @@ describe('renderTable', () => {
     expect(new Set(lengths).size).toBe(1);
   });
 
-  test('renders multiple rows', () => {
+  it('renders multiple rows', () => {
     const output = renderTable(
       ['A', 'B'],
       [
@@ -54,7 +54,7 @@ describe('renderTable', () => {
     expect(output).toContain('row2a');
   });
 
-  test('contains a separator row between header and data', () => {
+  it('contains a separator row between header and data', () => {
     const output = renderTable(['Col'], [['val']]);
     expect(output).toContain('├');
     expect(output).toContain('┤');
@@ -80,7 +80,7 @@ describe('renderTable card layout fallback', () => {
     });
   }
 
-  test('renders table at full width when terminal width is undefined', () => {
+  it('renders table at full width when terminal width is undefined', () => {
     setTerminalWidth(undefined);
     const output = renderTable(
       ['Name', 'ID'],
@@ -91,7 +91,7 @@ describe('renderTable card layout fallback', () => {
     expect(output).toContain('abc-123-def-456');
   });
 
-  test('renders table when it fits within terminal width', () => {
+  it('renders table when it fits within terminal width', () => {
     setTerminalWidth(undefined);
     const output = renderTable(['Name', 'ID'], [['Alice', 'abc-123']]);
     const lineWidth = output.split('\n')[0].length;
@@ -102,7 +102,7 @@ describe('renderTable card layout fallback', () => {
     expect(output2).toBe(output);
   });
 
-  test('switches to cards when table overflows terminal', () => {
+  it('switches to cards when table overflows terminal', () => {
     setTerminalWidth(30);
     const output = renderTable(
       ['Name', 'ID'],
@@ -113,7 +113,7 @@ describe('renderTable card layout fallback', () => {
     expect(output).toContain('abc-123');
   });
 
-  test('cards include all values untruncated', () => {
+  it('cards include all values untruncated', () => {
     setTerminalWidth(30);
     const output = renderTable(
       ['Name', 'Description', 'ID'],
@@ -124,7 +124,7 @@ describe('renderTable card layout fallback', () => {
     expect(output).toContain('my-widget');
   });
 
-  test('cards separate rows with blank lines', () => {
+  it('cards separate rows with blank lines', () => {
     setTerminalWidth(30);
     const output = renderTable(
       ['Name', 'Description', 'ID'],
@@ -139,7 +139,7 @@ describe('renderTable card layout fallback', () => {
     expect(cards[1]).toContain('widget-b');
   });
 
-  test('cards use box-drawing separator with row number', () => {
+  it('cards use box-drawing separator with row number', () => {
     setTerminalWidth(20);
     const output = renderTable(
       ['Name', 'ID'],
@@ -152,7 +152,7 @@ describe('renderTable card layout fallback', () => {
     expect(output).toContain('── 2 ─');
   });
 
-  test('wide table with many columns switches to cards', () => {
+  it('wide table with many columns switches to cards', () => {
     setTerminalWidth(60);
     const output = renderTable(
       ['From', 'To', 'Subject', 'Status', 'Created', 'ID'],

--- a/tests/lib/tty.test.ts
+++ b/tests/lib/tty.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { captureTestEnv } from '../helpers';
 
 // We need to import the module fresh per test to pick up env changes,
@@ -26,7 +26,7 @@ describe('isInteractive', () => {
     });
   }
 
-  test('returns true when stdin and stdout are TTY and no CI env', async () => {
+  it('returns true when stdin and stdout are TTY and no CI env', async () => {
     setTTY(true, true);
     delete process.env.CI;
     delete process.env.GITHUB_ACTIONS;
@@ -36,7 +36,7 @@ describe('isInteractive', () => {
     expect(isInteractive()).toBe(true);
   });
 
-  test('returns false when stdin is not TTY', async () => {
+  it('returns false when stdin is not TTY', async () => {
     setTTY(false, true);
     delete process.env.CI;
 
@@ -44,7 +44,7 @@ describe('isInteractive', () => {
     expect(isInteractive()).toBe(false);
   });
 
-  test('returns false when stdout is not TTY', async () => {
+  it('returns false when stdout is not TTY', async () => {
     setTTY(true, false);
     delete process.env.CI;
 
@@ -52,7 +52,7 @@ describe('isInteractive', () => {
     expect(isInteractive()).toBe(false);
   });
 
-  test('returns false when CI=true', async () => {
+  it('returns false when CI=true', async () => {
     setTTY(true, true);
     process.env.CI = 'true';
 
@@ -60,7 +60,7 @@ describe('isInteractive', () => {
     expect(isInteractive()).toBe(false);
   });
 
-  test('returns false when CI=1', async () => {
+  it('returns false when CI=1', async () => {
     setTTY(true, true);
     process.env.CI = '1';
 
@@ -68,7 +68,7 @@ describe('isInteractive', () => {
     expect(isInteractive()).toBe(false);
   });
 
-  test('returns false when GITHUB_ACTIONS is set', async () => {
+  it('returns false when GITHUB_ACTIONS is set', async () => {
     setTTY(true, true);
     delete process.env.CI;
     process.env.GITHUB_ACTIONS = 'true';
@@ -77,7 +77,7 @@ describe('isInteractive', () => {
     expect(isInteractive()).toBe(false);
   });
 
-  test('returns false when TERM=dumb', async () => {
+  it('returns false when TERM=dumb', async () => {
     setTTY(true, true);
     delete process.env.CI;
     delete process.env.GITHUB_ACTIONS;

--- a/tests/lib/update-check.test.ts
+++ b/tests/lib/update-check.test.ts
@@ -14,7 +14,6 @@ import {
   expect,
   it,
   type MockInstance,
-  test,
   vi,
 } from 'vitest';
 import {
@@ -84,19 +83,19 @@ describe('checkForUpdates', () => {
       .mockRejectedValue(new Error('network error'));
   }
 
-  test('skips check when RESEND_NO_UPDATE_NOTIFIER=1', async () => {
+  it('skips check when RESEND_NO_UPDATE_NOTIFIER=1', async () => {
     process.env.RESEND_NO_UPDATE_NOTIFIER = '1';
     await checkForUpdates();
     expect(stderrOutput).toBe('');
   });
 
-  test('skips check when CI=true', async () => {
+  it('skips check when CI=true', async () => {
     process.env.CI = 'true';
     await checkForUpdates();
     expect(stderrOutput).toBe('');
   });
 
-  test('skips check when not a TTY', async () => {
+  it('skips check when not a TTY', async () => {
     Object.defineProperty(process.stdout, 'isTTY', {
       value: undefined,
       writable: true,
@@ -105,7 +104,7 @@ describe('checkForUpdates', () => {
     expect(stderrOutput).toBe('');
   });
 
-  test('prints notice when newer version available from fresh fetch', async () => {
+  it('prints notice when newer version available from fresh fetch', async () => {
     mockFetch(`v${NEWER_VERSION}`);
     await checkForUpdates();
 
@@ -114,13 +113,13 @@ describe('checkForUpdates', () => {
     expect(stderrOutput).toContain(`v${NEWER_VERSION}`);
   });
 
-  test('prints nothing when already on latest', async () => {
+  it('prints nothing when already on latest', async () => {
     mockFetch(`v${VERSION}`);
     await checkForUpdates();
     expect(stderrOutput).toBe('');
   });
 
-  test('uses cached state when fresh (no fetch)', async () => {
+  it('uses cached state when fresh (no fetch)', async () => {
     writeFileSync(
       statePath,
       JSON.stringify({ lastChecked: Date.now(), latestVersion: NEWER_VERSION }),
@@ -133,7 +132,7 @@ describe('checkForUpdates', () => {
     expect(stderrOutput).toContain(`v${NEWER_VERSION}`);
   });
 
-  test('refetches when cache is stale', async () => {
+  it('refetches when cache is stale', async () => {
     const staleTime = Date.now() - 25 * 60 * 60 * 1000; // 25 hours ago
     writeFileSync(
       statePath,
@@ -150,13 +149,13 @@ describe('checkForUpdates', () => {
     expect(state.latestVersion).toBe(NEWER_VERSION);
   });
 
-  test('handles fetch failure gracefully', async () => {
+  it('handles fetch failure gracefully', async () => {
     mockFetchFailure();
     await checkForUpdates();
     expect(stderrOutput).toBe('');
   });
 
-  test('writes state file after successful fetch', async () => {
+  it('writes state file after successful fetch', async () => {
     mockFetch('v1.0.0');
     await checkForUpdates();
 
@@ -165,7 +164,7 @@ describe('checkForUpdates', () => {
     expect(state.latestVersion).toBe('1.0.0');
   });
 
-  test('ignores prerelease versions', async () => {
+  it('ignores prerelease versions', async () => {
     fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
       ok: true,
       json: async () => ({ tag_name: 'v99.0.0', prerelease: true }),
@@ -175,7 +174,7 @@ describe('checkForUpdates', () => {
     expect(stderrOutput).toBe('');
   });
 
-  test('ignores non-semver tag names', async () => {
+  it('ignores non-semver tag names', async () => {
     mockFetch('canary-20260311');
     await checkForUpdates();
     expect(stderrOutput).toBe('');
@@ -227,7 +226,7 @@ describe('detectInstallMethod', () => {
     restoreEnv();
   });
 
-  test('detects npm when script path contains node_modules', () => {
+  it('detects npm when script path contains node_modules', () => {
     Object.defineProperty(process, 'execPath', {
       value: '/opt/homebrew/bin/node',
     });
@@ -236,7 +235,7 @@ describe('detectInstallMethod', () => {
     expect(detectInstallMethod()).toBe('npm install -g resend-cli');
   });
 
-  test('detects npm when npm_execpath is set even with homebrew node', () => {
+  it('detects npm when npm_execpath is set even with homebrew node', () => {
     Object.defineProperty(process, 'execPath', {
       value: '/opt/homebrew/bin/node',
     });
@@ -247,7 +246,7 @@ describe('detectInstallMethod', () => {
     expect(detectInstallMethod()).toBe('npm install -g resend-cli');
   });
 
-  test('detects homebrew when no npm signals present', () => {
+  it('detects homebrew when no npm signals present', () => {
     Object.defineProperty(process, 'execPath', {
       value: '/opt/homebrew/Cellar/resend/1.4.0/bin/resend',
     });
@@ -256,7 +255,7 @@ describe('detectInstallMethod', () => {
     expect(detectInstallMethod()).toBe('brew update && brew upgrade resend');
   });
 
-  test('detects install script', () => {
+  it('detects install script', () => {
     Object.defineProperty(process, 'execPath', {
       value: '/Users/test/.resend/bin/resend',
     });

--- a/tests/welcome.test.ts
+++ b/tests/welcome.test.ts
@@ -1,6 +1,6 @@
 import { type ExecFileSyncOptions, execFileSync } from 'node:child_process';
 import { resolve } from 'node:path';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 const CLI = resolve(import.meta.dirname, '../src/cli.ts');
 
@@ -11,7 +11,7 @@ const noUpdateEnv = {
 };
 
 describe('no-args welcome', () => {
-  test('exits 0 and shows help when invoked with no arguments', () => {
+  it('exits 0 and shows help when invoked with no arguments', () => {
     const execOptions: ExecFileSyncOptions = {
       encoding: 'utf-8',
       timeout: 10_000,
@@ -22,7 +22,7 @@ describe('no-args welcome', () => {
     expect(stdout).toContain('Usage: resend');
   });
 
-  test('skips banner when stdout is not a TTY', () => {
+  it('skips banner when stdout is not a TTY', () => {
     const execOptions: ExecFileSyncOptions = {
       encoding: 'utf-8',
       timeout: 10_000,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replaced all test() usages with it() across the `vitest` test suite to standardize the style and improve consistency. No test behavior or coverage changes.

<sup>Written for commit c574f34daa86d8b2777bcd8df31b1093bc1ae537. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

