### PR TITLE
chore: bump v2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-cli",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "The official CLI for Resend",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update `resend-cli` to 2.1.0 for the next minor release. Only updates the version field in package.json.

<sup>Written for commit c96ea75173d389806cfd61474d4b4c88ac83caf0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

