### PR TITLE
fix: add new domain statuses

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "esbuild": "0.28.0",
     "esbuild-wasm": "0.28.0",
     "picocolors": "1.1.1",
-    "resend": "6.12.0"
+    "resend": "6.12.2"
   },
   "pkg": {
     "scripts": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-cli",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "The official CLI for Resend",
   "license": "MIT",
   "repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: 1.1.1
         version: 1.1.1
       resend:
-        specifier: 6.12.0
-        version: 6.12.0
+        specifier: 6.12.2
+        version: 6.12.2
     devDependencies:
       '@biomejs/biome':
         specifier: 2.4.11
@@ -1227,8 +1227,8 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
-  resend@6.12.0:
-    resolution: {integrity: sha512-CaxEvX1z+/MGbgnhsM/bvmkbnZd1v1sEXELAjBNSDBQNMaB7MgqOyrBgI27CYikEgdaDnBrXghAXYWTBs/h5Bw==}
+  resend@6.12.2:
+    resolution: {integrity: sha512-xwgmU4b0OqoabJsIoK/x0Whk0Fcs3bpbK4i/DEWPiE5hYJHyHl0TbB6QbI3gIr+bLdLUJ1GYm/fe41aVFuHXgw==}
     engines: {node: '>=20'}
     peerDependencies:
       '@react-email/render': '*'
@@ -2447,7 +2447,7 @@ snapshots:
 
   require-directory@2.1.1: {}
 
-  resend@6.12.0:
+  resend@6.12.2:
     dependencies:
       postal-mime: 2.7.4
       svix: 1.90.0

--- a/src/commands/domains/get.ts
+++ b/src/commands/domains/get.ts
@@ -18,7 +18,7 @@ export const getDomainCommand = new Command('get')
     'after',
     buildHelpText({
       output:
-        '  Full domain object including records array and current status.\n\nDomain status values: not_started | pending | verified | failed | temporary_failure',
+        '  Full domain object including records array and current status.\n\nDomain status values: not_started | pending | verified | failed | partially_verified | partially_failed',
       errorCodes: ['auth_error', 'fetch_error'],
       examples: [
         'resend domains get 4dd369bc-aa82-4ff3-97de-514ae3000ee0',

--- a/src/commands/domains/utils.ts
+++ b/src/commands/domains/utils.ts
@@ -47,6 +47,10 @@ export function statusIndicator(status: string): string {
       return '⏳ Pending';
     case 'not_started':
       return '○ Not started';
+    case 'partially_verified':
+      return '◐ Partially verified';
+    case 'partially_failed':
+      return '◐ Partially failed';
     case 'failed':
     case 'temporary_failure':
       return '✗ Failed';


### PR DESCRIPTION
## Summary

Surface the two new domain-level statuses from resend/resend-node#936 in the CLI:

- Update `domains get` help text to list `partially_verified` and `partially_failed` as valid domain statuses
- Drop `temporary_failure` from the domain-level help text — it is a record-level status, not a domain-level one
- Add `statusIndicator` cases for the new statuses, rendered with a half-circle glyph (`◐`) to signal a partially-completed state

## Test plan

- [x] `pnpm test` — all 847 tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for new domain-level statuses in the CLI. `domains get` help now lists `partially_verified` and `partially_failed` (drops `temporary_failure`), partial statuses render with `◐`, `resend` is bumped to `6.12.2`, and the CLI version is bumped to 2.2.1.

<sup>Written for commit 8081751023d46c8aba910dfd301e52095088376a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

