### PR TITLE
fix: replace yourdomain.com with example.com in all examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ resend login
 
 # Send an email
 resend emails send \
-  --from "you@yourdomain.com" \
+  --from "you@example.com" \
   --to delivered@resend.dev \
   --subject "Hello from Resend CLI" \
   --text "Sent from my terminal."
@@ -226,7 +226,7 @@ Provide all options via flags for scripting, or let the CLI prompt interactively
 
 ```bash
 resend emails send \
-  --from "Name <sender@yourdomain.com>" \
+  --from "Name <sender@example.com>" \
   --to delivered@resend.dev \
   --subject "Subject line" \
   --text "Plain text body"
@@ -255,7 +255,7 @@ When run in a terminal without all required flags, the CLI prompts for missing f
 resend emails send
 
 # prompts only for missing fields
-resend emails send --from "you@yourdomain.com"
+resend emails send --from "you@example.com"
 ```
 
 #### Non-interactive mode
@@ -263,7 +263,7 @@ resend emails send --from "you@yourdomain.com"
 When piped or run in CI, all required flags must be provided. Missing flags cause an error listing what's needed:
 
 ```bash
-echo "" | resend emails send --from "you@yourdomain.com"
+echo "" | resend emails send --from "you@example.com"
 # Error: Missing required flags: --to, --subject
 ```
 
@@ -275,7 +275,7 @@ A body (`--text`, `--html`, or `--html-file`) is also required — omitting all 
 
 ```bash
 resend emails send \
-  --from "you@yourdomain.com" \
+  --from "you@example.com" \
   --to delivered@resend.dev bounced@resend.dev \
   --subject "Team update" \
   --text "Hello everyone"
@@ -285,7 +285,7 @@ resend emails send \
 
 ```bash
 resend emails send \
-  --from "you@yourdomain.com" \
+  --from "you@example.com" \
   --to delivered@resend.dev \
   --subject "Newsletter" \
   --html-file ./newsletter.html
@@ -295,7 +295,7 @@ resend emails send \
 
 ```bash
 resend emails send \
-  --from "you@yourdomain.com" \
+  --from "you@example.com" \
   --to delivered@resend.dev \
   --subject "Meeting notes" \
   --text "See attached." \
@@ -308,7 +308,7 @@ resend emails send \
 
 ```bash
 resend --api-key re_other_key emails send \
-  --from "you@yourdomain.com" \
+  --from "you@example.com" \
   --to delivered@resend.dev \
   --subject "Test" \
   --text "Using a different key"
@@ -626,7 +626,7 @@ env:
 steps:
   - run: |
       resend emails send \
-        --from "deploy@yourdomain.com" \
+        --from "deploy@example.com" \
         --to "delivered@resend.com" \
         --subject "Deploy complete" \
         --text "Version ${{ github.sha }} deployed."

--- a/skills/resend-cli/SKILL.md
+++ b/skills/resend-cli/SKILL.md
@@ -11,7 +11,7 @@ description: >
 license: MIT
 metadata:
   author: resend
-  version: "2.0.0"
+  version: "2.0.1"
   homepage: https://resend.com/docs/cli-agents
   source: https://github.com/resend/resend-cli
   openclaw:

--- a/skills/resend-cli/references/workflows.md
+++ b/skills/resend-cli/references/workflows.md
@@ -27,31 +27,31 @@ resend doctor -q
 ```bash
 # Basic text email
 resend emails send \
-  --from "you@yourdomain.com" \
+  --from "you@example.com" \
   --to recipient@example.com \
   --subject "Hello" \
   --text "Body text"
 
 # HTML email with attachments
 resend emails send \
-  --from "Name <you@yourdomain.com>" \
+  --from "Name <you@example.com>" \
   --to alice@example.com bob@example.com \
   --subject "Report" \
   --html-file ./email.html \
   --attachment ./report.pdf \
   --cc manager@example.com \
-  --reply-to support@yourdomain.com
+  --reply-to support@example.com
 
 # React Email template (.tsx) — bundles, renders to HTML, and sends
 resend emails send \
-  --from "you@yourdomain.com" \
+  --from "you@example.com" \
   --to recipient@example.com \
   --subject "Welcome" \
   --react-email ./emails/welcome.tsx
 
 # React Email with plain-text fallback
 resend emails send \
-  --from "you@yourdomain.com" \
+  --from "you@example.com" \
   --to recipient@example.com \
   --subject "Welcome" \
   --react-email ./emails/welcome.tsx \
@@ -59,7 +59,7 @@ resend emails send \
 
 # Scheduled email (ISO 8601 or natural language)
 resend emails send \
-  --from "you@yourdomain.com" \
+  --from "you@example.com" \
   --to recipient@example.com \
   --subject "Reminder" \
   --text "Don't forget!" \
@@ -127,7 +127,7 @@ resend contacts create --email user@example.com --first-name Jane --segment-id <
 
 # 3. Create and send broadcast
 resend broadcasts create \
-  --from "news@yourdomain.com" \
+  --from "news@example.com" \
   --subject "Monthly Update" \
   --segment-id <segment-id> \
   --html "<h1>Hello {{{FIRST_NAME|there}}}</h1><p>News content...</p>" \
@@ -135,7 +135,7 @@ resend broadcasts create \
 
 # Create broadcast from a React Email template
 resend broadcasts create \
-  --from "news@yourdomain.com" \
+  --from "news@example.com" \
   --subject "Monthly Update" \
   --segment-id <segment-id> \
   --react-email ./emails/newsletter.tsx \
@@ -143,7 +143,7 @@ resend broadcasts create \
 
 # Or create as draft first, then send later
 resend broadcasts create \
-  --from "news@yourdomain.com" \
+  --from "news@example.com" \
   --subject "Monthly Update" \
   --segment-id <segment-id> \
   --html-file ./newsletter.html \
@@ -234,7 +234,7 @@ resend templates create \
   --name "Welcome Email" \
   --subject "Welcome, {{{NAME}}}!" \
   --html "<h1>Welcome {{{NAME}}}</h1><p>Your plan: {{{PLAN}}}</p>" \
-  --from "welcome@yourdomain.com" \
+  --from "welcome@example.com" \
   --alias welcome-email \
   --var NAME:string --var PLAN:string:free
 
@@ -362,8 +362,8 @@ jobs:
       - name: Send deploy notification
         run: |
           resend emails send \
-            --from "deploy@yourdomain.com" \
-            --to "team@yourdomain.com" \
+            --from "deploy@example.com" \
+            --to "team@example.com" \
             --subject "Deploy: ${{ github.repository }}@${{ github.sha }}" \
             --text "Deployed by ${{ github.actor }} at $(date -u)"
 ```
@@ -372,8 +372,8 @@ jobs:
 # Generic CI script
 export RESEND_API_KEY=re_xxx
 resend emails send -q \
-  --from "ci@yourdomain.com" \
-  --to "team@yourdomain.com" \
+  --from "ci@example.com" \
+  --to "team@example.com" \
   --subject "Build complete" \
   --text "Build ${BUILD_ID} passed all tests."
 ```
@@ -400,7 +400,7 @@ resend emails receiving attachment <email-id> <attachment-id>
 
 # Forward received email
 resend emails receiving forward <email-id> \
-  --from "forwarded@yourdomain.com" \
+  --from "forwarded@example.com" \
   --to colleague@example.com
 
 # Watch for new inbound emails in real time

--- a/src/commands/emails/receiving/get.ts
+++ b/src/commands/emails/receiving/get.ts
@@ -16,7 +16,7 @@ export const getReceivingCommand = new Command('get')
       context:
         'The raw.download_url field is a signed URL (expires ~1 hour) containing the full RFC 2822\nMIME message. Pipe it to curl to save the original email:\n  resend emails receiving get <id> --json | jq -r .raw.download_url | xargs curl > email.eml\n\nAttachments are listed in the attachments array. Use the attachments sub-command to get\ndownload URLs:\n  resend emails receiving attachments <id>',
       output:
-        '  {"object":"email","id":"<uuid>","to":["inbox@yourdomain.com"],"from":"sender@external.com","subject":"Hello","html":"<p>Hello!</p>","text":"Hello!","headers":{"x-mailer":"..."},"message_id":"<str>","bcc":[],"cc":[],"reply_to":[],"raw":{"download_url":"<url>","expires_at":"<iso-date>"},"attachments":[]}',
+        '  {"object":"email","id":"<uuid>","to":["inbox@example.com"],"from":"sender@external.com","subject":"Hello","html":"<p>Hello!</p>","text":"Hello!","headers":{"x-mailer":"..."},"message_id":"<str>","bcc":[],"cc":[],"reply_to":[],"raw":{"download_url":"<url>","expires_at":"<iso-date>"},"attachments":[]}',
       errorCodes: ['auth_error', 'fetch_error'],
       examples: [
         'resend emails receiving get <email-id>',

--- a/src/commands/emails/receiving/list.ts
+++ b/src/commands/emails/receiving/list.ts
@@ -26,7 +26,7 @@ export const listReceivingCommand = new Command('list')
       context:
         'Receiving must be enabled on the domain first:\n  resend domains update <id> --receiving enabled\n\nPagination: use --after or --before with a received email ID as the cursor.\nOnly one of --after or --before may be used at a time.\nThe response includes has_more: true when additional pages exist.',
       output:
-        '  {"object":"list","has_more":false,"data":[{"id":"<uuid>","to":["inbox@yourdomain.com"],"from":"sender@external.com","subject":"Hello","created_at":"<iso-date>","message_id":"<str>","bcc":null,"cc":null,"reply_to":null,"attachments":[]}]}',
+        '  {"object":"list","has_more":false,"data":[{"id":"<uuid>","to":["inbox@example.com"],"from":"sender@external.com","subject":"Hello","created_at":"<iso-date>","message_id":"<str>","bcc":null,"cc":null,"reply_to":null,"attachments":[]}]}',
       errorCodes: ['auth_error', 'invalid_limit', 'list_error'],
       examples: [
         'resend emails receiving list',

--- a/tests/commands/emails/receiving/get.test.ts
+++ b/tests/commands/emails/receiving/get.test.ts
@@ -20,7 +20,7 @@ const mockGet = vi.fn(async () => ({
   data: {
     object: 'email' as const,
     id: 'rcv_abc123',
-    to: ['inbox@yourdomain.com'],
+    to: ['inbox@example.com'],
     from: 'sender@external.com',
     subject: 'Hello from outside',
     created_at: '2026-02-18T12:00:00.000Z',

--- a/tests/commands/emails/receiving/list.test.ts
+++ b/tests/commands/emails/receiving/list.test.ts
@@ -23,7 +23,7 @@ const mockList = vi.fn(async () => ({
     data: [
       {
         id: 'rcv_abc123',
-        to: ['inbox@yourdomain.com'],
+        to: ['inbox@example.com'],
         from: 'sender@external.com',
         subject: 'Hello from outside',
         created_at: '2026-02-18T12:00:00.000Z',

--- a/tests/commands/emails/receiving/listen.test.ts
+++ b/tests/commands/emails/receiving/listen.test.ts
@@ -23,7 +23,7 @@ const mockList = vi.fn(async () => ({
     data: [
       {
         id: 'rcv_abc123',
-        to: ['inbox@yourdomain.com'],
+        to: ['inbox@example.com'],
         from: 'sender@external.com',
         subject: 'Hello from outside',
         created_at: '2026-02-18T12:00:00.000Z',


### PR DESCRIPTION
Use the safe, IANA-reserved example.com domain for examples.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace `yourdomain.com` with the IANA‑reserved `example.com` across docs, examples, and tests to avoid linking to a real domain. No behavior changes.

- **Bug Fixes**
  - Updated examples in `README.md` and `skills/resend-cli/references/workflows.md` to use `example.com` (`--from`, `--reply-to`, CI snippets).
  - Updated sample JSON and test mocks in receiving commands to `inbox@example.com`; bumped `skills/resend-cli` to `2.0.1`.

<sup>Written for commit cce3f49c5ead964a9e4802cc2f24591ef802a1f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

