### PR TITLE
feat: support --react-email flag in binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
         env:
           POSTHOG_PUBLIC_KEY: ${{ secrets.POSTHOG_PUBLIC_KEY }}
       - name: Build binary
-        run: pnpm exec pkg dist/cli.cjs --compress Brotli --target ${{ matrix.target }} --output ${{ matrix.binary }}
+        run: pnpm exec pkg dist/cli.cjs --config package.json --compress Brotli --target ${{ matrix.target }} --output ${{ matrix.binary }}
       - name: Verify binary runs
         run: |
           ${{ matrix.binary }} --version
@@ -69,7 +69,7 @@ jobs:
         env:
           POSTHOG_PUBLIC_KEY: ${{ secrets.POSTHOG_PUBLIC_KEY }}
       - name: Build binary (no-bytecode workaround)
-        run: pnpm exec pkg dist/cli.cjs --compress Brotli --target node24-linux-arm64 --output dist/resend --no-bytecode --public-packages "*" --public
+        run: pnpm exec pkg dist/cli.cjs --config package.json --compress Brotli --target node24-linux-arm64 --output dist/resend --no-bytecode --public-packages "*" --public
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
         with:
@@ -98,8 +98,8 @@ jobs:
           POSTHOG_PUBLIC_KEY: ${{ secrets.POSTHOG_PUBLIC_KEY }}
       - name: Build macOS binaries
         run: |
-          pnpm exec pkg dist/cli.cjs --compress Brotli --target node24-macos-arm64 --output dist/resend-darwin-arm64
-          pnpm exec pkg dist/cli.cjs --compress Brotli --target node24-macos-x64   --output dist/resend-darwin-x64
+          pnpm exec pkg dist/cli.cjs --config package.json --compress Brotli --target node24-macos-arm64 --output dist/resend-darwin-arm64
+          pnpm exec pkg dist/cli.cjs --config package.json --compress Brotli --target node24-macos-x64   --output dist/resend-darwin-x64
       - name: Verify signatures
         run: |
           codesign -v dist/resend-darwin-arm64
@@ -138,9 +138,9 @@ jobs:
           POSTHOG_PUBLIC_KEY: ${{ secrets.POSTHOG_PUBLIC_KEY }}
       - name: Build binaries
         run: |
-          pnpm exec pkg dist/cli.cjs --compress Brotli --target node24-linux-x64   --output dist/resend-linux-x64
-          pnpm exec pkg dist/cli.cjs --compress Brotli --target node24-linux-arm64 --output dist/resend-linux-arm64 --no-bytecode --public-packages "*" --public
-          pnpm exec pkg dist/cli.cjs --compress Brotli --target node24-win-x64     --output dist/resend-windows-x64.exe
+          pnpm exec pkg dist/cli.cjs --config package.json --compress Brotli --target node24-linux-x64   --output dist/resend-linux-x64
+          pnpm exec pkg dist/cli.cjs --config package.json --compress Brotli --target node24-linux-arm64 --output dist/resend-linux-arm64 --no-bytecode --public-packages "*" --public
+          pnpm exec pkg dist/cli.cjs --config package.json --compress Brotli --target node24-win-x64     --output dist/resend-windows-x64.exe
       - name: Verify binaries
         run: |
           for f in dist/resend-linux-x64 dist/resend-linux-arm64 dist/resend-windows-x64.exe; do

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Build Node bundle
         run: pnpm build
       - name: Build pkg binary
-        run: pnpm exec pkg dist/cli.cjs --compress Brotli --target node24-linux-x64 --output dist/resend
+        run: pnpm exec pkg dist/cli.cjs --config package.json --compress Brotli --target node24-linux-x64 --output dist/resend
       - name: Smoke test Node bundle
         run: |
           node dist/cli.cjs --version

--- a/.github/workflows/test-react-email-binary.yml
+++ b/.github/workflows/test-react-email-binary.yml
@@ -1,0 +1,59 @@
+name: Test react-email in binaries
+on: [pull_request]
+concurrency:
+  group: test-react-email-binary-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            target: node24-macos-arm64
+            binary: dist/resend
+          - os: ubuntu-latest
+            target: node24-linux-x64
+            binary: dist/resend
+          - os: windows-latest
+            target: node24-win-x64
+            binary: dist/resend.exe
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: 24
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - name: Build binary
+        run: pnpm exec pkg dist/cli.cjs --config package.json --compress Brotli --target ${{ matrix.target }} --output ${{ matrix.binary }}
+      - name: Create test project
+        shell: bash
+        run: |
+          mkdir -p /tmp/react-email-test
+          cd /tmp/react-email-test
+          npm init -y
+          npm install react @react-email/components
+          cat > email.tsx << 'TEMPLATE'
+          import { Html, Text } from '@react-email/components';
+          export default function Email() {
+            return <Html><Text>Hello from React Email!</Text></Html>;
+          }
+          TEMPLATE
+      - name: Test react-email in binary
+        shell: bash
+        run: |
+          output=$(cd /tmp/react-email-test && "$GITHUB_WORKSPACE/${{ matrix.binary }}" emails send \
+            --from test@example.com --to test@example.com --subject Test \
+            --react-email ./email.tsx --json 2>&1 || true)
+          echo "$output"
+
+          # If we see a build/render error, esbuild-wasm failed
+          if echo "$output" | grep -q '"react_email_build_error"\|"react_email_render_error"'; then
+            echo "::error::react-email bundling/rendering failed in binary"
+            exit 1
+          fi
+          echo "react-email template bundled and rendered successfully in binary"

--- a/.github/workflows/test-react-email-binary.yml
+++ b/.github/workflows/test-react-email-binary.yml
@@ -51,9 +51,10 @@ jobs:
             --react-email ./email.tsx --json 2>&1 || true)
           echo "$output"
 
-          # If we see a build/render error, esbuild-wasm failed
-          if echo "$output" | grep -q '"react_email_build_error"\|"react_email_render_error"'; then
+          # Verify we reached the API call (send_error proves bundling + rendering succeeded)
+          if echo "$output" | grep -q '"send_error"'; then
+            echo "react-email template bundled and rendered successfully in binary"
+          else
             echo "::error::react-email bundling/rendering failed in binary"
             exit 1
           fi
-          echo "react-email template bundled and rendered successfully in binary"

--- a/.github/workflows/test-react-email-binary.yml
+++ b/.github/workflows/test-react-email-binary.yml
@@ -51,8 +51,8 @@ jobs:
             --react-email ./email.tsx --json 2>&1 || true)
           echo "$output"
 
-          # Verify we reached the API call (send_error proves bundling + rendering succeeded)
-          if echo "$output" | grep -q '"send_error"'; then
+          # Verify we got past bundling + rendering (send_error or auth_error both prove success)
+          if echo "$output" | grep -q '"send_error"\|"auth_error"'; then
             echo "react-email template bundled and rendered successfully in binary"
           else
             echo "::error::react-email bundling/rendering failed in binary"

--- a/.github/workflows/test-telemetry-windows.yml
+++ b/.github/workflows/test-telemetry-windows.yml
@@ -18,7 +18,7 @@ jobs:
         env:
           POSTHOG_PUBLIC_KEY: ${{ secrets.POSTHOG_STAGING_KEY }}
       - name: Build Windows binary
-        run: pnpm exec pkg dist/cli.cjs --compress Brotli --target node24-win-x64 --output dist/resend.exe
+        run: pnpm exec pkg dist/cli.cjs --config package.json --compress Brotli --target node24-win-x64 --output dist/resend.exe
       - name: Test telemetry spawn from binary
         run: |
           $tmpdir = [System.IO.Path]::GetTempPath()

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "dev": "tsx src/cli.ts",
     "dev:watch": "tsx --watch src/cli.ts",
     "build": "node scripts/build.mjs",
-    "build:bin": "pnpm build && pkg dist/cli.cjs --compress Brotli --target node24 --output dist/resend",
+    "build:bin": "pnpm build && pkg dist/cli.cjs --config package.json --compress Brotli --target node24 --output dist/resend",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "typecheck": "tsc --noEmit",
@@ -44,8 +44,19 @@
     "@commander-js/extra-typings": "14.0.0",
     "commander": "14.0.3",
     "esbuild": "0.28.0",
+    "esbuild-wasm": "0.28.0",
     "picocolors": "1.1.1",
     "resend": "6.12.0"
+  },
+  "pkg": {
+    "scripts": [
+      "node_modules/esbuild-wasm/bin/esbuild",
+      "node_modules/esbuild-wasm/wasm_exec.js",
+      "node_modules/esbuild-wasm/wasm_exec_node.js"
+    ],
+    "assets": [
+      "node_modules/esbuild-wasm/esbuild.wasm"
+    ]
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       esbuild:
         specifier: 0.28.0
         version: 0.28.0
+      esbuild-wasm:
+        specifier: ^0.28.0
+        version: 0.28.0
       picocolors:
         specifier: 1.1.1
         version: 1.1.1
@@ -969,6 +972,11 @@ packages:
 
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
+  esbuild-wasm@0.28.0:
+    resolution: {integrity: sha512-5TRVKExcEmeMkccIZMzUq+Az6X2RoMAJyfl6SMMO1dMVhmvt0I2mx7gAb6zYi42n4d1ETcatFXazGKzA+aW7fg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -2124,6 +2132,8 @@ snapshots:
       once: 1.4.0
 
   es-module-lexer@2.0.0: {}
+
+  esbuild-wasm@0.28.0: {}
 
   esbuild@0.25.12:
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
         specifier: 0.28.0
         version: 0.28.0
       esbuild-wasm:
-        specifier: ^0.28.0
+        specifier: 0.28.0
         version: 0.28.0
       picocolors:
         specifier: 1.1.1

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -24,7 +24,7 @@ await build({
   format: 'cjs',
   minify: true,
   outfile: 'dist/cli.cjs',
-  external: ['esbuild'],
+  external: ['esbuild', 'esbuild-wasm'],
   define: {
     'process.env.POSTHOG_PUBLIC_KEY': JSON.stringify(posthogKey),
   },

--- a/src/commands/broadcasts/create.ts
+++ b/src/commands/broadcasts/create.ts
@@ -34,7 +34,7 @@ export const createBroadcastCommand = new Command('create')
   )
   .option(
     '--react-email <path>',
-    'Path to a React Email template (.tsx) to bundle, render, and use as HTML body (npm install only)',
+    'Path to a React Email template (.tsx) to bundle, render, and use as HTML body',
   )
   .option('--name <name>', 'Internal label for the broadcast (optional)')
   .option('--reply-to <address>', 'Reply-to address (optional)')

--- a/src/commands/broadcasts/update.ts
+++ b/src/commands/broadcasts/update.ts
@@ -30,7 +30,7 @@ export const updateBroadcastCommand = new Command('update')
   )
   .option(
     '--react-email <path>',
-    'Path to a React Email template (.tsx) to bundle, render, and use as HTML body (npm install only)',
+    'Path to a React Email template (.tsx) to bundle, render, and use as HTML body',
   )
   .option('--name <name>', 'Update internal label')
   .addHelpText(

--- a/src/commands/emails/batch.ts
+++ b/src/commands/emails/batch.ts
@@ -18,7 +18,7 @@ export const batchCommand = new Command('batch')
   )
   .option(
     '--react-email <path>',
-    'Path to a React Email template (.tsx) — rendered HTML is set on every email in the batch (npm install only)',
+    'Path to a React Email template (.tsx) — rendered HTML is set on every email in the batch',
   )
   .option(
     '--idempotency-key <key>',

--- a/src/commands/emails/send.ts
+++ b/src/commands/emails/send.ts
@@ -52,7 +52,7 @@ export const sendCommand = new Command('send')
   )
   .option(
     '--react-email <path>',
-    'Path to a React Email template (.tsx) to bundle, render, and send (npm install only)',
+    'Path to a React Email template (.tsx) to bundle, render, and send',
   )
   .option('--cc <addresses...>', 'CC recipients')
   .option('--bcc <addresses...>', 'BCC recipients')

--- a/src/commands/templates/create.ts
+++ b/src/commands/templates/create.ts
@@ -26,7 +26,7 @@ export const createTemplateCommand = new Command('create')
   )
   .option(
     '--react-email <path>',
-    'Path to a React Email template (.tsx) to bundle, render, and use as HTML body (npm install only)',
+    'Path to a React Email template (.tsx) to bundle, render, and use as HTML body',
   )
   .option('--from <address>', 'Sender address')
   .option('--reply-to <address>', 'Reply-to address')

--- a/src/commands/templates/update.ts
+++ b/src/commands/templates/update.ts
@@ -25,7 +25,7 @@ export const updateTemplateCommand = new Command('update')
   )
   .option(
     '--react-email <path>',
-    'Path to a React Email template (.tsx) to bundle, render, and use as HTML body (npm install only)',
+    'Path to a React Email template (.tsx) to bundle, render, and use as HTML body',
   )
   .option('--from <address>', 'Update sender address')
   .option('--reply-to <address>', 'Update reply-to address')

--- a/src/lib/react-email-bundler.ts
+++ b/src/lib/react-email-bundler.ts
@@ -1,8 +1,14 @@
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { build } from 'esbuild';
 import { renderingUtilitiesExporter } from './esbuild/rendering-utilities-exporter';
+
+function loadEsbuild(): typeof import('esbuild') {
+  if ('pkg' in process) {
+    return require('esbuild-wasm');
+  }
+  return require('esbuild');
+}
 
 export interface BundleResult {
   cjsPath: string;
@@ -16,6 +22,7 @@ export async function bundleReactEmail(
   const tmpDir = mkdtempSync(path.join(tmpdir(), 'resend-react-email-'));
 
   try {
+    const { build } = await loadEsbuild();
     await build({
       bundle: true,
       entryPoints: [resolved],

--- a/src/lib/react-email-bundler.ts
+++ b/src/lib/react-email-bundler.ts
@@ -22,7 +22,7 @@ export async function bundleReactEmail(
   const tmpDir = mkdtempSync(path.join(tmpdir(), 'resend-react-email-'));
 
   try {
-    const { build } = await loadEsbuild();
+    const { build } = loadEsbuild();
     await build({
       bundle: true,
       entryPoints: [resolved],

--- a/src/lib/react-email.ts
+++ b/src/lib/react-email.ts
@@ -26,17 +26,6 @@ export const buildReactEmailHtml = async (
     );
   }
 
-  if ('pkg' in process) {
-    return outputError(
-      {
-        message:
-          '--react-email requires a Node.js install (npm i -g resend-cli or npx resend-cli)',
-        code: 'react_email_build_error',
-      },
-      { json: globalOpts.json },
-    );
-  }
-
   const resolved = resolve(templatePath);
   if (!existsSync(resolved)) {
     return outputError(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable React Email templates in compiled binaries by loading `esbuild-wasm` when running under `pkg`, while keeping native `esbuild` for npm installs. Adds cross-platform CI to prove bundling/rendering across macOS, Linux, and Windows binaries.

- **New Features**
  - `--react-email` works in Homebrew/curl/Windows installer binaries via `esbuild-wasm` fallback.
  - Automatically detects `pkg` runtime and loads `esbuild-wasm`; uses `esbuild` otherwise.
  - CI builds binaries and tests a React Email template; treats "send_error" or "auth_error" as success to confirm bundling/rendering reached the API call.
  - Updated CLI help text to remove “(npm install only)”.

- **Dependencies**
  - Added `esbuild-wasm@0.28.0` and configured `pkg` to include its scripts/assets.
  - Updated build script to externalize `esbuild` and `esbuild-wasm`.
  - Passed `--config package.json` to all `pkg` invocations in workflows and `build:bin` so assets are bundled.

<sup>Written for commit f1fe94d7c37bbaa560d388e53a0b69ea0f0ed8cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

