### PR TITLE
feat: add npm provenance attestation to publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,7 +265,7 @@ jobs:
             echo "tag=${PRERELEASE%%[-.]*}" >> "$GITHUB_OUTPUT"
           fi
       - name: Publish to npm
-        run: npm publish --tag ${{ steps.npm-tag.outputs.tag }}
+        run: npm publish --provenance --tag ${{ steps.npm-tag.outputs.tag }}
   notify-tap:
     if: github.event_name != 'workflow_dispatch' && needs.release.outputs.prerelease == 'false'
     name: Trigger Homebrew Tap Update


### PR DESCRIPTION
Adds --provenance flag to npm publish so published packages include a signed attestation linking back to the source commit and workflow run.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable provenance attestation in the release workflow by adding --provenance to `npm publish`. This embeds a signed attestation linking each published package to the source commit and workflow run, improving traceability.

<sup>Written for commit 9459d85029b2d972032f841b69eda335089f5a97. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

