### PR TITLE
chore: stop running react-email binary test on every dep bump

### DIFF
--- a/.github/workflows/test-react-email-binary.yml
+++ b/.github/workflows/test-react-email-binary.yml
@@ -5,8 +5,6 @@ on:
     paths:
       - 'src/lib/react-email*.ts'
       - 'src/lib/esbuild/**'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
       - '.github/workflows/test-react-email-binary.yml'
 permissions:
   contents: read


### PR DESCRIPTION
The path filter included package.json and pnpm-lock.yaml, so every Renovate PR triggered the full macOS/Linux/Windows binary build and react-email bundling check. Drop those paths; rely on workflow_dispatch for ad-hoc runs when an esbuild or @yao-pkg/pkg bump warrants it.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>: <message>`

Examples:
- New feature: `feat: add new thing`
- Fix: `fix: resolve issue with send command`
- Misc/Chore: `chore: update readme.md`
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop running the react-email binary test on every dependency bump by removing `package.json` and `pnpm-lock.yaml` from the workflow path filter. The CI job now runs only on relevant source/workflow changes; trigger ad‑hoc via `workflow_dispatch` when bumping `esbuild` or `@yao-pkg/pkg`.

<sup>Written for commit f1a65f460b010f58950da55d6f094b5cc430a9e0. Summary will update on new commits. <a href="https://cubic.dev/pr/resend/resend-cli/pull/307?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

