### PR TITLE
chore: release 2.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-cli",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "The official CLI for Resend",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Release 2.5.0 — adds custom-return-path and tracking flags to domains claim create (#327).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release 2.5.0 of `resend-cli` with new flags for domain claiming. You can now pass `--custom-return-path` and `--tracking` to `domains claim create`.

- **New Features**
  - Added `--custom-return-path` to `domains claim create`.
  - Added `--tracking` to `domains claim create`.

<sup>Written for commit 82f5fd765133cb6f4c0e1188fa330617e036f2b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-cli/pull/328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

