### PR TITLE
feat: support react-email import

### DIFF
--- a/skills/resend-cli/references/error-codes.md
+++ b/skills/resend-cli/references/error-codes.md
@@ -20,7 +20,7 @@ All errors exit with code `1` and output JSON to **stderr**:
 | Code | Cause | Resolution |
 |------|-------|------------|
 | `missing_body` | None of `--text`, `--html`, `--html-file`, or `--react-email` provided | Provide at least one body flag |
-| `react_email_build_error` | Failed to bundle a React Email `.tsx` template with esbuild | Check the template compiles; ensure `react` and `@react-email/render` (or `@react-email/components`) are installed in the project |
+| `react_email_build_error` | Failed to bundle a React Email `.tsx` template with esbuild | Check the template compiles; ensure `react` and one of `@react-email/render`, `@react-email/components`, or `react-email` are installed in the project |
 | `react_email_render_error` | Bundled template failed during `render()` | Check the component exports a default function and renders valid React Email markup |
 | `file_read_error` | Could not read file from `--html-file` path | Check file path exists and is readable |
 | `send_error` | Resend API rejected the send request | Check from address is on a verified domain; check recipient is valid |

--- a/src/lib/esbuild/rendering-utilities-exporter.ts
+++ b/src/lib/esbuild/rendering-utilities-exporter.ts
@@ -40,9 +40,14 @@ export const renderingUtilitiesExporter = (emailTemplates: string[]) => ({
         }
 
         result = await b.resolve('@react-email/components', options);
+        if (result.errors.length === 0) {
+          return result;
+        }
+
+        result = await b.resolve('react-email', options);
         if (result.errors.length > 0 && result.errors[0]) {
           result.errors[0].text =
-            "Failed trying to import `render` from either `@react-email/render` or `@react-email/components` to be able to render your email template.\n Maybe you don't have either of them installed?";
+            "Failed trying to import `render` from `@react-email/render`, `@react-email/components`, or `react-email` to be able to render your email template.\nMaybe you don't have any of them installed?";
         }
         return result;
       },


### PR DESCRIPTION



<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `react-email` as a third fallback for resolving `render` in the esbuild plugin, so templates work with the v6 umbrella package. Updated the error text and `error-codes.md` to mention `@react-email/render`, `@react-email/components`, and `react-email`.

<sup>Written for commit 40cbc4b21cab7dd05d04a53e0843e5cb3ed5019b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



