### PR TITLE
feat: add domains claim commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "esbuild": "0.28.0",
     "esbuild-wasm": "0.28.0",
     "picocolors": "1.1.1",
-    "resend": "6.12.3"
+    "resend": "6.14.0"
   },
   "pkg": {
     "scripts": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: 1.1.1
         version: 1.1.1
       resend:
-        specifier: 6.12.3
-        version: 6.12.3
+        specifier: 6.14.0
+        version: 6.14.0
     devDependencies:
       '@biomejs/biome':
         specifier: 2.4.11
@@ -1226,8 +1226,8 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
-  resend@6.12.3:
-    resolution: {integrity: sha512-FkEi6YPnVL96/LvH8+QP7NaeaBy5brYXwlRqUCqZZeNL0/iyKij18IPmyPXYauT/2ODn1JG04qKz+qlJfzqzTw==}
+  resend@6.14.0:
+    resolution: {integrity: sha512-jVdpUgOoWGLjaP64lo8KwzHT9gY4w6Dl8c36CIb2F+ayYOMLr3khqs8xrNjXM2k19b+lPoj0VWQFhVNLiToBjA==}
     engines: {node: '>=20'}
     peerDependencies:
       '@react-email/render': '*'
@@ -1312,9 +1312,6 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
-
-  svix@1.92.2:
-    resolution: {integrity: sha512-ZmuA3UVvlnF9EgxlzmPtF7CKjQb64Z6OFlyfdDfU0sdcC7dJa+3aOYX5B9mA+RS6ch1AxBa4UP/l6KmqfGtWBQ==}
 
   tar-fs@2.1.4:
     resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
@@ -2434,10 +2431,10 @@ snapshots:
 
   require-directory@2.1.1: {}
 
-  resend@6.12.3:
+  resend@6.14.0:
     dependencies:
       postal-mime: 2.7.4
-      svix: 1.92.2
+      standardwebhooks: 1.0.0
 
   resolve.exports@2.0.3: {}
 
@@ -2541,10 +2538,6 @@ snapshots:
   strip-json-comments@2.0.1: {}
 
   supports-preserve-symlinks-flag@1.0.0: {}
-
-  svix@1.92.2:
-    dependencies:
-      standardwebhooks: 1.0.0
 
   tar-fs@2.1.4:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 allowBuilds:
   esbuild: true
   '@biomejs/biome': true
+minimumReleaseAgeExclude:
+  - resend@6.14.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,3 @@
 allowBuilds:
   esbuild: true
   '@biomejs/biome': true
-minimumReleaseAgeExclude:
-  - resend@6.14.0

--- a/skills/resend-cli/SKILL.md
+++ b/skills/resend-cli/SKILL.md
@@ -11,7 +11,7 @@ description: >
 license: MIT
 metadata:
   author: resend
-  version: "2.1.0"
+  version: "2.2.0"
   homepage: https://resend.com/docs/cli-agents
   source: https://github.com/resend/resend-cli
   openclaw:
@@ -139,7 +139,7 @@ Auth resolves: `--api-key` flag > `RESEND_API_KEY` env > config file (`resend lo
 |--------------|-------------|
 | `emails` | send, get, list, batch, cancel, update |
 | `emails receiving` | list, get, attachments, forward, listen |
-| `domains` | create, verify, update, delete, list |
+| `domains` | create, verify, claim, update, delete, list |
 | `logs` | list, get, open |
 | `api-keys` | create, list, delete |
 | `automations` | create, get, list, update, delete, stop, open, runs |

--- a/skills/resend-cli/SKILL.md
+++ b/skills/resend-cli/SKILL.md
@@ -139,7 +139,7 @@ Auth resolves: `--api-key` flag > `RESEND_API_KEY` env > config file (`resend lo
 |--------------|-------------|
 | `emails` | send, get, list, batch, cancel, update |
 | `emails receiving` | list, get, attachments, forward, listen |
-| `domains` | create, verify, claim, update, delete, list |
+| `domains` | create, verify, get, claim, update, delete, list |
 | `logs` | list, get, open |
 | `api-keys` | create, list, delete |
 | `automations` | create, get, list, update, delete, stop, open, runs |

--- a/skills/resend-cli/references/domains.md
+++ b/skills/resend-cli/references/domains.md
@@ -79,3 +79,40 @@ At least one option required.
 | `--yes` | boolean | Yes (non-interactive) | Skip confirmation |
 
 **Alias:** `rm`
+
+---
+
+## domains claim
+
+Claim a domain that **another Resend account has already verified**. The domain transfers to your account as a brand-new domain with fresh DKIM keys, so the previous account's DNS records can't be reused.
+
+**Lifecycle:**
+1. `resend domains claim create --name example.com` — returns the TXT record to add
+2. Add the TXT record at your DNS provider
+3. `resend domains claim verify <domain-id>` — trigger verification + transfer
+4. `resend domains claim get <domain-id>` — poll until `completed`
+5. The transferred domain has NEW DKIM records — run `resend domains get <domain-id>` for the records, update DNS, then `resend domains verify <domain-id>`
+
+Claim status values: `pending` | `verified` | `completed` | `blocked` | `expired` | `superseded` | `canceled` | `failed`.
+
+### domains claim create
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--name <domain>` | string | Yes (non-interactive) | Domain name to claim (e.g., `example.com`) |
+| `--region <region>` | string | No | `us-east-1` \| `eu-west-1` \| `sa-east-1` \| `ap-northeast-1` |
+| `--tracking-subdomain <subdomain>` | string | No | Subdomain for click and open tracking (e.g., `track`) |
+
+**Output:** `domain_claim` object with `domain_id` (the placeholder domain) and a TXT `record` to add to DNS.
+
+### domains claim get
+
+**Argument:** `<id>` — Domain ID (the placeholder domain created by the claim)
+
+**Output:** `domain_claim` with `status`, `domain_id`, the TXT `record`, `blocked_reason`, `expires_at`.
+
+### domains claim verify
+
+**Argument:** `<id>` — Domain ID (the placeholder domain created by the claim)
+
+Triggers async verification + transfer. Poll `domains claim get <id>` for status. After `completed`, fetch the new DKIM records with `domains get <id>`, update DNS, then run `domains verify <id>`.

--- a/src/commands/domains/claim/create.ts
+++ b/src/commands/domains/claim/create.ts
@@ -1,0 +1,72 @@
+import { Command, Option } from '@commander-js/extra-typings';
+import { runCreate } from '../../../lib/actions';
+import type { GlobalOpts } from '../../../lib/client';
+import { buildHelpText } from '../../../lib/help-text';
+import { requireText } from '../../../lib/prompts';
+
+export const claimCreateCommand = new Command('create')
+  .description('Start a claim for a domain another Resend account has verified')
+  .option('--name <domain>', 'Domain name to claim (e.g. example.com)')
+  .addOption(
+    new Option('--region <region>', 'Sending region').choices([
+      'us-east-1',
+      'eu-west-1',
+      'sa-east-1',
+      'ap-northeast-1',
+    ] as const),
+  )
+  .option(
+    '--tracking-subdomain <subdomain>',
+    'Subdomain for click and open tracking (e.g. track)',
+  )
+  .addHelpText(
+    'after',
+    buildHelpText({
+      context:
+        'Non-interactive: --name is required (no prompts when stdin/stdout is not a TTY)',
+      output:
+        '  domain_claim object with the placeholder domain_id and the TXT record to add to DNS.',
+      errorCodes: ['auth_error', 'missing_name', 'create_error'],
+      examples: [
+        'resend domains claim create --name example.com',
+        'resend domains claim create --name example.com --region eu-west-1',
+        'resend domains claim create --name example.com --json',
+      ],
+    }),
+  )
+  .action(async (opts, cmd) => {
+    const globalOpts = cmd.optsWithGlobals() as GlobalOpts;
+
+    const name = await requireText(
+      opts.name,
+      { message: 'Domain name to claim', placeholder: 'example.com' },
+      { message: 'Missing --name flag.', code: 'missing_name' },
+      globalOpts,
+    );
+
+    await runCreate(
+      {
+        loading: 'Starting domain claim...',
+        sdkCall: (resend) =>
+          resend.domains.claims.create({
+            name,
+            ...(opts.region && { region: opts.region }),
+            ...(opts.trackingSubdomain && {
+              trackingSubdomain: opts.trackingSubdomain,
+            }),
+          }),
+        onInteractive: (c) => {
+          console.log(
+            `Claim started for ${c.name} (claim id: ${c.id}, domain id: ${c.domain_id})`,
+          );
+          console.log(`Status: ${c.status}`);
+          console.log('\nAdd this TXT record at your DNS provider:');
+          console.log(`  ${c.record.name}  TXT  ${c.record.value}`);
+          console.log(
+            `\nThen run \`resend domains claim verify ${c.domain_id}\`.`,
+          );
+        },
+      },
+      globalOpts,
+    );
+  });

--- a/src/commands/domains/claim/create.ts
+++ b/src/commands/domains/claim/create.ts
@@ -51,7 +51,7 @@ export const claimCreateCommand = new Command('create')
           resend.domains.claims.create({
             name,
             ...(opts.region && { region: opts.region }),
-            ...(opts.trackingSubdomain && {
+            ...(opts.trackingSubdomain !== undefined && {
               trackingSubdomain: opts.trackingSubdomain,
             }),
           }),

--- a/src/commands/domains/claim/get.ts
+++ b/src/commands/domains/claim/get.ts
@@ -1,0 +1,44 @@
+import { Command } from '@commander-js/extra-typings';
+import { runGet } from '../../../lib/actions';
+import type { GlobalOpts } from '../../../lib/client';
+import { buildHelpText } from '../../../lib/help-text';
+import { pickId } from '../../../lib/prompts';
+import { domainPickerConfig } from '../utils';
+
+export const claimGetCommand = new Command('get')
+  .description('Retrieve the latest claim for a domain')
+  .argument('[id]', 'Domain ID (the placeholder domain created by the claim)')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      output:
+        '  domain_claim object: status, domain_id, the TXT record, blocked_reason, expires_at.\n\nClaim status values: pending | verified | completed | blocked | expired | superseded | canceled | failed',
+      errorCodes: ['auth_error', 'fetch_error', 'not_found'],
+      examples: [
+        'resend domains claim get 4dd369bc-aa82-4ff3-97de-514ae3000ee0',
+        'resend domains claim get 4dd369bc-aa82-4ff3-97de-514ae3000ee0 --json',
+      ],
+    }),
+  )
+  .action(async (idArg, _opts, cmd) => {
+    const globalOpts = cmd.optsWithGlobals() as GlobalOpts;
+    const id = await pickId(idArg, domainPickerConfig, globalOpts);
+    await runGet(
+      {
+        loading: 'Fetching domain claim...',
+        sdkCall: (resend) => resend.domains.claims.get(id),
+        onInteractive: (c) => {
+          console.log(`${c.name} — ${c.status}`);
+          console.log(`Claim ID: ${c.id}`);
+          console.log(`Domain ID: ${c.domain_id}`);
+          if (c.blocked_reason) {
+            console.log(`Blocked: ${c.blocked_reason}`);
+          }
+          console.log(`Expires: ${c.expires_at}`);
+          console.log('\nTXT record:');
+          console.log(`  ${c.record.name}  TXT  ${c.record.value}`);
+        },
+      },
+      globalOpts,
+    );
+  });

--- a/src/commands/domains/claim/index.ts
+++ b/src/commands/domains/claim/index.ts
@@ -1,0 +1,28 @@
+import { Command } from '@commander-js/extra-typings';
+import { buildHelpText } from '../../../lib/help-text';
+import { claimCreateCommand } from './create';
+import { claimGetCommand } from './get';
+import { claimVerifyCommand } from './verify';
+
+export const claimCommand = new Command('claim')
+  .description('Claim a domain already verified by another Resend account')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      context: `Claim lifecycle:
+  1. resend domains claim create --name example.com   (returns the TXT record)
+  2. Configure the TXT record at your DNS provider
+  3. resend domains claim verify <domain-id>           (trigger verification + transfer)
+  4. resend domains claim get <domain-id>              (poll until "completed")
+  5. The transferred domain has NEW DKIM records — update DNS, then run:
+     resend domains verify <domain-id>`,
+      examples: [
+        'resend domains claim create --name example.com',
+        'resend domains claim get 4dd369bc-aa82-4ff3-97de-514ae3000ee0',
+        'resend domains claim verify 4dd369bc-aa82-4ff3-97de-514ae3000ee0',
+      ],
+    }),
+  )
+  .addCommand(claimCreateCommand)
+  .addCommand(claimGetCommand)
+  .addCommand(claimVerifyCommand);

--- a/src/commands/domains/claim/verify.ts
+++ b/src/commands/domains/claim/verify.ts
@@ -1,0 +1,34 @@
+import { Command } from '@commander-js/extra-typings';
+import { runWrite } from '../../../lib/actions';
+import type { GlobalOpts } from '../../../lib/client';
+import { buildHelpText } from '../../../lib/help-text';
+import { pickId } from '../../../lib/prompts';
+import { domainPickerConfig } from '../utils';
+
+export const claimVerifyCommand = new Command('verify')
+  .description('Trigger DNS verification and transfer for a domain claim')
+  .argument('[id]', 'Domain ID (the placeholder domain created by the claim)')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      output:
+        '  domain_claim object (status stays pending while verification runs async).',
+      errorCodes: ['auth_error', 'verify_error', 'not_found'],
+      examples: [
+        'resend domains claim verify 4dd369bc-aa82-4ff3-97de-514ae3000ee0',
+      ],
+    }),
+  )
+  .action(async (idArg, _opts, cmd) => {
+    const globalOpts = cmd.optsWithGlobals() as GlobalOpts;
+    const id = await pickId(idArg, domainPickerConfig, globalOpts);
+    await runWrite(
+      {
+        loading: 'Verifying domain claim...',
+        sdkCall: (resend) => resend.domains.claims.verify(id),
+        errorCode: 'verify_error',
+        successMsg: `Domain claim verification started. Check status with resend domains claim get ${id}.`,
+      },
+      globalOpts,
+    );
+  });

--- a/src/commands/domains/index.ts
+++ b/src/commands/domains/index.ts
@@ -1,5 +1,6 @@
 import { Command } from '@commander-js/extra-typings';
 import { buildHelpText } from '../../lib/help-text';
+import { claimCommand } from './claim';
 import { createDomainCommand } from './create';
 import { deleteDomainCommand } from './delete';
 import { getDomainCommand } from './get';
@@ -24,6 +25,7 @@ export const domainsCommand = new Command('domains')
         'resend domains get 4dd369bc-aa82-4ff3-97de-514ae3000ee0',
         'resend domains update <id> --tls enforced --open-tracking',
         'resend domains delete <id> --yes',
+        'resend domains claim create --name example.com',
       ],
     }),
   )
@@ -32,4 +34,5 @@ export const domainsCommand = new Command('domains')
   .addCommand(getDomainCommand)
   .addCommand(listDomainsCommand, { isDefault: true })
   .addCommand(updateDomainCommand)
-  .addCommand(deleteDomainCommand);
+  .addCommand(deleteDomainCommand)
+  .addCommand(claimCommand);

--- a/tests/commands/domains/claim/create.test.ts
+++ b/tests/commands/domains/claim/create.test.ts
@@ -1,0 +1,128 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from 'vitest';
+import {
+  captureTestEnv,
+  expectExit1,
+  mockExitThrow,
+  mockSdkError,
+  setNonInteractive,
+  setupOutputSpies,
+} from '../../../helpers';
+
+const claim = {
+  object: 'domain_claim',
+  id: 'claim-id',
+  name: 'example.com',
+  status: 'pending',
+  domain_id: 'placeholder-id',
+  region: 'us-east-1',
+  record: {
+    type: 'TXT',
+    name: 'example.com',
+    value: 'resend-domain-verification=3f8a1c2d4e5b6a7f8091a2b3c4d5e6f7',
+    ttl: 'Auto',
+  },
+  blocked_reason: null,
+  failure_reason: null,
+  created_at: '2026-06-16T17:12:02.059593+00:00',
+  expires_at: '2026-06-23T17:12:02.059593+00:00',
+};
+
+const mockCreate = vi.fn(async () => ({ data: claim, error: null }));
+
+vi.mock('resend', () => ({
+  Resend: class MockResend {
+    constructor(public key: string) {}
+    domains = { claims: { create: mockCreate } };
+  },
+}));
+
+describe('domains claim create command', () => {
+  const restoreEnv = captureTestEnv();
+  let spies: ReturnType<typeof setupOutputSpies> | undefined;
+  let errorSpy: MockInstance | undefined;
+  let stderrSpy: MockInstance | undefined;
+  let exitSpy: MockInstance | undefined;
+
+  beforeEach(() => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    mockCreate.mockClear();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    errorSpy?.mockRestore();
+    stderrSpy?.mockRestore();
+    exitSpy?.mockRestore();
+    spies = undefined;
+    errorSpy = undefined;
+    stderrSpy = undefined;
+    exitSpy = undefined;
+  });
+
+  it('calls SDK claims.create and outputs the domain_claim as JSON', async () => {
+    spies = setupOutputSpies();
+
+    const { claimCreateCommand } = await import(
+      '../../../../src/commands/domains/claim/create'
+    );
+    await claimCreateCommand.parseAsync(['--name', 'example.com'], {
+      from: 'user',
+    });
+
+    expect(mockCreate).toHaveBeenCalledWith({ name: 'example.com' });
+    const output = spies.logSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output);
+    expect(parsed.object).toBe('domain_claim');
+    expect(parsed.status).toBe('pending');
+    expect(parsed.domain_id).toBe('placeholder-id');
+    expect(parsed.record.type).toBe('TXT');
+  });
+
+  it('errors with missing_name when --name is absent in non-interactive mode', async () => {
+    setNonInteractive();
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = mockExitThrow();
+
+    const { claimCreateCommand } = await import(
+      '../../../../src/commands/domains/claim/create'
+    );
+    await expectExit1(() =>
+      claimCreateCommand.parseAsync([], { from: 'user' }),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('missing_name');
+  });
+
+  it('errors with create_error when the SDK returns an error', async () => {
+    setNonInteractive();
+    mockCreate.mockResolvedValueOnce(
+      mockSdkError('Domain is not available to claim', 'validation_error'),
+    );
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    exitSpy = mockExitThrow();
+
+    const { claimCreateCommand } = await import(
+      '../../../../src/commands/domains/claim/create'
+    );
+    await expectExit1(() =>
+      claimCreateCommand.parseAsync(['--name', 'example.com'], {
+        from: 'user',
+      }),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('create_error');
+  });
+});

--- a/tests/commands/domains/claim/get.test.ts
+++ b/tests/commands/domains/claim/get.test.ts
@@ -1,0 +1,106 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from 'vitest';
+import {
+  captureTestEnv,
+  expectExit1,
+  mockExitThrow,
+  mockSdkError,
+  setNonInteractive,
+  setupOutputSpies,
+} from '../../../helpers';
+
+const claim = {
+  object: 'domain_claim',
+  id: 'claim-id',
+  name: 'example.com',
+  status: 'pending',
+  domain_id: 'placeholder-id',
+  region: 'us-east-1',
+  record: {
+    type: 'TXT',
+    name: 'example.com',
+    value: 'resend-domain-verification=3f8a1c2d4e5b6a7f8091a2b3c4d5e6f7',
+    ttl: 'Auto',
+  },
+  blocked_reason: null,
+  failure_reason: null,
+  created_at: '2026-06-16T17:12:02.059593+00:00',
+  expires_at: '2026-06-23T17:12:02.059593+00:00',
+};
+
+const mockGet = vi.fn(async () => ({ data: claim, error: null }));
+
+vi.mock('resend', () => ({
+  Resend: class MockResend {
+    constructor(public key: string) {}
+    domains = { claims: { get: mockGet } };
+  },
+}));
+
+describe('domains claim get command', () => {
+  const restoreEnv = captureTestEnv();
+  let spies: ReturnType<typeof setupOutputSpies> | undefined;
+  let errorSpy: MockInstance | undefined;
+  let stderrSpy: MockInstance | undefined;
+  let exitSpy: MockInstance | undefined;
+
+  beforeEach(() => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    mockGet.mockClear();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    errorSpy?.mockRestore();
+    stderrSpy?.mockRestore();
+    exitSpy?.mockRestore();
+    spies = undefined;
+    errorSpy = undefined;
+    stderrSpy = undefined;
+    exitSpy = undefined;
+  });
+
+  it('calls SDK claims.get with the domain id and outputs JSON', async () => {
+    spies = setupOutputSpies();
+
+    const { claimGetCommand } = await import(
+      '../../../../src/commands/domains/claim/get'
+    );
+    await claimGetCommand.parseAsync(['placeholder-id'], { from: 'user' });
+
+    expect(mockGet).toHaveBeenCalledWith('placeholder-id');
+    const output = spies.logSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output);
+    expect(parsed.object).toBe('domain_claim');
+    expect(parsed.domain_id).toBe('placeholder-id');
+  });
+
+  it('errors with fetch_error when the SDK returns an error', async () => {
+    setNonInteractive();
+    mockGet.mockResolvedValueOnce(
+      mockSdkError('Domain claim not found', 'not_found'),
+    );
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    exitSpy = mockExitThrow();
+
+    const { claimGetCommand } = await import(
+      '../../../../src/commands/domains/claim/get'
+    );
+    await expectExit1(() =>
+      claimGetCommand.parseAsync(['placeholder-id'], { from: 'user' }),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('fetch_error');
+  });
+});

--- a/tests/commands/domains/claim/verify.test.ts
+++ b/tests/commands/domains/claim/verify.test.ts
@@ -1,0 +1,106 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from 'vitest';
+import {
+  captureTestEnv,
+  expectExit1,
+  mockExitThrow,
+  mockSdkError,
+  setNonInteractive,
+  setupOutputSpies,
+} from '../../../helpers';
+
+const claim = {
+  object: 'domain_claim',
+  id: 'claim-id',
+  name: 'example.com',
+  status: 'pending',
+  domain_id: 'placeholder-id',
+  region: 'us-east-1',
+  record: {
+    type: 'TXT',
+    name: 'example.com',
+    value: 'resend-domain-verification=3f8a1c2d4e5b6a7f8091a2b3c4d5e6f7',
+    ttl: 'Auto',
+  },
+  blocked_reason: null,
+  failure_reason: null,
+  created_at: '2026-06-16T17:12:02.059593+00:00',
+  expires_at: '2026-06-23T17:12:02.059593+00:00',
+};
+
+const mockVerify = vi.fn(async () => ({ data: claim, error: null }));
+
+vi.mock('resend', () => ({
+  Resend: class MockResend {
+    constructor(public key: string) {}
+    domains = { claims: { verify: mockVerify } };
+  },
+}));
+
+describe('domains claim verify command', () => {
+  const restoreEnv = captureTestEnv();
+  let spies: ReturnType<typeof setupOutputSpies> | undefined;
+  let errorSpy: MockInstance | undefined;
+  let stderrSpy: MockInstance | undefined;
+  let exitSpy: MockInstance | undefined;
+
+  beforeEach(() => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    mockVerify.mockClear();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    errorSpy?.mockRestore();
+    stderrSpy?.mockRestore();
+    exitSpy?.mockRestore();
+    spies = undefined;
+    errorSpy = undefined;
+    stderrSpy = undefined;
+    exitSpy = undefined;
+  });
+
+  it('calls SDK claims.verify with the domain id and outputs JSON', async () => {
+    spies = setupOutputSpies();
+
+    const { claimVerifyCommand } = await import(
+      '../../../../src/commands/domains/claim/verify'
+    );
+    await claimVerifyCommand.parseAsync(['placeholder-id'], { from: 'user' });
+
+    expect(mockVerify).toHaveBeenCalledWith('placeholder-id');
+    const output = spies.logSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output);
+    expect(parsed.object).toBe('domain_claim');
+    expect(parsed.domain_id).toBe('placeholder-id');
+  });
+
+  it('errors with verify_error when the SDK returns an error', async () => {
+    setNonInteractive();
+    mockVerify.mockResolvedValueOnce(
+      mockSdkError('Domain claim not found', 'not_found'),
+    );
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    exitSpy = mockExitThrow();
+
+    const { claimVerifyCommand } = await import(
+      '../../../../src/commands/domains/claim/verify'
+    );
+    await expectExit1(() =>
+      claimVerifyCommand.parseAsync(['placeholder-id'], { from: 'user' }),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('verify_error');
+  });
+});


### PR DESCRIPTION
Adds a `domains claim` command group so the Domain Claim API is runnable from the CLI, completing the feature across all surfaces (API → docs → Node SDK → skills → CLI).

```
resend domains claim create --name example.com   # POST /domains/claim
resend domains claim get <domain-id>             # GET /domains/:id/claim
resend domains claim verify <domain-id>          # POST /domains/:id/claim/verify
```

**Changes:**
- Bumps `resend` 6.12.3 → 6.14.0 (the GA release with `domains.claims`).
- New `src/commands/domains/claim/` group (`create`/`get`/`verify`), mirroring the existing `domains` commands and the nested-group precedent (`emails receiving`, `automations runs`). `get`/`verify` take a positional domain id and reuse the domain picker.
- Tests (7) in `tests/commands/domains/claim/`.
- Updates the bundled `resend-cli` skill (command table + `references/domains.md`) so it syncs to resend-skills.

The `create` output and skill docs both flag the post-completion step: the transferred domain gets **new DKIM keys**, so update DNS (via `domains get`) and run `domains verify` before sending.

Full suite: 944 passing; typecheck + build clean.

Related: resend-node #985 (SDK), resend-docs #1570/#1575/#1576, resend-skills #77.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `domains claim` CLI command group to run the Domain Claim flow end to end. You can claim a domain verified in another account and complete the transfer from the terminal.

- **New Features**
  - Added `resend domains claim create|get|verify` with domain picker, clear TXT record output, and forwards `--tracking-subdomain` only when set.
  - Transferred domains get new DKIM keys; fetch with `resend domains get <id>`, update DNS, then run `resend domains verify <id>`. Updated `resend-cli` skill docs to cover the flow and include `domains` `get` and `claim` in the table.

- **Dependencies**
  - Bumped `resend` to `6.14.0` to enable `domains.claims`. Added `minimumReleaseAgeExclude` for `resend@6.14.0` in `pnpm-workspace.yaml` to satisfy the org CI policy.

<sup>Written for commit 6d6d718efc13bb6c39db2497b7afd90feac0b04f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-cli/pull/325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

