### PR TITLE
feat(domains): add TrackingCAA record support

### DIFF
--- a/tests/commands/domains/get.test.ts
+++ b/tests/commands/domains/get.test.ts
@@ -34,6 +34,14 @@ const mockGet = vi.fn(async () => ({
         value: 'feedback-smtp.us-east-1.amazonses.com',
         priority: 10,
       },
+      {
+        record: 'TrackingCAA',
+        type: 'CAA',
+        name: '',
+        ttl: 'Auto',
+        status: 'verified',
+        value: '0 issue "amazon.com"',
+      },
     ],
     capabilities: { sending: 'enabled', receiving: 'disabled' },
   },
@@ -93,7 +101,9 @@ describe('domains get command', () => {
     const parsed = JSON.parse(output);
     expect(parsed.id).toBe('test-domain-id');
     expect(parsed.status).toBe('verified');
-    expect(parsed.records).toHaveLength(1);
+    expect(parsed.records).toHaveLength(2);
+    expect(parsed.records[1].record).toBe('TrackingCAA');
+    expect(parsed.records[1].type).toBe('CAA');
   });
 
   it('errors with auth_error when no API key', async () => {

--- a/tests/commands/domains/utils.test.ts
+++ b/tests/commands/domains/utils.test.ts
@@ -85,6 +85,26 @@ describe('renderDnsRecordsTable', () => {
     expect(output).toContain('Name   example.com');
   });
 
+  it('renders a TrackingCAA record using domain name when record name is empty', () => {
+    const output = renderDnsRecordsTable(
+      [
+        {
+          record: 'TrackingCAA',
+          type: 'CAA',
+          name: '',
+          ttl: 'Auto',
+          status: 'verified',
+          value: '0 issue "amazon.com"',
+        },
+      ],
+      'example.com',
+    );
+
+    expect(output).toContain('CAA');
+    expect(output).toContain('Name   example.com');
+    expect(output).toContain('Value  0 issue "amazon.com"');
+  });
+
   it('separates multiple records with blank line', () => {
     const output = renderDnsRecordsTable(
       [


### PR DESCRIPTION
## Summary

The Domains API now returns an additional DNS record on `POST /domains` and `GET /domains/:id` responses when:

1. A `tracking_subdomain` is configured on the domain, AND
2. The customer's root domain has CAA records that would otherwise prevent AWS from issuing a TLS certificate.

The new record looks like:

```json
{
  "record": "TrackingCAA",
  "name": "",
  "type": "CAA",
  "ttl": "Auto",
  "value": "0 issue \"amazon.com\"",
  "status": "verified"
}
```

The CLI's `renderDnsRecordsTable` already handles arbitrary record types and falls back to the root domain name when the record `name` is empty (which CAA records use), so no source change is required. This PR:

- Adds a `TrackingCAA` case to the `renderDnsRecordsTable` test that asserts the empty-name fallback to the root domain.
- Extends the `domains get` fixture with a `TrackingCAA` record and asserts it round-trips through the CLI's JSON output.

Once the resend Node SDK release that adds `TrackingCaaRecord` to the `DomainRecords` union ships, we should bump the `resend` dep so the union narrows correctly on `record === 'TrackingCAA'`.

## Test plan

- [x] `pnpm test` passes (includes new fixtures)
- [x] `pnpm typecheck` passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `TrackingCAA` DNS record coverage to the CLI. Updates fixtures and tests to verify correct rendering and JSON round‑trip. No source changes.

- **New Features**
  - Extend `domains get` fixture with a `TrackingCAA` record and assert it appears in CLI JSON.
  - Add `renderDnsRecordsTable` test to use the domain name when the CAA record name is empty.

- **Dependencies**
  - Follow-up: bump `resend` once `TrackingCaaRecord` is added to the `DomainRecords` union.

<sup>Written for commit 628be130c540fce9f6fd8f181d6970334ae5175c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

