### PR TITLE
chore(ci): harden security

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,12 +3,15 @@ on:
   push:
     branches: [main]
   pull_request:
+permissions:
+  contents: read
 concurrency:
   group: lint-${{ github.ref }}
   cancel-in-progress: true
 jobs:
   lint:
     runs-on: depot-ubuntu-24.04
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6

--- a/.github/workflows/pin-dependencies-check.yml
+++ b/.github/workflows/pin-dependencies-check.yml
@@ -4,9 +4,15 @@ on:
     branches:
       - main
   pull_request:
+permissions:
+  contents: read
+concurrency:
+  group: pin-dependencies-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   pin-dependencies-check:
     runs-on: depot-ubuntu-24.04
+    timeout-minutes: 10
     container:
       image: node:24
     steps:

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -3,9 +3,15 @@ on:
   workflow_run:
     workflows: [Release]
     types: [completed]
+permissions:
+  contents: read
+concurrency:
+  group: post-release-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
 jobs:
   verify-install-unix:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -21,6 +27,7 @@ jobs:
   verify-install-windows:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: windows-latest
+    timeout-minutes: 20
     steps:
       - name: Install via install.ps1
         shell: pwsh
@@ -34,6 +41,7 @@ jobs:
   verify-npx:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: depot-ubuntu-24.04
+    timeout-minutes: 20
     steps:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -5,9 +5,13 @@ on:
 permissions:
   contents: read
   pull-requests: read
+concurrency:
+  group: pr-title-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   pr-title-check:
     runs-on: depot-ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - run: node .github/scripts/pr-title-check.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,7 @@
 name: Release
+permissions:
+  contents: read
+
 on:
   push:
     tags:
@@ -10,6 +13,7 @@ concurrency:
 jobs:
   preflight:
     runs-on: depot-ubuntu-24.04
+    timeout-minutes: 5
     steps:
       - name: Verify PostHog key is configured
         run: |
@@ -19,6 +23,7 @@ jobs:
           fi
   test-binary:
     needs: preflight
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -54,6 +59,7 @@ jobs:
           ${{ matrix.binary }} --help
   test-binary-linux-arm64:
     needs: preflight
+    timeout-minutes: 45
     runs-on: depot-ubuntu-24.04-4
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -82,6 +88,7 @@ jobs:
             sh -c "resend --version && resend --help"
   build-macos:
     needs: [test-binary, test-binary-linux-arm64]
+    timeout-minutes: 45
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -122,6 +129,7 @@ jobs:
             dist/resend-darwin-x64.tar.gz
   build-linux-windows:
     needs: [test-binary, test-binary-linux-arm64]
+    timeout-minutes: 45
     runs-on: depot-ubuntu-24.04-4
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -169,9 +177,11 @@ jobs:
   release:
     if: github.event_name != 'workflow_dispatch'
     needs: [build-macos, build-linux-windows]
+    environment: release
     permissions:
       contents: write
     runs-on: depot-ubuntu-24.04
+    timeout-minutes: 30
     outputs:
       prerelease: ${{ steps.meta.outputs.prerelease }}
     steps:
@@ -235,6 +245,8 @@ jobs:
     if: github.event_name != 'workflow_dispatch'
     needs: release
     runs-on: ubuntu-latest
+    environment: release
+    timeout-minutes: 30
     permissions:
       contents: read
       id-token: write
@@ -267,6 +279,8 @@ jobs:
     name: Trigger Homebrew Tap Update
     needs: release
     runs-on: depot-ubuntu-24.04
+    environment: release
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -3,12 +3,15 @@ on:
   push:
     branches: [main]
   pull_request:
+permissions:
+  contents: read
 concurrency:
   group: smoke-${{ github.ref }}
   cancel-in-progress: true
 jobs:
   smoke:
     runs-on: depot-ubuntu-24.04-4
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -9,9 +9,14 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: sync-skills-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   sync:
     runs-on: depot-ubuntu-24.04
+    timeout-minutes: 15
     steps:
       - name: Trigger sync on resend-skills
         env:

--- a/.github/workflows/test-credential-backends.yml
+++ b/.github/workflows/test-credential-backends.yml
@@ -8,6 +8,11 @@ on:
       - tests/commands/auth/**
       - .github/workflows/test-credential-backends.yml
   workflow_dispatch:
+permissions:
+  contents: read
+concurrency:
+  group: test-credential-backends-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   # ── Cross-platform vitest run for credential file plumbing ───
   # The main test workflow runs Linux only. These jobs exercise the
@@ -16,6 +21,7 @@ jobs:
   # have already produced one cross-platform regression in this area.
   config-tests:
     name: "Config tests (${{ matrix.os }})"
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
@@ -35,6 +41,7 @@ jobs:
   win-passwordvault:
     name: "Windows: PasswordVault"
     runs-on: windows-latest
+    timeout-minutes: 25
     strategy:
       matrix:
         shell: [powershell]
@@ -87,6 +94,7 @@ jobs:
   win-credmanager:
     name: "Windows: Win32 CredManager (P/Invoke)"
     runs-on: windows-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         shell: [pwsh, powershell]
@@ -199,6 +207,7 @@ jobs:
   win-cmdkey:
     name: "Windows: cmdkey"
     runs-on: windows-latest
+    timeout-minutes: 15
     steps:
       - name: Test cmdkey store and list
         shell: cmd
@@ -210,6 +219,7 @@ jobs:
   linux-secret-tool:
     name: "Linux: secret-tool (libsecret)"
     runs-on: depot-ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - name: Install libsecret and gnome-keyring
         run: |
@@ -293,6 +303,7 @@ jobs:
   macos-keychain:
     name: "macOS: security (Keychain)"
     runs-on: macos-latest
+    timeout-minutes: 25
     steps:
       - name: Test security add-generic-password + find + delete
         run: |

--- a/.github/workflows/test-install-unix.yml
+++ b/.github/workflows/test-install-unix.yml
@@ -4,8 +4,14 @@ on:
     paths:
       - install.sh
   workflow_dispatch:
+permissions:
+  contents: read
+concurrency:
+  group: test-install-unix-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   test:
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-install-windows.yml
+++ b/.github/workflows/test-install-windows.yml
@@ -5,9 +5,15 @@ on:
       - install.ps1
       - .github/workflows/test-install-windows.yml
   workflow_dispatch:
+permissions:
+  contents: read
+concurrency:
+  group: test-install-windows-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   test-install:
     runs-on: windows-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         shell: [pwsh, powershell]
@@ -46,6 +52,7 @@ jobs:
           Write-Host "PATH correctly updated"
   test-error-path:
     runs-on: windows-latest
+    timeout-minutes: 15
     strategy:
       matrix:
         shell: [pwsh, powershell]

--- a/.github/workflows/test-react-email-binary.yml
+++ b/.github/workflows/test-react-email-binary.yml
@@ -8,11 +8,14 @@ on:
       - 'package.json'
       - 'pnpm-lock.yaml'
       - '.github/workflows/test-react-email-binary.yml'
+permissions:
+  contents: read
 concurrency:
   group: test-react-email-binary-${{ github.ref }}
   cancel-in-progress: true
 jobs:
   test:
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-telemetry-windows.yml
+++ b/.github/workflows/test-telemetry-windows.yml
@@ -1,9 +1,15 @@
 name: Test Telemetry (Windows)
 on:
   workflow_dispatch:
+permissions:
+  contents: read
+concurrency:
+  group: test-telemetry-windows-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   test:
     runs-on: windows-latest
+    timeout-minutes: 35
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,12 +3,15 @@ on:
   push:
     branches: [main]
   pull_request:
+permissions:
+  contents: read
 concurrency:
   group: test-${{ github.ref }}
   cancel-in-progress: true
 jobs:
   test:
     runs-on: depot-ubuntu-24.04
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -3,12 +3,15 @@ on:
   push:
     branches: [main]
   pull_request:
+permissions:
+  contents: read
 concurrency:
   group: typecheck-${{ github.ref }}
   cancel-in-progress: true
 jobs:
   typecheck:
     runs-on: depot-ubuntu-24.04
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardened GitHub Actions for `resend-cli` by enforcing least-privilege permissions, adding concurrency controls, and setting job timeouts. Publishing is now gated by a `release` environment to require reviewers.

- **Refactors**
  - Set top-level `permissions: contents: read` across workflows; kept `contents: write` only in the release job.
  - Added `concurrency` groups (ref-based); cancel-in-progress true, except `post-release` grouped by head SHA without cancel.
  - Added `timeout-minutes` to all jobs (5–45) to prevent hung runs.
  - Updated `release.yml` with `environment: release` and timeouts across test/build/release.
  - Aligns with Linear DEV-654 findings: missing top-level permissions, missing concurrency, release without environment gate, and missing timeouts.

<sup>Written for commit ade60b9756fe801c6342f0e208cc03eb02e3850a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

