### PR TITLE
chore: bump v2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-cli",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "The official CLI for Resend",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump `resend-cli` version from 2.1.0 to 2.2.0 to prepare the v2.2.0 release.

<sup>Written for commit 53258b8e7a8e39e73fbf007642642a53e0a5bad0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

