### PR TITLE
feat: add custom-return-path and tracking flags to domains claim create

### DIFF
--- a/skills/resend-cli/SKILL.md
+++ b/skills/resend-cli/SKILL.md
@@ -11,7 +11,7 @@ description: >
 license: MIT
 metadata:
   author: resend
-  version: "2.2.0"
+  version: "2.3.0"
   homepage: https://resend.com/docs/cli-agents
   source: https://github.com/resend/resend-cli
   openclaw:

--- a/skills/resend-cli/references/domains.md
+++ b/skills/resend-cli/references/domains.md
@@ -102,6 +102,9 @@ Claim status values: `pending` | `verified` | `completed` | `blocked` | `expired
 | `--name <domain>` | string | Yes (non-interactive) | Domain name to claim (e.g., `example.com`) |
 | `--region <region>` | string | No | `us-east-1` \| `eu-west-1` \| `sa-east-1` \| `ap-northeast-1` |
 | `--tracking-subdomain <subdomain>` | string | No | Subdomain for click and open tracking (e.g., `track`) |
+| `--custom-return-path <subdomain>` | string | No | Subdomain for the Return-Path address (e.g., `bounce`) |
+| `--open-tracking` / `--no-open-tracking` | boolean | No | Enable/disable open tracking |
+| `--click-tracking` / `--no-click-tracking` | boolean | No | Enable/disable click tracking |
 
 **Output:** `domain_claim` object with `domain_id` (the placeholder domain) and a TXT `record` to add to DNS.
 

--- a/src/commands/domains/claim/create.ts
+++ b/src/commands/domains/claim/create.ts
@@ -19,6 +19,14 @@ export const claimCreateCommand = new Command('create')
     '--tracking-subdomain <subdomain>',
     'Subdomain for click and open tracking (e.g. track)',
   )
+  .option(
+    '--custom-return-path <subdomain>',
+    'Subdomain for the Return-Path address (e.g. bounce)',
+  )
+  .option('--open-tracking', 'Enable open tracking')
+  .option('--no-open-tracking', 'Disable open tracking')
+  .option('--click-tracking', 'Enable click tracking')
+  .option('--no-click-tracking', 'Disable click tracking')
   .addHelpText(
     'after',
     buildHelpText({
@@ -51,6 +59,15 @@ export const claimCreateCommand = new Command('create')
           resend.domains.claims.create({
             name,
             ...(opts.region && { region: opts.region }),
+            ...(opts.customReturnPath !== undefined && {
+              customReturnPath: opts.customReturnPath,
+            }),
+            ...(opts.openTracking !== undefined && {
+              openTracking: opts.openTracking,
+            }),
+            ...(opts.clickTracking !== undefined && {
+              clickTracking: opts.clickTracking,
+            }),
             ...(opts.trackingSubdomain !== undefined && {
               trackingSubdomain: opts.trackingSubdomain,
             }),

--- a/tests/commands/domains/claim/create.test.ts
+++ b/tests/commands/domains/claim/create.test.ts
@@ -102,6 +102,66 @@ describe('domains claim create command', () => {
     expect(output).toContain('missing_name');
   });
 
+  it('passes customReturnPath when --custom-return-path is set', async () => {
+    spies = setupOutputSpies();
+    const { claimCreateCommand } = await import(
+      '../../../../src/commands/domains/claim/create'
+    );
+    await claimCreateCommand.parseAsync(
+      ['--name', 'example.com', '--custom-return-path', 'bounce'],
+      { from: 'user' },
+    );
+    expect(mockCreate).toHaveBeenCalledWith({
+      name: 'example.com',
+      customReturnPath: 'bounce',
+    });
+  });
+
+  it('passes openTracking=true with --open-tracking', async () => {
+    spies = setupOutputSpies();
+    const { claimCreateCommand } = await import(
+      '../../../../src/commands/domains/claim/create'
+    );
+    await claimCreateCommand.parseAsync(
+      ['--name', 'example.com', '--open-tracking'],
+      { from: 'user' },
+    );
+    expect(mockCreate).toHaveBeenCalledWith({
+      name: 'example.com',
+      openTracking: true,
+    });
+  });
+
+  it('passes openTracking=false with --no-open-tracking', async () => {
+    spies = setupOutputSpies();
+    const { claimCreateCommand } = await import(
+      '../../../../src/commands/domains/claim/create'
+    );
+    await claimCreateCommand.parseAsync(
+      ['--name', 'example.com', '--no-open-tracking'],
+      { from: 'user' },
+    );
+    expect(mockCreate).toHaveBeenCalledWith({
+      name: 'example.com',
+      openTracking: false,
+    });
+  });
+
+  it('passes clickTracking=true with --click-tracking', async () => {
+    spies = setupOutputSpies();
+    const { claimCreateCommand } = await import(
+      '../../../../src/commands/domains/claim/create'
+    );
+    await claimCreateCommand.parseAsync(
+      ['--name', 'example.com', '--click-tracking'],
+      { from: 'user' },
+    );
+    expect(mockCreate).toHaveBeenCalledWith({
+      name: 'example.com',
+      clickTracking: true,
+    });
+  });
+
   it('errors with create_error when the SDK returns an error', async () => {
     setNonInteractive();
     mockCreate.mockResolvedValueOnce(

--- a/tests/commands/domains/claim/create.test.ts
+++ b/tests/commands/domains/claim/create.test.ts
@@ -162,6 +162,21 @@ describe('domains claim create command', () => {
     });
   });
 
+  it('passes clickTracking=false with --no-click-tracking', async () => {
+    spies = setupOutputSpies();
+    const { claimCreateCommand } = await import(
+      '../../../../src/commands/domains/claim/create'
+    );
+    await claimCreateCommand.parseAsync(
+      ['--name', 'example.com', '--no-click-tracking'],
+      { from: 'user' },
+    );
+    expect(mockCreate).toHaveBeenCalledWith({
+      name: 'example.com',
+      clickTracking: false,
+    });
+  });
+
   it('errors with create_error when the SDK returns an error', async () => {
     setNonInteractive();
     mockCreate.mockResolvedValueOnce(


### PR DESCRIPTION
## Summary

`resend domains claim create` exposed only 3 of the 6 fields the SDK and API support. This PR closes the gap.

**New flags:**
- `--custom-return-path <subdomain>` → `customReturnPath`
- `--open-tracking` / `--no-open-tracking` → `openTracking`
- `--click-tracking` / `--no-click-tracking` → `clickTracking`

These mirror the existing `domains update` pattern exactly (`!== undefined` guards for booleans). No SDK bump needed — `resend@6.14.0` already exposes all 6 `ClaimDomainOptions`.

**Also:** bundled CLI skill docs updated with the 3 new flags; skill version bumped 2.2.0 → 2.3.0.

**Note:** No `package.json` version bump — release is handled separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `--custom-return-path`, `--open-tracking`/`--no-open-tracking`, and `--click-tracking`/`--no-click-tracking` to `resend domains claim create` for feature parity with the SDK/API. Docs and tests updated; no SDK bump needed (`resend@6.14.0` already supports these fields).

- **New Features**
  - Booleans are only sent when provided, matching `domains update`.
  - Updated CLI skill docs; version bumped to 2.3.0.
  - Tests added to cover all new flag combinations.

<sup>Written for commit d514062ac8498fee99231b6be78463f9fa23a45f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-cli/pull/327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

