### PR TITLE
feat(react-email): update support to v6.0

### DIFF
--- a/.github/workflows/test-react-email-binary.yml
+++ b/.github/workflows/test-react-email-binary.yml
@@ -44,9 +44,9 @@ jobs:
           mkdir -p /tmp/react-email-test
           cd /tmp/react-email-test
           npm init -y
-          npm install react @react-email/components
+          npm install react react-email
           cat > email.tsx << 'TEMPLATE'
-          import { Html, Text } from '@react-email/components';
+          import { Html, Text } from 'react-email';
           export default function Email() {
             return <Html><Text>Hello from React Email!</Text></Html>;
           }

--- a/skills/resend-cli/references/error-codes.md
+++ b/skills/resend-cli/references/error-codes.md
@@ -20,7 +20,7 @@ All errors exit with code `1` and output JSON to **stderr**:
 | Code | Cause | Resolution |
 |------|-------|------------|
 | `missing_body` | None of `--text`, `--html`, `--html-file`, or `--react-email` provided | Provide at least one body flag |
-| `react_email_build_error` | Failed to bundle a React Email `.tsx` template with esbuild | Check the template compiles; ensure `react` and one of `@react-email/render`, `@react-email/components`, or `react-email` are installed in the project |
+| `react_email_build_error` | Failed to bundle a React Email `.tsx` template with esbuild | Check the template compiles; ensure `react` and `react-email` (6.0+) are installed in the project |
 | `react_email_render_error` | Bundled template failed during `render()` | Check the component exports a default function and renders valid React Email markup |
 | `file_read_error` | Could not read file from `--html-file` path | Check file path exists and is readable |
 | `send_error` | Resend API rejected the send request | Check from address is on a verified domain; check recipient is valid |

--- a/skills/resend-cli/references/error-codes.md
+++ b/skills/resend-cli/references/error-codes.md
@@ -20,7 +20,7 @@ All errors exit with code `1` and output JSON to **stderr**:
 | Code | Cause | Resolution |
 |------|-------|------------|
 | `missing_body` | None of `--text`, `--html`, `--html-file`, or `--react-email` provided | Provide at least one body flag |
-| `react_email_build_error` | Failed to bundle a React Email `.tsx` template with esbuild | Check the template compiles; ensure `react` and `react-email` (6.0+) are installed in the project |
+| `react_email_build_error` | Failed to bundle a React Email `.tsx` template with esbuild | Check the template compiles; ensure `react` and either `react-email` (6.0+) or `@react-email/components` (5.x) are installed in the project |
 | `react_email_render_error` | Bundled template failed during `render()` | Check the component exports a default function and renders valid React Email markup |
 | `file_read_error` | Could not read file from `--html-file` path | Check file path exists and is readable |
 | `send_error` | Resend API rejected the send request | Check from address is on a verified domain; check recipient is valid |

--- a/skills/resend-cli/references/error-codes.md
+++ b/skills/resend-cli/references/error-codes.md
@@ -20,7 +20,7 @@ All errors exit with code `1` and output JSON to **stderr**:
 | Code | Cause | Resolution |
 |------|-------|------------|
 | `missing_body` | None of `--text`, `--html`, `--html-file`, or `--react-email` provided | Provide at least one body flag |
-| `react_email_build_error` | Failed to bundle a React Email `.tsx` template with esbuild | Check the template compiles; ensure `react` and either `react-email` (6.0+) or `@react-email/components` (5.x) are installed in the project |
+| `react_email_build_error` | Failed to bundle a React Email `.tsx` template with esbuild | Check the template compiles; ensure `react` and one of `react-email` (6.0+), `@react-email/components` (5.x), or `@react-email/render` are installed in the project |
 | `react_email_render_error` | Bundled template failed during `render()` | Check the component exports a default function and renders valid React Email markup |
 | `file_read_error` | Could not read file from `--html-file` path | Check file path exists and is readable |
 | `send_error` | Resend API rejected the send request | Check from address is on a verified domain; check recipient is valid |

--- a/src/lib/esbuild/rendering-utilities-exporter.ts
+++ b/src/lib/esbuild/rendering-utilities-exporter.ts
@@ -40,9 +40,14 @@ export const renderingUtilitiesExporter = (emailTemplates: string[]) => ({
         }
 
         result = await b.resolve('@react-email/components', options);
+        if (result.errors.length === 0) {
+          return result;
+        }
+
+        result = await b.resolve('@react-email/render', options);
         if (result.errors.length > 0 && result.errors[0]) {
           result.errors[0].text =
-            'Failed to import `render` from `react-email` (6.0+) or `@react-email/components` (5.x). Install one of them in your project.';
+            'Failed to import `render` from `react-email` (6.0+), `@react-email/components` (5.x), or `@react-email/render`. Install one of them in your project.';
         }
         return result;
       },

--- a/src/lib/esbuild/rendering-utilities-exporter.ts
+++ b/src/lib/esbuild/rendering-utilities-exporter.ts
@@ -34,10 +34,15 @@ export const renderingUtilitiesExporter = (emailTemplates: string[]) => ({
           resolveDir: args.resolveDir,
           namespace: args.namespace,
         };
-        const result = await b.resolve('react-email', options);
+        let result = await b.resolve('react-email', options);
+        if (result.errors.length === 0) {
+          return result;
+        }
+
+        result = await b.resolve('@react-email/components', options);
         if (result.errors.length > 0 && result.errors[0]) {
           result.errors[0].text =
-            'Failed to import `render` from `react-email`. Install it with `npm install react-email` (or upgrade from `@react-email/components` to `react-email` 6.0+).';
+            'Failed to import `render` from `react-email` (6.0+) or `@react-email/components` (5.x). Install one of them in your project.';
         }
         return result;
       },

--- a/src/lib/esbuild/rendering-utilities-exporter.ts
+++ b/src/lib/esbuild/rendering-utilities-exporter.ts
@@ -34,20 +34,10 @@ export const renderingUtilitiesExporter = (emailTemplates: string[]) => ({
           resolveDir: args.resolveDir,
           namespace: args.namespace,
         };
-        let result = await b.resolve('@react-email/render', options);
-        if (result.errors.length === 0) {
-          return result;
-        }
-
-        result = await b.resolve('@react-email/components', options);
-        if (result.errors.length === 0) {
-          return result;
-        }
-
-        result = await b.resolve('react-email', options);
+        const result = await b.resolve('react-email', options);
         if (result.errors.length > 0 && result.errors[0]) {
           result.errors[0].text =
-            "Failed trying to import `render` from `@react-email/render`, `@react-email/components`, or `react-email` to be able to render your email template.\nMaybe you don't have any of them installed?";
+            'Failed to import `render` from `react-email`. Install it with `npm install react-email` (or upgrade from `@react-email/components` to `react-email` 6.0+).';
         }
         return result;
       },


### PR DESCRIPTION
## Summary

react-email 6.0 unifies all components and rendering utilities into a single `react-email` package ([release notes](https://github.com/resend/react-email/releases/tag/react-email%406.0.0)). Users now uninstall `@react-email/components` and install `react-email` instead.

resend-cli doesn't depend on react-email directly — it bundles user `.tsx` templates via esbuild and resolves the `render` export from the user's installed react-email package (`src/lib/esbuild/rendering-utilities-exporter.ts`). Previously the resolver tried `@react-email/render` → `@react-email/components` → `react-email`. This PR drops the legacy fallbacks and resolves only from `react-email` (6.0+).

Changes:
- `src/lib/esbuild/rendering-utilities-exporter.ts` — single resolve to `react-email`; new error message instructing users to install/upgrade.
- `.github/workflows/test-react-email-binary.yml` — binary smoke test now installs `react-email` and uses the new import path.
- `skills/resend-cli/references/error-codes.md` — `react_email_build_error` guidance points to `react-email` (6.0+) only.

## Testing steps

- [ ] In a scratch dir: `npm init -y && npm install react react-email`
- [ ] Create `email.tsx` with `import { Html, Text } from 'react-email'` and a default-exported component
- [ ] Run `node dist/cli.cjs emails send --from x@x.com --to y@y.com --subject t --react-email ./email.tsx --json` — expect `send_error` or `auth_error` (proves bundling + rendering succeeded)
- [ ] Repeat against a project with only `@react-email/components` installed — expect the new `react_email_build_error` with the upgrade instructions
- [ ] Verify the `Test react-email in binaries` workflow passes on macOS/Linux/Windows in CI

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add React Email v6 support by resolving `render` from `react-email`, while keeping fallbacks to `@react-email/components` (v5) and `@react-email/render` for older installs. Updates error guidance and the CI binary smoke test.

- **Migration**
  - Install `react` and `react-email` (6.0+). On v5, keep `@react-email/components` or `@react-email/render`.
  - Update imports on v6 to `from 'react-email'` (e.g., `import { Html, Text, render } from 'react-email'`).
  - If none of `react-email`, `@react-email/components`, or `@react-email/render` are installed, the CLI throws `react_email_build_error` with upgrade steps.

<sup>Written for commit 7fb0550bbe4fb0db49772bd65e80807986af60b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

