### PR TITLE
chore: run react-email binary test only on relevant changes

### DIFF
--- a/.github/workflows/test-react-email-binary.yml
+++ b/.github/workflows/test-react-email-binary.yml
@@ -1,5 +1,13 @@
 name: Test react-email in binaries
-on: [pull_request]
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'src/lib/react-email*.ts'
+      - 'src/lib/esbuild/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/test-react-email-binary.yml'
 concurrency:
   group: test-react-email-binary-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Run the “Test `react-email` in binaries” workflow only on manual dispatch or PRs that touch the `react-email` bundling layer, `esbuild` plugins, dependencies, or the workflow file. This cuts unnecessary CI runs.

Triggers limited to:
- src/lib/react-email*.ts
- src/lib/esbuild/**
- package.json
- pnpm-lock.yaml
- .github/workflows/test-react-email-binary.yml

<sup>Written for commit 4a677740ed11d90b2d6a5656ed790094349b592c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

