### PR TITLE
chore: add sync-prs-to-linear action

### DIFF
--- a/.github/workflows/sync-prs-to-linear.yml
+++ b/.github/workflows/sync-prs-to-linear.yml
@@ -1,0 +1,24 @@
+name: Sync Open PRs to Linear
+
+on:
+  schedule:
+    - cron: '0 10 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: none
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      pull-requests: write
+      issues: write
+
+    steps:
+      - uses: resend/public-shared-workflows/.github/actions/sync_prs_to_linear@6adbbae7541681ead204faab5d4e5ea9bebca4da
+        with:
+          linear-api-key: ${{ secrets.LINEAR_API_KEY }}
+          linear-team-id: ${{ secrets.LINEAR_TEAM_ID }}
+          github-token: ${{ github.token }}


### PR DESCRIPTION
Adds the  workflow to automatically sync open external contributor PRs to Linear daily.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Actions workflow to sync open external-contributor PRs to Linear daily, with a manual trigger for on-demand runs. Aligns with Linear issue ENG-4902.

- New Features
  - Runs daily at 10:00 UTC (`cron: 0 10 * * *`) and supports `workflow_dispatch`.
  - Uses reusable action `resend/public-shared-workflows/.github/actions/sync_prs_to_linear`.
  - Minimal permissions: write to pull requests and issues only.
  - Inputs: `LINEAR_API_KEY`, `LINEAR_TEAM_ID`, and `github.token`.

<sup>Written for commit c34af373096dc88d6bfaae2afb63a13ab3fb7a84. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

