### PR TITLE
feat: suggest commands for mistyped CLI input

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,6 +25,7 @@ import { updateCommand } from './commands/update';
 import { webhooksCommand } from './commands/webhooks/index';
 import { whoamiCommand } from './commands/whoami';
 import { setupCliExitHandler } from './lib/cli-exit';
+import { installCommandSuggestions } from './lib/command-suggestions';
 import { printBannerPlain } from './lib/logo';
 import { errorMessage, outputError } from './lib/output';
 import { trackCommand } from './lib/telemetry';
@@ -163,6 +164,7 @@ telemetryCommand
   });
 
 program.addCommand(telemetryCommand, { hidden: true });
+installCommandSuggestions(program);
 
 program
   .parseAsync()

--- a/src/lib/command-suggestions.ts
+++ b/src/lib/command-suggestions.ts
@@ -121,7 +121,7 @@ export function getCommandSuggestion(
       } else {
         const next = argv[index + 1];
 
-        if (option.optional && (!next || next.startsWith('-'))) {
+        if (option.optional && (next === undefined || next.startsWith('-'))) {
           nextIndex = index + 1;
         } else {
           nextIndex = Math.min(index + 2, argv.length);

--- a/src/lib/command-suggestions.ts
+++ b/src/lib/command-suggestions.ts
@@ -17,8 +17,6 @@ type CommandSuggestion = {
   suggestions: string[];
 }
 
-type OutputConfiguration = ReturnType<Command['configureOutput']>;
-
 export function installCommandSuggestions(
   root: Command,
   opts: InstallOptions = {},
@@ -26,7 +24,7 @@ export function installCommandSuggestions(
   const getArgv = opts.getArgv ?? (() => process.argv.slice(2));
 
   for (const command of walkCommands(root)) {
-    const output = command.configureOutput() as OutputConfiguration;
+    const output = command.configureOutput();
     const outputError = output.outputError ?? ((str, write) => write(str));
 
     command.configureOutput({

--- a/src/lib/command-suggestions.ts
+++ b/src/lib/command-suggestions.ts
@@ -235,7 +235,7 @@ function suggestCommands(unknown: string, commands: Command[]): Command[] {
           continue;
         }
 
-        const distance = editDistance(unknown, name);
+        const distance = editDistance(unknown, name, MAX_DISTANCE);
         const length = Math.max(unknown.length, name.length);
         const similarity = (length - distance) / length;
 
@@ -264,8 +264,12 @@ function suggestCommands(unknown: string, commands: Command[]): Command[] {
     .map((match) => match.command);
 }
 
-function editDistance(a: string, b: string): number {
-  if (Math.abs(a.length - b.length) > MAX_DISTANCE) {
+export function editDistance(
+  a: string,
+  b: string,
+  maxLengthDifference = Number.POSITIVE_INFINITY,
+): number {
+  if (Math.abs(a.length - b.length) > maxLengthDifference) {
     return Math.max(a.length, b.length);
   }
 

--- a/src/lib/command-suggestions.ts
+++ b/src/lib/command-suggestions.ts
@@ -179,13 +179,12 @@ function formatSuggestion(
   suggestion: CommandSuggestion,
 ): string {
   const trailingNewline = errorText.endsWith('\n') ? '\n' : '';
-  const suggestions = suggestion.suggestions;
-  const didYouMean =
-    suggestions.length === 1
-      ? `Did you mean ${suggestions[0]}?`
-      : `Did you mean one of ${suggestions.join(', ')}?`;
+  const { suggestions } = suggestion;
+  const header =
+    suggestions.length === 1 ? 'Did you mean this?' : 'Did you mean one of these?';
+  const list = suggestions.map((s) => `\t${s}`).join('\n');
 
-  return `error: unknown command '${suggestion.unknownCommand}'\n(${didYouMean})${trailingNewline}`;
+  return `error: unknown command '${suggestion.unknownCommand}'\n\n${header}\n${list}${trailingNewline}`;
 }
 
 function commandAndAncestors(command: Command): Command[] {

--- a/src/lib/command-suggestions.ts
+++ b/src/lib/command-suggestions.ts
@@ -1,0 +1,316 @@
+import type { Command, Option } from '@commander-js/extra-typings';
+
+const MAX_DISTANCE = 3;
+const MIN_SIMILARITY = 0.4;
+
+type InternalCommand = Command & {
+  _hidden?: boolean;
+  commands: Command[];
+};
+
+type InstallOptions = {
+  getArgv?: () => string[];
+};
+
+type CommandSuggestion = {
+  unknownCommand: string;
+  suggestions: string[];
+}
+
+type OutputConfiguration = ReturnType<Command['configureOutput']>;
+
+export function installCommandSuggestions(
+  root: Command,
+  opts: InstallOptions = {},
+): void {
+  const getArgv = opts.getArgv ?? (() => process.argv.slice(2));
+
+  for (const command of walkCommands(root)) {
+    const output = command.configureOutput() as OutputConfiguration;
+    const outputError = output.outputError ?? ((str, write) => write(str));
+
+    command.configureOutput({
+      outputError: (str, write) => {
+        outputError(enhanceCommandError(str, root, getArgv()), write);
+      },
+    });
+  }
+}
+
+export function enhanceCommandError(
+  errorText: string,
+  root: Command,
+  argv: string[],
+): string {
+  if (!isCommandError(errorText)) {
+    return errorText;
+  }
+
+  const suggestion = getCommandSuggestion(root, argv);
+  if (!suggestion) {
+    return errorText;
+  }
+
+  return formatSuggestion(errorText, suggestion);
+}
+
+export function getCommandSuggestion(
+  root: Command,
+  argv: string[],
+): CommandSuggestion | undefined {
+  let current = root;
+  const path: string[] = [];
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+
+    if (!token || token === '--') {
+      return undefined;
+    }
+
+    const nextIndex = skipOption(argv, index, current);
+    if (nextIndex === undefined) {
+      return undefined;
+    }
+    if (nextIndex !== index) {
+      index = nextIndex - 1;
+      continue;
+    }
+
+    if (token.startsWith('-')) {
+      return undefined;
+    }
+
+    const exact = findCommand(current, token);
+    if (exact) {
+      current = exact;
+      path.push(exact.name());
+      continue;
+    }
+
+    const suggestions = suggestCommands(token, visibleSubcommands(current)).map(
+      (command) => [root.name(), ...path, command.name()].join(' '),
+    );
+
+    if (suggestions.length === 0) {
+      return undefined;
+    }
+
+    return {
+      unknownCommand: token,
+      suggestions,
+    };
+  }
+
+  return undefined;
+}
+
+function isCommandError(errorText: string): boolean {
+  return (
+    /^error: unknown command /.test(errorText) ||
+    /^error: too many arguments/.test(errorText)
+  );
+}
+
+function formatSuggestion(
+  errorText: string,
+  suggestion: CommandSuggestion,
+): string {
+  const trailingNewline = errorText.endsWith('\n') ? '\n' : '';
+  const suggestions = suggestion.suggestions;
+  const didYouMean =
+    suggestions.length === 1
+      ? `Did you mean ${suggestions[0]}?`
+      : `Did you mean one of ${suggestions.join(', ')}?`;
+
+  return `error: unknown command '${suggestion.unknownCommand}'\n(${didYouMean})${trailingNewline}`;
+}
+
+function walkCommands(root: Command): Command[] {
+  const commands: Command[] = [root];
+
+  for (const subcommand of (root as InternalCommand).commands) {
+    commands.push(...walkCommands(subcommand));
+  }
+
+  return commands;
+}
+
+function skipOption(
+  argv: string[],
+  index: number,
+  current: Command,
+): number | undefined {
+  const token = argv[index];
+
+  if (!token.startsWith('-') || token === '-') {
+    return index;
+  }
+
+  const option = findOption(current, token);
+  if (!option) {
+    return undefined;
+  }
+
+  if (!option.required && !option.optional) {
+    return index + 1;
+  }
+
+  if (option.variadic) {
+    return argv.length;
+  }
+
+  if (token.startsWith('--') && token.includes('=')) {
+    return index + 1;
+  }
+
+  if (!token.startsWith('--') && token.length > 2) {
+    return index + 1;
+  }
+
+  const next = argv[index + 1];
+  if (option.optional && (!next || next.startsWith('-'))) {
+    return index + 1;
+  }
+
+  return Math.min(index + 2, argv.length);
+}
+
+function findOption(current: Command, token: string): Option | undefined {
+  const flag = optionFlag(token);
+
+  for (const command of commandAndAncestors(current)) {
+    for (const option of command.createHelp().visibleOptions(command)) {
+      if (option.long === flag || option.short === flag) {
+        return option;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function optionFlag(token: string): string {
+  if (token.startsWith('--')) {
+    return token.split('=', 1)[0];
+  }
+
+  return token.length > 2 ? token.slice(0, 2) : token;
+}
+
+function commandAndAncestors(command: Command): Command[] {
+  const commands: Command[] = [];
+
+  for (
+    let current: Command | undefined = command;
+    current;
+    current = current.parent as Command | undefined
+  ) {
+    commands.push(current);
+  }
+
+  return commands;
+}
+
+function findCommand(parent: Command, name: string): Command | undefined {
+  return subcommands(parent).find((command) => commandNames(command).has(name));
+}
+
+function visibleSubcommands(parent: Command): Command[] {
+  return parent
+    .createHelp()
+    .visibleCommands(parent)
+    .filter((command) => !(command as InternalCommand)._hidden) as Command[];
+}
+
+function subcommands(parent: Command): Command[] {
+  const commands = [...(parent as InternalCommand).commands];
+
+  for (const command of visibleSubcommands(parent)) {
+    if (!commands.includes(command)) {
+      commands.push(command);
+    }
+  }
+
+  return commands;
+}
+
+function commandNames(command: Command): Set<string> {
+  return new Set([command.name(), ...command.aliases()]);
+}
+
+function suggestCommands(unknown: string, commands: Command[]): Command[] {
+  const matches = commands
+    .map((command) => {
+      let bestDistance = Number.POSITIVE_INFINITY;
+
+      for (const name of commandNames(command)) {
+        if (name.length <= 1) {
+          continue;
+        }
+
+        const distance = editDistance(unknown, name);
+        const length = Math.max(unknown.length, name.length);
+        const similarity = (length - distance) / length;
+
+        if (
+          distance <= MAX_DISTANCE &&
+          similarity > MIN_SIMILARITY &&
+          distance < bestDistance
+        ) {
+          bestDistance = distance;
+        }
+      }
+
+      return { command, distance: bestDistance };
+    })
+    .filter((match) => Number.isFinite(match.distance));
+
+  if (matches.length === 0) {
+    return [];
+  }
+
+  const bestDistance = Math.min(...matches.map((match) => match.distance));
+
+  return matches
+    .filter((match) => match.distance === bestDistance)
+    .sort((a, b) => a.command.name().localeCompare(b.command.name()))
+    .map((match) => match.command);
+}
+
+function editDistance(a: string, b: string): number {
+  if (Math.abs(a.length - b.length) > MAX_DISTANCE) {
+    return Math.max(a.length, b.length);
+  }
+
+  const distances: number[][] = [];
+
+  for (let i = 0; i <= a.length; i += 1) {
+    distances[i] = [i];
+  }
+
+  for (let j = 0; j <= b.length; j += 1) {
+    distances[0][j] = j;
+  }
+
+  for (let j = 1; j <= b.length; j += 1) {
+    for (let i = 1; i <= a.length; i += 1) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+
+      distances[i][j] = Math.min(
+        distances[i - 1][j] + 1,
+        distances[i][j - 1] + 1,
+        distances[i - 1][j - 1] + cost,
+      );
+
+      if (i > 1 && j > 1 && a[i - 1] === b[j - 2] && a[i - 2] === b[j - 1]) {
+        distances[i][j] = Math.min(
+          distances[i][j],
+          distances[i - 2][j - 2] + 1,
+        );
+      }
+    }
+  }
+
+  return distances[a.length][b.length];
+}

--- a/src/lib/command-suggestions.ts
+++ b/src/lib/command-suggestions.ts
@@ -15,7 +15,7 @@ type InstallOptions = {
 type CommandSuggestion = {
   unknownCommand: string;
   suggestions: string[];
-}
+};
 
 export function installCommandSuggestions(
   root: Command,
@@ -23,7 +23,23 @@ export function installCommandSuggestions(
 ): void {
   const getArgv = opts.getArgv ?? (() => process.argv.slice(2));
 
-  for (const command of walkCommands(root)) {
+  const commands: Command[] = [];
+  const stack = [root];
+
+  while (stack.length > 0) {
+    const command = stack.pop();
+    if (!command) {
+      break;
+    }
+
+    commands.push(command);
+
+    for (const subcommand of (command as InternalCommand).commands) {
+      stack.push(subcommand);
+    }
+  }
+
+  for (const command of commands) {
     const output = command.configureOutput();
     const outputError = output.outputError ?? ((str, write) => write(str));
 
@@ -66,7 +82,53 @@ export function getCommandSuggestion(
       return undefined;
     }
 
-    const nextIndex = skipOption(argv, index, current);
+    let nextIndex: number | undefined = index;
+
+    if (token.startsWith('-') && token !== '-') {
+      const flag = token.startsWith('--')
+        ? token.split('=', 1)[0]
+        : token.length > 2
+          ? token.slice(0, 2)
+          : token;
+
+      let option: Option | undefined;
+
+      for (const command of commandAndAncestors(current)) {
+        for (const visibleOption of command
+          .createHelp()
+          .visibleOptions(command)) {
+          if (visibleOption.long === flag || visibleOption.short === flag) {
+            option = visibleOption;
+            break;
+          }
+        }
+
+        if (option) {
+          break;
+        }
+      }
+
+      if (!option) {
+        nextIndex = undefined;
+      } else if (!option.required && !option.optional) {
+        nextIndex = index + 1;
+      } else if (option.variadic) {
+        nextIndex = argv.length;
+      } else if (token.startsWith('--') && token.includes('=')) {
+        nextIndex = index + 1;
+      } else if (!token.startsWith('--') && token.length > 2) {
+        nextIndex = index + 1;
+      } else {
+        const next = argv[index + 1];
+
+        if (option.optional && (!next || next.startsWith('-'))) {
+          nextIndex = index + 1;
+        } else {
+          nextIndex = Math.min(index + 2, argv.length);
+        }
+      }
+    }
+
     if (nextIndex === undefined) {
       return undefined;
     }
@@ -79,7 +141,9 @@ export function getCommandSuggestion(
       return undefined;
     }
 
-    const exact = findCommand(current, token);
+    const exact = subcommands(current).find((command) =>
+      commandNames(command).has(token),
+    );
     if (exact) {
       current = exact;
       path.push(exact.name());
@@ -124,78 +188,6 @@ function formatSuggestion(
   return `error: unknown command '${suggestion.unknownCommand}'\n(${didYouMean})${trailingNewline}`;
 }
 
-function walkCommands(root: Command): Command[] {
-  const commands: Command[] = [root];
-
-  for (const subcommand of (root as InternalCommand).commands) {
-    commands.push(...walkCommands(subcommand));
-  }
-
-  return commands;
-}
-
-function skipOption(
-  argv: string[],
-  index: number,
-  current: Command,
-): number | undefined {
-  const token = argv[index];
-
-  if (!token.startsWith('-') || token === '-') {
-    return index;
-  }
-
-  const option = findOption(current, token);
-  if (!option) {
-    return undefined;
-  }
-
-  if (!option.required && !option.optional) {
-    return index + 1;
-  }
-
-  if (option.variadic) {
-    return argv.length;
-  }
-
-  if (token.startsWith('--') && token.includes('=')) {
-    return index + 1;
-  }
-
-  if (!token.startsWith('--') && token.length > 2) {
-    return index + 1;
-  }
-
-  const next = argv[index + 1];
-  if (option.optional && (!next || next.startsWith('-'))) {
-    return index + 1;
-  }
-
-  return Math.min(index + 2, argv.length);
-}
-
-function findOption(current: Command, token: string): Option | undefined {
-  const flag = optionFlag(token);
-
-  for (const command of commandAndAncestors(current)) {
-    for (const option of command.createHelp().visibleOptions(command)) {
-      if (option.long === flag || option.short === flag) {
-        return option;
-      }
-    }
-  }
-
-  return undefined;
-}
-
-function optionFlag(token: string): string {
-  if (token.startsWith('--')) {
-    return token.split('=', 1)[0];
-  }
-
-  return token.length > 2 ? token.slice(0, 2) : token;
-}
-
 function commandAndAncestors(command: Command): Command[] {
   const commands: Command[] = [];
 
@@ -208,10 +200,6 @@ function commandAndAncestors(command: Command): Command[] {
   }
 
   return commands;
-}
-
-function findCommand(parent: Command, name: string): Command | undefined {
-  return subcommands(parent).find((command) => commandNames(command).has(name));
 }
 
 function visibleSubcommands(parent: Command): Command[] {

--- a/src/lib/command-suggestions.ts
+++ b/src/lib/command-suggestions.ts
@@ -181,7 +181,9 @@ function formatSuggestion(
   const trailingNewline = errorText.endsWith('\n') ? '\n' : '';
   const { suggestions } = suggestion;
   const header =
-    suggestions.length === 1 ? 'Did you mean this?' : 'Did you mean one of these?';
+    suggestions.length === 1
+      ? 'Did you mean this?'
+      : 'Did you mean one of these?';
   const list = suggestions.map((s) => `\t${s}`).join('\n');
 
   return `error: unknown command '${suggestion.unknownCommand}'\n\n${header}\n${list}${trailingNewline}`;

--- a/tests/lib/command-suggestions.test.ts
+++ b/tests/lib/command-suggestions.test.ts
@@ -105,6 +105,18 @@ describe('enhanceCommandError', () => {
     );
   });
 
+  it('consumes empty-string optional option values before suggesting commands', () => {
+    expect(
+      enhanceCommandError(EXCESS_ARGS, buildProgram(), [
+        '--profile',
+        '',
+        'contatcs',
+      ]),
+    ).toBe(
+      "error: unknown command 'contatcs'\n(Did you mean resend contacts?)\n",
+    );
+  });
+
   it('uses aliases to find suggestions but prints canonical command names', () => {
     expect(
       enhanceCommandError(EXCESS_ARGS, buildProgram(), ['contacts', 'sl']),

--- a/tests/lib/command-suggestions.test.ts
+++ b/tests/lib/command-suggestions.test.ts
@@ -69,7 +69,7 @@ function plainLevenshteinDistance(a: string, b: string): number {
 describe('enhanceCommandError', () => {
   it('suggests a top-level command for a singular typo', () => {
     expect(enhanceCommandError(EXCESS_ARGS, buildProgram(), ['contact'])).toBe(
-      "error: unknown command 'contact'\n(Did you mean resend contacts?)\n",
+      "error: unknown command 'contact'\n\nDid you mean this?\n\tresend contacts\n",
     );
   });
 
@@ -77,7 +77,7 @@ describe('enhanceCommandError', () => {
     expect(
       enhanceCommandError(EXCESS_ARGS, buildProgram(), ['contacts', 'lsti']),
     ).toBe(
-      "error: unknown command 'lsti'\n(Did you mean resend contacts list?)\n",
+      "error: unknown command 'lsti'\n\nDid you mean this?\n\tresend contacts list\n",
     );
   });
 
@@ -89,7 +89,7 @@ describe('enhanceCommandError', () => {
         'attchments',
       ]),
     ).toBe(
-      "error: unknown command 'attchments'\n(Did you mean resend emails receiving attachments?)\n",
+      "error: unknown command 'attchments'\n\nDid you mean this?\n\tresend emails receiving attachments\n",
     );
   });
 
@@ -101,7 +101,7 @@ describe('enhanceCommandError', () => {
         'contatcs',
       ]),
     ).toBe(
-      "error: unknown command 'contatcs'\n(Did you mean resend contacts?)\n",
+      "error: unknown command 'contatcs'\n\nDid you mean this?\n\tresend contacts\n",
     );
   });
 
@@ -113,7 +113,7 @@ describe('enhanceCommandError', () => {
         'contatcs',
       ]),
     ).toBe(
-      "error: unknown command 'contatcs'\n(Did you mean resend contacts?)\n",
+      "error: unknown command 'contatcs'\n\nDid you mean this?\n\tresend contacts\n",
     );
   });
 
@@ -121,7 +121,7 @@ describe('enhanceCommandError', () => {
     expect(
       enhanceCommandError(EXCESS_ARGS, buildProgram(), ['contacts', 'sl']),
     ).toBe(
-      "error: unknown command 'sl'\n(Did you mean resend contacts list?)\n",
+      "error: unknown command 'sl'\n\nDid you mean this?\n\tresend contacts list\n",
     );
   });
 

--- a/tests/lib/command-suggestions.test.ts
+++ b/tests/lib/command-suggestions.test.ts
@@ -1,9 +1,14 @@
 import { Command } from '@commander-js/extra-typings';
 import { describe, expect, it } from 'vitest';
-import { enhanceCommandError } from '../../src/lib/command-suggestions';
+import {
+  editDistance,
+  enhanceCommandError,
+} from '../../src/lib/command-suggestions';
 
 const EXCESS_ARGS =
   'error: too many arguments. Expected 0 arguments but got 1.\n';
+
+const COMMAND_SUGGESTION_MAX_DISTANCE = 3;
 
 function buildProgram(): Command {
   const program = new Command('resend')
@@ -33,6 +38,32 @@ function buildProgram(): Command {
     .addCommand(new Command('telemetry'), { hidden: true });
 
   return program;
+}
+
+function plainLevenshteinDistance(a: string, b: string): number {
+  const distances: number[][] = [];
+
+  for (let i = 0; i <= a.length; i += 1) {
+    distances[i] = [i];
+  }
+
+  for (let j = 0; j <= b.length; j += 1) {
+    distances[0][j] = j;
+  }
+
+  for (let j = 1; j <= b.length; j += 1) {
+    for (let i = 1; i <= a.length; i += 1) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+
+      distances[i][j] = Math.min(
+        distances[i - 1][j] + 1,
+        distances[i][j - 1] + 1,
+        distances[i - 1][j - 1] + cost,
+      );
+    }
+  }
+
+  return distances[a.length][b.length];
 }
 
 describe('enhanceCommandError', () => {
@@ -104,5 +135,62 @@ describe('enhanceCommandError', () => {
     expect(
       enhanceCommandError(EXCESS_ARGS, buildProgram(), ['telemetri']),
     ).toBe(EXCESS_ARGS);
+  });
+});
+
+describe('editDistance', () => {
+  it.each([
+    ['identical strings', 'contacts', 'contacts', 0],
+    ['empty strings', '', '', 0],
+    ['empty to non-empty', '', 'list', 4],
+    ['single insertion', 'contact', 'contacts', 1],
+    ['single deletion', 'contacts', 'contact', 1],
+    ['single substitution', 'contect', 'contact', 1],
+    ['adjacent transposition', 'sl', 'ls', 1],
+    ['transposition in longer strings', 'contatcs', 'contacts', 1],
+    ['multiple edits within threshold', 'lsti', 'list', 2],
+    ['missing character typo', 'attchments', 'attachments', 1],
+    ['trailing typo', 'telemetri', 'telemetry', 1],
+    ['unrelated strings', 'abc', 'xyz', 3],
+    ['classic damerau example', 'ca', 'abc', 3],
+  ] as const)('%s', (_label, a, b, expected) => {
+    expect(editDistance(a, b)).toBe(expected);
+    expect(editDistance(b, a)).toBe(expected);
+  });
+
+  it('treats adjacent transpositions as one edit, unlike plain Levenshtein', () => {
+    expect(editDistance('sl', 'ls')).toBe(1);
+    expect(plainLevenshteinDistance('sl', 'ls')).toBe(2);
+  });
+
+  it('short-circuits when length difference exceeds maxLengthDifference', () => {
+    expect(editDistance('a', 'abcdef', COMMAND_SUGGESTION_MAX_DISTANCE)).toBe(
+      6,
+    );
+    expect(editDistance('abcdef', 'a', COMMAND_SUGGESTION_MAX_DISTANCE)).toBe(
+      6,
+    );
+  });
+
+  it('still computes exact distance when length difference is within threshold', () => {
+    expect(editDistance('abcd', 'abef', COMMAND_SUGGESTION_MAX_DISTANCE)).toBe(
+      2,
+    );
+  });
+
+  it('computes exact distance when maxLengthDifference is not provided', () => {
+    expect(editDistance('short', 'much-longer-string')).toBe(14);
+  });
+
+  it('keeps alias typo matches inside suggestion thresholds', () => {
+    const typo = 'sl';
+    const alias = 'ls';
+    const distance = editDistance(typo, alias, COMMAND_SUGGESTION_MAX_DISTANCE);
+    const similarity =
+      (Math.max(typo.length, alias.length) - distance) /
+      Math.max(typo.length, alias.length);
+
+    expect(distance).toBeLessThanOrEqual(COMMAND_SUGGESTION_MAX_DISTANCE);
+    expect(similarity).toBeGreaterThan(0.4);
   });
 });

--- a/tests/lib/command-suggestions.test.ts
+++ b/tests/lib/command-suggestions.test.ts
@@ -1,0 +1,108 @@
+import { Command } from '@commander-js/extra-typings';
+import { describe, expect, it } from 'vitest';
+import { enhanceCommandError } from '../../src/lib/command-suggestions';
+
+const EXCESS_ARGS =
+  'error: too many arguments. Expected 0 arguments but got 1.\n';
+
+function buildProgram(): Command {
+  const program = new Command('resend')
+    .option('--api-key <key>', 'API key')
+    .option('-p, --profile <name>', 'Profile name')
+    .option('--json', 'JSON output')
+    .option('-q, --quiet', 'Quiet output');
+
+  const contacts = new Command('contacts')
+    .addCommand(new Command('list').alias('ls'), { isDefault: true })
+    .addCommand(new Command('get').argument('[id]'))
+    .addCommand(new Command('delete').alias('rm'));
+
+  const receiving = new Command('receiving')
+    .addCommand(new Command('list'), { isDefault: true })
+    .addCommand(new Command('attachments'))
+    .addCommand(new Command('attachment'));
+
+  const emails = new Command('emails')
+    .addCommand(new Command('list'), { isDefault: true })
+    .addCommand(new Command('send'))
+    .addCommand(receiving);
+
+  program
+    .addCommand(contacts)
+    .addCommand(emails)
+    .addCommand(new Command('telemetry'), { hidden: true });
+
+  return program;
+}
+
+describe('enhanceCommandError', () => {
+  it('suggests a top-level command for a singular typo', () => {
+    expect(enhanceCommandError(EXCESS_ARGS, buildProgram(), ['contact'])).toBe(
+      "error: unknown command 'contact'\n(Did you mean resend contacts?)\n",
+    );
+  });
+
+  it('suggests nested commands hidden by a default list command', () => {
+    expect(
+      enhanceCommandError(EXCESS_ARGS, buildProgram(), ['contacts', 'lsti']),
+    ).toBe(
+      "error: unknown command 'lsti'\n(Did you mean resend contacts list?)\n",
+    );
+  });
+
+  it('suggests deeply nested commands', () => {
+    expect(
+      enhanceCommandError(EXCESS_ARGS, buildProgram(), [
+        'emails',
+        'receiving',
+        'attchments',
+      ]),
+    ).toBe(
+      "error: unknown command 'attchments'\n(Did you mean resend emails receiving attachments?)\n",
+    );
+  });
+
+  it('skips global option values before suggesting commands', () => {
+    expect(
+      enhanceCommandError(EXCESS_ARGS, buildProgram(), [
+        '--profile',
+        'contact',
+        'contatcs',
+      ]),
+    ).toBe(
+      "error: unknown command 'contatcs'\n(Did you mean resend contacts?)\n",
+    );
+  });
+
+  it('uses aliases to find suggestions but prints canonical command names', () => {
+    expect(
+      enhanceCommandError(EXCESS_ARGS, buildProgram(), ['contacts', 'sl']),
+    ).toBe(
+      "error: unknown command 'sl'\n(Did you mean resend contacts list?)\n",
+    );
+  });
+
+  it('does not suggest commands for real extra positional arguments', () => {
+    expect(
+      enhanceCommandError(EXCESS_ARGS, buildProgram(), [
+        'contacts',
+        'someone@example.com',
+      ]),
+    ).toBe(EXCESS_ARGS);
+  });
+
+  it('does not duplicate existing unknown option suggestions', () => {
+    const unknownOption =
+      "error: unknown option '--jsn'\n(Did you mean --json?)\n";
+
+    expect(enhanceCommandError(unknownOption, buildProgram(), ['--jsn'])).toBe(
+      unknownOption,
+    );
+  });
+
+  it('does not suggest hidden commands', () => {
+    expect(
+      enhanceCommandError(EXCESS_ARGS, buildProgram(), ['telemetri']),
+    ).toBe(EXCESS_ARGS);
+  });
+});


### PR DESCRIPTION
## Summary
- Suggest the closest valid command when users mistype a CLI command or subcommand (Git-style "Did you mean?")
- Supports nested commands and aliases; skips hidden/internal commands
- Handles global flags before parsing command tokens

Closes discussion #294

- `pnpm dev template` → suggests `resend templates`
- `pnpm dev contact` → suggests `resend contacts`
- `pnpm dev telemetri` → no suggestion (hidden command)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Git-style “Did you mean?” suggestions for mistyped CLI commands and subcommands. Installed via `installCommandSuggestions(program)` with clearer message formatting and no exposure of hidden commands.

- **New Features**
  - Intercepts unknown-command errors via `configureOutput` and suggests candidates using a Damerau–Levenshtein score; improves copy with singular/plural headers.
  - Skips global flags and their values before matching, suggests full command paths, prints canonical names, and preserves existing unknown option suggestions.

- **Bug Fixes**
  - Treats empty optional option values (e.g., `--profile ""`) as present so they’re consumed before matching commands.

<sup>Written for commit 7c5149601d5d715c82b4fbd85ee36a1557a7e68f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-cli/pull/322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

