### PR TITLE
fix: pass POSTHOG_PUBLIC_KEY to npm publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -248,12 +248,6 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Build
-        run: pnpm build
-        env:
-          POSTHOG_PUBLIC_KEY: ${{ secrets.POSTHOG_PUBLIC_KEY }}
-      - name: Verify bundle
-        run: node scripts/verify-bundle.mjs
       - name: Determine npm tag
         id: npm-tag
         run: |
@@ -266,6 +260,8 @@ jobs:
           fi
       - name: Publish to npm
         run: npm publish --provenance --tag ${{ steps.npm-tag.outputs.tag }}
+        env:
+          POSTHOG_PUBLIC_KEY: ${{ secrets.POSTHOG_PUBLIC_KEY }}
   notify-tap:
     if: github.event_name != 'workflow_dispatch' && needs.release.outputs.prerelease == 'false'
     name: Trigger Homebrew Tap Update


### PR DESCRIPTION
npm publish triggers the prepack script which rebuilds the bundle and runs verify-bundle. The previous Build and Verify steps were redundant since prepack does both. Remove them and pass the env var to the publish step so the prepack build has access to it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix release workflow by passing POSTHOG_PUBLIC_KEY to the npm publish step so the prepack build can access it. Removed redundant Build and Verify steps because npm publish already triggers prepack, which rebuilds and runs verify-bundle.

<sup>Written for commit 7f535c1759d5032fcdafcc1a178b6daa078f1b81. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

