### PR TITLE
chore: use depot runners

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [depot-ubuntu-24.04, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install via install.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           - os: macos-latest
             target: node24-macos-arm64
             binary: dist/resend
-          - os: ubuntu-latest
+          - os: depot-ubuntu-24.04-4
             target: node24-linux-x64
             binary: dist/resend
           - os: windows-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           - os: macos-latest
             target: node24-macos-arm64
             binary: dist/resend
-          - os: depot-ubuntu-24.04-4
+          - os: depot-ubuntu-24.04
             target: node24-linux-x64
             binary: dist/resend
           - os: windows-latest

--- a/.github/workflows/test-install-unix.yml
+++ b/.github/workflows/test-install-unix.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [depot-ubuntu-24.04-4, macos-latest]
+        os: [depot-ubuntu-24.04, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/test-install-unix.yml
+++ b/.github/workflows/test-install-unix.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [depot-ubuntu-24.04-4, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/test-react-email-binary.yml
+++ b/.github/workflows/test-react-email-binary.yml
@@ -20,7 +20,7 @@ jobs:
           - os: macos-latest
             target: node24-macos-arm64
             binary: dist/resend
-          - os: depot-ubuntu-24.04-4
+          - os: depot-ubuntu-24.04
             target: node24-linux-x64
             binary: dist/resend
           - os: windows-latest

--- a/.github/workflows/test-react-email-binary.yml
+++ b/.github/workflows/test-react-email-binary.yml
@@ -20,7 +20,7 @@ jobs:
           - os: macos-latest
             target: node24-macos-arm64
             binary: dist/resend
-          - os: ubuntu-latest
+          - os: depot-ubuntu-24.04-4
             target: node24-linux-x64
             binary: dist/resend
           - os: windows-latest


### PR DESCRIPTION
## Summary

- Replace remaining `ubuntu-latest` entries with depot runners (matching existing `depot-ubuntu-24.04` convention)
- `publish-npm` in `release.yml` stays on `ubuntu-latest` — npm trusted publishing (OIDC) requires GitHub-hosted runners
- Matrix entries in `post-release.yml`, `release.yml`, `test-install-unix.yml`, and `test-react-email-binary.yml` updated

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Linux CI jobs to Depot runners to standardize and speed up builds, using `depot-ubuntu-24.04` for light tests and `depot-ubuntu-24.04-4` where needed. `publish-npm` in `release.yml` stays on `ubuntu-latest` because npm Trusted Publishing (OIDC) requires GitHub-hosted runners.

<sup>Written for commit 5d7bbef9bca9957a2d7855f490d879753c7f5725. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

