### PR TITLE
chore: switch back to Depot runners

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   lint:
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: depot-ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-8
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6

--- a/.github/workflows/pin-dependencies-check.yml
+++ b/.github/workflows/pin-dependencies-check.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 jobs:
   pin-dependencies-check:
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: depot-ubuntu-24.04
     container:
       image: node:24
     steps:

--- a/.github/workflows/pin-dependencies-check.yml
+++ b/.github/workflows/pin-dependencies-check.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 jobs:
   pin-dependencies-check:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-8
     container:
       image: node:24
     steps:

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -33,7 +33,7 @@ jobs:
           & $exe --help
   verify-npx:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: depot-ubuntu-24.04
     steps:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -33,7 +33,7 @@ jobs:
           & $exe --help
   verify-npx:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-8
     steps:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -7,7 +7,7 @@ permissions:
   pull-requests: read
 jobs:
   pr-title-check:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-8
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - run: node .github/scripts/pr-title-check.js

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -7,7 +7,7 @@ permissions:
   pull-requests: read
 jobs:
   pr-title-check:
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: depot-ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - run: node .github/scripts/pr-title-check.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ concurrency:
   cancel-in-progress: false
 jobs:
   preflight:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-8
     steps:
       - name: Verify PostHog key is configured
         run: |
@@ -54,7 +54,7 @@ jobs:
           ${{ matrix.binary }} --help
   test-binary-linux-arm64:
     needs: preflight
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-8
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6
@@ -122,7 +122,7 @@ jobs:
             dist/resend-darwin-x64.tar.gz
   build-linux-windows:
     needs: [test-binary, test-binary-linux-arm64]
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-8
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6
@@ -171,7 +171,7 @@ jobs:
     needs: [build-macos, build-linux-windows]
     permissions:
       contents: write
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-8
     outputs:
       prerelease: ${{ steps.meta.outputs.prerelease }}
     steps:
@@ -235,7 +235,7 @@ jobs:
     if: github.event_name != 'workflow_dispatch' && needs.release.outputs.prerelease == 'false'
     name: Trigger Homebrew Tap Update
     needs: release
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-8
     permissions:
       contents: read
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ concurrency:
   cancel-in-progress: false
 jobs:
   preflight:
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Verify PostHog key is configured
         run: |
@@ -54,7 +54,7 @@ jobs:
           ${{ matrix.binary }} --help
   test-binary-linux-arm64:
     needs: preflight
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: depot-ubuntu-24.04-4
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6
@@ -122,7 +122,7 @@ jobs:
             dist/resend-darwin-x64.tar.gz
   build-linux-windows:
     needs: [test-binary, test-binary-linux-arm64]
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: depot-ubuntu-24.04-4
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6
@@ -171,7 +171,7 @@ jobs:
     needs: [build-macos, build-linux-windows]
     permissions:
       contents: write
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: depot-ubuntu-24.04
     outputs:
       prerelease: ${{ steps.meta.outputs.prerelease }}
     steps:
@@ -235,7 +235,7 @@ jobs:
     if: github.event_name != 'workflow_dispatch' && needs.release.outputs.prerelease == 'false'
     name: Trigger Homebrew Tap Update
     needs: release
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: depot-ubuntu-24.04
     permissions:
       contents: read
     steps:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -8,7 +8,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   smoke:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-8
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -8,7 +8,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   smoke:
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: depot-ubuntu-24.04-4
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   sync:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-8
     steps:
       - name: Trigger sync on resend-skills
         env:

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   sync:
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Trigger sync on resend-skills
         env:

--- a/.github/workflows/test-credential-backends.yml
+++ b/.github/workflows/test-credential-backends.yml
@@ -184,7 +184,7 @@ jobs:
   # ── Linux ────────────────────────────────────────────────
   linux-secret-tool:
     name: "Linux: secret-tool (libsecret)"
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-8
     steps:
       - name: Install libsecret and gnome-keyring
         run: |

--- a/.github/workflows/test-credential-backends.yml
+++ b/.github/workflows/test-credential-backends.yml
@@ -184,7 +184,7 @@ jobs:
   # ── Linux ────────────────────────────────────────────────
   linux-secret-tool:
     name: "Linux: secret-tool (libsecret)"
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Install libsecret and gnome-keyring
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   test:
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: depot-ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-8
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -8,7 +8,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   typecheck:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-8
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -8,7 +8,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   typecheck:
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: depot-ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6


### PR DESCRIPTION
Revert ubuntu-latest back to depot-ubuntu-24.04-8 across all workflows.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch CI back to Depot runners and right-size them for speed and consistency. Lightweight jobs use `depot-ubuntu-24.04` (2 vCPU); build-heavy jobs use `depot-ubuntu-24.04-4`.

- **Refactors**
  - Replaced `ubuntu-latest` with `depot-ubuntu-24.04` across lint, test, typecheck, PR title check, dependency pin check, post-release verify, skills sync, and Linux credential tests.
  - Moved heavy builds to `depot-ubuntu-24.04-4` (pkg/Brotli): smoke, release `test-binary-linux-arm64`, and `build-linux-windows`.

<sup>Written for commit c13e3b8eda0aa738477445f754a9fd2b93577c54. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

