### PR TITLE
chore: enable npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,6 +231,41 @@ jobs:
             dist/resend-linux-x64.tar.gz
             dist/resend-linux-arm64.tar.gz
             dist/resend-windows-x64.zip
+  publish-npm:
+    if: github.event_name != 'workflow_dispatch'
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build
+        run: pnpm build
+        env:
+          POSTHOG_PUBLIC_KEY: ${{ secrets.POSTHOG_PUBLIC_KEY }}
+      - name: Verify bundle
+        run: node scripts/verify-bundle.mjs
+      - name: Determine npm tag
+        id: npm-tag
+        run: |
+          TAG="${{ github.ref_name }}"
+          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          else
+            PRERELEASE="${TAG#v[0-9]*.[0-9]*.[0-9]*-}"
+            echo "tag=${PRERELEASE%%[-.]*}" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Publish to npm
+        run: npm publish --tag ${{ steps.npm-tag.outputs.tag }}
   notify-tap:
     if: github.event_name != 'workflow_dispatch' && needs.release.outputs.prerelease == 'false'
     name: Trigger Homebrew Tap Update


### PR DESCRIPTION
Publishes to npm automatically on tag push using GitHub Actions OIDC. The npm dist-tag is derived from the pre-release identifier (e.g. v2.3.0-preview-foo.0 publishes with --tag preview).



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add trusted publishing to npm in the release workflow. On tag pushes, we build and publish via OIDC and auto-derive the npm `--tag` from the version.

- **New Features**
  - Adds `publish-npm` job in `.github/workflows/release.yml` (skips on `workflow_dispatch`).
  - Uses GitHub Actions OIDC to publish to `npm` (no long-lived tokens).
  - Sets `--tag latest` for tags like `vX.Y.Z`; for pre-releases, uses the first identifier (e.g., `v2.3.0-preview-foo.0` -> `preview`).
  - Builds with `pnpm`, verifies with `scripts/verify-bundle.mjs`, then runs `npm publish`.

<sup>Written for commit 4ec46aef56b61499565cfad5de356f1a0064ad26. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

