### PR TITLE
feat: add custom click tracking subdomain to domain commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "commander": "14.0.3",
     "esbuild": "0.28.0",
     "picocolors": "1.1.1",
-    "resend": "6.11.0"
+    "resend": "6.12.0"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: 1.1.1
         version: 1.1.1
       resend:
-        specifier: 6.11.0
-        version: 6.11.0
+        specifier: 6.12.0
+        version: 6.12.0
     devDependencies:
       '@biomejs/biome':
         specifier: 2.4.11
@@ -1206,8 +1206,8 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
-  resend@6.11.0:
-    resolution: {integrity: sha512-S9gxOccfwc+E6Cr3q28Gu8NkiIjYlYPlj9rqk4zkIuzlEoh8sWu/IvJSg7U7t+o3g0Ov2IOCzcneUaCi/M/WdQ==}
+  resend@6.12.0:
+    resolution: {integrity: sha512-CaxEvX1z+/MGbgnhsM/bvmkbnZd1v1sEXELAjBNSDBQNMaB7MgqOyrBgI27CYikEgdaDnBrXghAXYWTBs/h5Bw==}
     engines: {node: '>=20'}
     peerDependencies:
       '@react-email/render': '*'
@@ -2414,7 +2414,7 @@ snapshots:
 
   require-directory@2.1.1: {}
 
-  resend@6.11.0:
+  resend@6.12.0:
     dependencies:
       postal-mime: 2.7.4
       svix: 1.90.0

--- a/skills/resend-cli/references/domains.md
+++ b/skills/resend-cli/references/domains.md
@@ -27,6 +27,7 @@ Create a new domain and receive DNS records to configure.
 | `--name <domain>` | string | Yes (non-interactive) | Domain name (e.g., `example.com`) |
 | `--region <region>` | string | No | `us-east-1` \| `eu-west-1` \| `sa-east-1` \| `ap-northeast-1` |
 | `--tls <mode>` | string | No | `opportunistic` (default) \| `enforced` |
+| `--tracking-subdomain <subdomain>` | string | No | Subdomain for click and open tracking (e.g., `track`) |
 | `--sending` | boolean | No | Enable sending (default: enabled) |
 | `--receiving` | boolean | No | Enable receiving (default: disabled) |
 
@@ -38,7 +39,7 @@ Create a new domain and receive DNS records to configure.
 
 **Argument:** `<id>` — Domain ID
 
-Returns full domain with `records[]`, `status` (`not_started`|`pending`|`verified`|`failed`|`temporary_failure`), `capabilities`, `region`.
+Returns full domain with `records[]`, `status` (`not_started`|`pending`|`verified`|`failed`|`temporary_failure`), `capabilities`, `region`, `open_tracking`, `click_tracking`, `tracking_subdomain`. Records may include a `Tracking` CNAME record when a tracking subdomain is configured, and a `TrackingCAA` CAA record when the root domain has CAA records that require an additional entry for AWS certificate issuance.
 
 ---
 
@@ -63,6 +64,7 @@ Trigger async DNS verification.
 | `--no-open-tracking` | boolean | Disable open tracking |
 | `--click-tracking` | boolean | Enable click tracking |
 | `--no-click-tracking` | boolean | Disable click tracking |
+| `--tracking-subdomain <subdomain>` | string | Subdomain for click and open tracking (e.g., `track`) |
 
 At least one option required.
 

--- a/src/commands/domains/create.ts
+++ b/src/commands/domains/create.ts
@@ -22,6 +22,10 @@ export const createDomainCommand = new Command('create')
       'enforced',
     ] as const),
   )
+  .option(
+    '--tracking-subdomain <subdomain>',
+    'Subdomain for click and open tracking (e.g. track)',
+  )
   .option('--sending', 'Enable sending capability (default: enabled)')
   .option('--receiving', 'Enable receiving capability (default: disabled)')
   .addHelpText(
@@ -35,6 +39,7 @@ export const createDomainCommand = new Command('create')
       examples: [
         'resend domains create --name example.com',
         'resend domains create --name example.com --region eu-west-1 --tls enforced',
+        'resend domains create --name example.com --tracking-subdomain track',
         'resend domains create --name example.com --receiving --json',
         'resend domains create --name example.com --sending --receiving --json',
       ],
@@ -58,6 +63,9 @@ export const createDomainCommand = new Command('create')
             name,
             ...(opts.region && { region: opts.region }),
             ...(opts.tls && { tls: opts.tls }),
+            ...(opts.trackingSubdomain && {
+              trackingSubdomain: opts.trackingSubdomain,
+            }),
             ...((opts.sending || opts.receiving) && {
               capabilities: {
                 ...(opts.sending && { sending: 'enabled' as const }),

--- a/src/commands/domains/get.ts
+++ b/src/commands/domains/get.ts
@@ -38,6 +38,19 @@ export const getDomainCommand = new Command('get')
           console.log(`ID: ${d.id}`);
           console.log(`Region: ${d.region}`);
           console.log(`Created: ${d.created_at}`);
+          if (d.open_tracking !== undefined) {
+            console.log(
+              `Open tracking: ${d.open_tracking ? 'enabled' : 'disabled'}`,
+            );
+          }
+          if (d.click_tracking !== undefined) {
+            console.log(
+              `Click tracking: ${d.click_tracking ? 'enabled' : 'disabled'}`,
+            );
+          }
+          if (d.tracking_subdomain) {
+            console.log(`Tracking subdomain: ${d.tracking_subdomain}`);
+          }
           if (d.records.length > 0) {
             console.log('\nDNS Records:');
             console.log(renderDnsRecordsTable(d.records, d.name));

--- a/src/commands/domains/update.ts
+++ b/src/commands/domains/update.ts
@@ -9,7 +9,7 @@ import { domainPickerConfig } from './utils';
 
 export const updateDomainCommand = new Command('update')
   .description(
-    'Update domain settings: TLS mode, open tracking, and click tracking',
+    'Update domain settings: TLS mode, tracking, and tracking subdomain',
   )
   .argument('[id]', 'Domain ID')
   .addOption(
@@ -22,6 +22,10 @@ export const updateDomainCommand = new Command('update')
   .option('--no-open-tracking', 'Disable open tracking')
   .option('--click-tracking', 'Enable click tracking')
   .option('--no-click-tracking', 'Disable click tracking')
+  .option(
+    '--tracking-subdomain <subdomain>',
+    'Subdomain for click and open tracking (e.g. track)',
+  )
   .addHelpText(
     'after',
     buildHelpText({
@@ -30,6 +34,7 @@ export const updateDomainCommand = new Command('update')
       examples: [
         'resend domains update <id> --tls enforced',
         'resend domains update <id> --open-tracking --click-tracking',
+        'resend domains update <id> --tracking-subdomain track',
         'resend domains update <id> --no-open-tracking --json',
       ],
     }),
@@ -38,13 +43,18 @@ export const updateDomainCommand = new Command('update')
     const globalOpts = cmd.optsWithGlobals() as GlobalOpts;
     const id = await pickId(idArg, domainPickerConfig, globalOpts);
 
-    const { tls, openTracking, clickTracking } = opts;
+    const { tls, openTracking, clickTracking, trackingSubdomain } = opts;
 
-    if (!tls && openTracking === undefined && clickTracking === undefined) {
+    if (
+      !tls &&
+      openTracking === undefined &&
+      clickTracking === undefined &&
+      !trackingSubdomain
+    ) {
       outputError(
         {
           message:
-            'Provide at least one option to update: --tls, --open-tracking, or --click-tracking.',
+            'Provide at least one option to update: --tls, --open-tracking, --click-tracking, or --tracking-subdomain.',
           code: 'no_changes',
         },
         { json: globalOpts.json },
@@ -60,6 +70,9 @@ export const updateDomainCommand = new Command('update')
     }
     if (clickTracking !== undefined) {
       payload.clickTracking = clickTracking;
+    }
+    if (trackingSubdomain) {
+      payload.trackingSubdomain = trackingSubdomain;
     }
 
     await runWrite(

--- a/tests/commands/domains/create.test.ts
+++ b/tests/commands/domains/create.test.ts
@@ -100,6 +100,21 @@ describe('domains create command', () => {
     expect(args.tls).toBe('enforced');
   });
 
+  it('passes trackingSubdomain when --tracking-subdomain is set', async () => {
+    spies = setupOutputSpies();
+
+    const { createDomainCommand } = await import(
+      '../../../src/commands/domains/create'
+    );
+    await createDomainCommand.parseAsync(
+      ['--name', 'example.com', '--tracking-subdomain', 'track'],
+      { from: 'user' },
+    );
+
+    const args = mockCreate.mock.calls[0][0] as Record<string, unknown>;
+    expect(args.trackingSubdomain).toBe('track');
+  });
+
   it('passes receiving capability when --receiving flag is set', async () => {
     spies = setupOutputSpies();
 

--- a/tests/commands/domains/get.test.ts
+++ b/tests/commands/domains/get.test.ts
@@ -96,6 +96,37 @@ describe('domains get command', () => {
     expect(parsed.records).toHaveLength(1);
   });
 
+  it('includes tracking fields in JSON output', async () => {
+    mockGet.mockResolvedValueOnce({
+      data: {
+        object: 'domain',
+        id: 'test-domain-id',
+        name: 'example.com',
+        status: 'verified',
+        created_at: '2026-01-01T00:00:00.000Z',
+        region: 'us-east-1',
+        open_tracking: true,
+        click_tracking: true,
+        tracking_subdomain: 'track',
+        records: [],
+        capabilities: { sending: 'enabled', receiving: 'disabled' },
+      },
+      error: null,
+    });
+    spies = setupOutputSpies();
+
+    const { getDomainCommand } = await import(
+      '../../../src/commands/domains/get'
+    );
+    await getDomainCommand.parseAsync(['test-domain-id'], { from: 'user' });
+
+    const output = spies.logSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output);
+    expect(parsed.open_tracking).toBe(true);
+    expect(parsed.click_tracking).toBe(true);
+    expect(parsed.tracking_subdomain).toBe('track');
+  });
+
   it('errors with auth_error when no API key', async () => {
     setNonInteractive();
     delete process.env.RESEND_API_KEY;

--- a/tests/commands/domains/update.test.ts
+++ b/tests/commands/domains/update.test.ts
@@ -144,6 +144,35 @@ describe('domains update command', () => {
     expect(args.clickTracking).toBe(false);
   });
 
+  it('passes trackingSubdomain when --tracking-subdomain is set', async () => {
+    spies = setupOutputSpies();
+
+    const { updateDomainCommand } = await import(
+      '../../../src/commands/domains/update'
+    );
+    await updateDomainCommand.parseAsync(
+      ['test-domain-id', '--tracking-subdomain', 'track'],
+      { from: 'user' },
+    );
+
+    const args = mockUpdate.mock.calls[0][0] as Record<string, unknown>;
+    expect(args.trackingSubdomain).toBe('track');
+  });
+
+  it('does not error when only --tracking-subdomain is provided', async () => {
+    spies = setupOutputSpies();
+
+    const { updateDomainCommand } = await import(
+      '../../../src/commands/domains/update'
+    );
+    await updateDomainCommand.parseAsync(
+      ['test-domain-id', '--tracking-subdomain', 'track'],
+      { from: 'user' },
+    );
+
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+  });
+
   it('errors with no_changes when no update flags are provided', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/tests/commands/domains/utils.test.ts
+++ b/tests/commands/domains/utils.test.ts
@@ -85,6 +85,26 @@ describe('renderDnsRecordsTable', () => {
     expect(output).toContain('Name   example.com');
   });
 
+  it('renders a Tracking CNAME record', () => {
+    const output = renderDnsRecordsTable(
+      [
+        {
+          record: 'Tracking',
+          type: 'CNAME',
+          name: 'track',
+          ttl: 'Auto',
+          status: 'not_started',
+          value: 'tracking.resend.com',
+        },
+      ],
+      'example.com',
+    );
+
+    expect(output).toContain('CNAME');
+    expect(output).toContain('Name   track.example.com');
+    expect(output).toContain('Value  tracking.resend.com');
+  });
+
   it('separates multiple records with blank line', () => {
     const output = renderDnsRecordsTable(
       [


### PR DESCRIPTION
Add --tracking-subdomain flag to `domains create` and `domains update` commands. Display open_tracking, click_tracking, and tracking_subdomain fields in `domains get` output. Upgrade resend SDK to 6.12.0 which includes tracking domain types and TrackingCAA record support.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `--tracking-subdomain` option to domain commands to let users set a custom subdomain for click/open tracking, and surface tracking settings in `domains get`. Upgrades the `resend` SDK to 6.12.0 to support tracking domain types and TrackingCAA records.

- **New Features**
  - `domains create` and `domains update`: add `--tracking-subdomain <subdomain>` (e.g., `track`); `update` allows this as the only change.
  - `domains get`: prints open/click tracking status and the tracking subdomain; JSON now includes `open_tracking`, `click_tracking`, and `tracking_subdomain`.
  - DNS records output now shows a Tracking CNAME when configured; docs updated.

- **Dependencies**
  - Bump `resend` from 6.11.0 to 6.12.0 for tracking domain types and TrackingCAA record support.

<sup>Written for commit f5258b56e53e53614bbe033fef60bfa2702ab128. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

