### PR TITLE
chore: bump to 2.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-cli",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "The official CLI for Resend",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Release bump `2.3.0` → `2.4.0` (minor) for the new `domains claim` commands (#325).

Squash-merge this, then tag the merge commit on `main`:
```
git checkout main && git pull
git tag v2.4.0
git push origin v2.4.0
```
The tag triggers the release workflow (tests → native binaries → GitHub Release → NPM publish → Homebrew tap dispatch).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `resend-cli` from 2.3.0 to 2.4.0 to ship the new `domains claim` commands. No other changes.

<sup>Written for commit d802af62f15bd42901bf9fcc60b8f816db93818a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-cli/pull/326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

