### PR TITLE
feat: add cli import commands

### DIFF
--- a/skills/resend-cli/SKILL.md
+++ b/skills/resend-cli/SKILL.md
@@ -11,6 +11,8 @@ description: >
 license: MIT
 metadata:
   author: resend
+  # Skill version is independent from the CLI/package.json version —
+  # bump it on skill content changes, not CLI releases.
   version: "2.3.0"
   homepage: https://resend.com/docs/cli-agents
   source: https://github.com/resend/resend-cli
@@ -145,7 +147,7 @@ Auth resolves: `--api-key` flag > `RESEND_API_KEY` env > config file (`resend lo
 | `automations` | create, get, list, update, delete, stop, open, runs |
 | `events` | create, get, list, update, delete, send, open |
 | `broadcasts` | create, send, update, delete, list |
-| `contacts` | create, update, delete, segments, topics |
+| `contacts` | create, update, delete, segments, topics, imports |
 | `contact-properties` | create, update, delete, list |
 | `segments` | create, get, list, delete, contacts |
 | `templates` | create, publish, duplicate, delete, list |

--- a/skills/resend-cli/SKILL.md
+++ b/skills/resend-cli/SKILL.md
@@ -172,6 +172,7 @@ Read the matching reference file for detailed flags and output shapes.
 | 6 | **Sending a dashboard-created broadcast via CLI** | Only API-created broadcasts can be sent with `broadcasts send` — dashboard broadcasts must be sent from the dashboard |
 | 7 | **Passing `--events` to `webhooks update` expecting additive behavior** | `--events` replaces the entire subscription list — always pass the complete set |
 | 8 | **Expecting `logs list` to include request/response bodies** | List returns summary fields only — use `logs get <id>` for full `request_body` and `response_body` |
+| 9 | **CSV import fails with `create_error` ("missing required email column")** | `contacts imports create` matches columns case-sensitively by lowercase names (`email`, `first_name`, `last_name`) — use `--column-map` for headers like `Email`/`First Name` |
 
 ## Common Patterns
 

--- a/skills/resend-cli/references/contacts.md
+++ b/skills/resend-cli/references/contacts.md
@@ -98,3 +98,42 @@ List contact's topic subscriptions.
 | `--topics <json>` | string | Yes (non-interactive) | JSON array: `[{"id":"topic-uuid","subscription":"opt_in"}]` |
 
 Subscription values: `opt_in` | `opt_out`
+
+---
+
+## contacts imports create
+
+Bulk-import contacts from a local CSV file. The file is uploaded as multipart form data (max 100MB). Imports run **asynchronously** — the command returns an import id immediately while the file is processed in the background (poll with `contacts imports get`).
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--file <path>` | string | Yes (non-interactive) | Path to the CSV file to import |
+| `--column-map <json>` | string | No | JSON object mapping contact fields to CSV column headers: `{"email":"Email","firstName":"First Name","properties":{"plan":{"column":"Plan","type":"string"}}}` |
+| `--on-conflict <strategy>` | string | No | How to handle existing contacts: `upsert` (default, updates) or `skip` |
+| `--segment-id <id...>` | string[] | No | Add imported contacts to segment(s) — repeatable |
+| `--topics <json>` | string | No | JSON array: `[{"id":"topic-uuid","subscription":"opt_in"}]` |
+
+Mappable contact fields: `email`, `firstName`, `lastName`, `unsubscribed`, `properties`.
+
+---
+
+## contacts imports get
+
+Retrieve a contact import's status and counts.
+
+**Argument:** `[id]` — Contact import ID (interactive picker when omitted)
+
+Status values: `queued` | `in_progress` | `completed` | `failed`
+
+---
+
+## contacts imports list
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--limit <n>` | number | 10 | Max results (1-100) |
+| `--after <cursor>` | string | — | Forward pagination |
+| `--before <cursor>` | string | — | Backward pagination |
+| `--status <status>` | string | — | Filter by status: `queued` \| `in_progress` \| `completed` \| `failed` |
+
+**Alias:** `ls`

--- a/skills/resend-cli/references/contacts.md
+++ b/skills/resend-cli/references/contacts.md
@@ -115,6 +115,8 @@ Bulk-import contacts from a local CSV file. The file is uploaded as multipart fo
 
 Mappable contact fields: `email`, `firstName`, `lastName`, `unsubscribed`, `properties`.
 
+Without `--column-map`, columns are matched by the lowercase names `email` (required), `first_name`, `last_name` — matching is **case-sensitive**, so a CSV with `Email`/`First Name` headers fails with `create_error` (422 "missing required email column"). Use `--column-map` to import such a file.
+
 ---
 
 ## contacts imports get

--- a/skills/resend-cli/references/error-codes.md
+++ b/skills/resend-cli/references/error-codes.md
@@ -22,8 +22,16 @@ All errors exit with code `1` and output JSON to **stderr**:
 | `missing_body` | None of `--text`, `--html`, `--html-file`, or `--react-email` provided | Provide at least one body flag |
 | `react_email_build_error` | Failed to bundle a React Email `.tsx` template with esbuild | Check the template compiles; ensure `react` and one of `react-email` (6.0+), `@react-email/components` (5.x), or `@react-email/render` are installed in the project |
 | `react_email_render_error` | Bundled template failed during `render()` | Check the component exports a default function and renders valid React Email markup |
-| `file_read_error` | Could not read file from `--html-file` path | Check file path exists and is readable |
+| `file_read_error` | Could not read file from a `--file`/`--html-file`/`--text-file` path | Check file path exists and is readable |
 | `send_error` | Resend API rejected the send request | Check from address is on a verified domain; check recipient is valid |
+
+## Contact Import Errors
+
+| Code | Cause | Resolution |
+|------|-------|------------|
+| `missing_file` | `contacts imports create` called non-interactively without `--file` | Pass `--file <path>` to the CSV to import |
+| `invalid_column_map` | `--column-map` is not valid JSON, or is not an object | Pass a JSON object mapping contact fields to CSV headers, e.g. `{"email":"Email"}` |
+| `invalid_topics` | `--topics` is not valid JSON, or is not an array | Pass a JSON array of `{id, subscription}` objects |
 
 ## Domain Errors
 

--- a/skills/resend-cli/references/error-codes.md
+++ b/skills/resend-cli/references/error-codes.md
@@ -32,6 +32,7 @@ All errors exit with code `1` and output JSON to **stderr**:
 | `missing_file` | `contacts imports create` called non-interactively without `--file` | Pass `--file <path>` to the CSV to import |
 | `invalid_column_map` | `--column-map` is not valid JSON, or is not an object | Pass a JSON object mapping contact fields to CSV headers, e.g. `{"email":"Email"}` |
 | `invalid_topics` | `--topics` is not valid JSON, or is not an array | Pass a JSON array of `{id, subscription}` objects |
+| `create_error` | Resend API rejected the import (e.g. CSV missing the required `email` column, or file over 100MB) | Ensure the CSV has an `email` column (or map it with `--column-map`) and is under 100MB |
 
 ## Domain Errors
 

--- a/skills/resend-cli/references/workflows.md
+++ b/skills/resend-cli/references/workflows.md
@@ -414,3 +414,33 @@ resend emails receiving listen --interval 10
 # Stream as NDJSON (for scripting)
 resend emails receiving listen --json | head -3
 ```
+
+---
+
+## 13. Bulk Import Contacts from CSV
+
+```bash
+# 1. Prepare a CSV file with a header row
+cat > contacts.csv << 'EOF'
+Email,First Name,Last Name
+ada@example.com,Ada,Lovelace
+alan@example.com,Alan,Turing
+EOF
+
+# 2. Start the import (returns an import id immediately; runs async)
+resend contacts imports create --file ./contacts.csv
+
+# Map non-standard CSV headers to contact fields, set a conflict strategy,
+# and add imported contacts to a segment in one call
+resend contacts imports create \
+  --file ./contacts.csv \
+  --column-map '{"email":"Email","firstName":"First Name","lastName":"Last Name"}' \
+  --on-conflict upsert \
+  --segment-id <segment-id>
+
+# 3. Poll status until "completed" (or "failed")
+resend contacts imports get <import-id>
+
+# 4. Review past imports (filter by status)
+resend contacts imports list --status completed
+```

--- a/skills/resend-cli/references/workflows.md
+++ b/skills/resend-cli/references/workflows.md
@@ -420,9 +420,12 @@ resend emails receiving listen --json | head -3
 ## 13. Bulk Import Contacts from CSV
 
 ```bash
-# 1. Prepare a CSV file with a header row
+# 1. Prepare a CSV. Without --column-map, columns are matched by the lowercase
+#    names email (required), first_name, last_name — matching is CASE-SENSITIVE,
+#    so headers like "Email" or "First Name" will NOT match (import fails with a
+#    422 "missing required email column"). Map those with --column-map instead.
 cat > contacts.csv << 'EOF'
-Email,First Name,Last Name
+email,first_name,last_name
 ada@example.com,Ada,Lovelace
 alan@example.com,Alan,Turing
 EOF
@@ -430,10 +433,14 @@ EOF
 # 2. Start the import (returns an import id immediately; runs async)
 resend contacts imports create --file ./contacts.csv
 
-# Map non-standard CSV headers to contact fields, set a conflict strategy,
-# and add imported contacts to a segment in one call
+# If your CSV uses different header names, map them with --column-map.
+# You can also set a conflict strategy and add contacts to a segment:
+cat > contacts-custom.csv << 'EOF'
+Email,First Name,Last Name
+ada@example.com,Ada,Lovelace
+EOF
 resend contacts imports create \
-  --file ./contacts.csv \
+  --file ./contacts-custom.csv \
   --column-map '{"email":"Email","firstName":"First Name","lastName":"Last Name"}' \
   --on-conflict upsert \
   --segment-id <segment-id>

--- a/src/commands/contacts/imports/create.ts
+++ b/src/commands/contacts/imports/create.ts
@@ -92,9 +92,10 @@ Topics: pass a JSON array of {id, subscription} objects (subscription is "opt_in
 
     const columnMap = parseColumnMapJson(opts.columnMap, globalOpts);
     const segments = (opts.segmentId ?? []).map((id) => ({ id }));
-    const topics = opts.topics
-      ? parseTopicsJson(opts.topics, globalOpts)
-      : undefined;
+    const topics =
+      opts.topics !== undefined
+        ? parseTopicsJson(opts.topics, globalOpts)
+        : undefined;
 
     await runCreate<CreateContactImportResponseSuccess>(
       {

--- a/src/commands/contacts/imports/create.ts
+++ b/src/commands/contacts/imports/create.ts
@@ -1,0 +1,116 @@
+import { readFileSync } from 'node:fs';
+import { basename } from 'node:path';
+import { Command, Option } from '@commander-js/extra-typings';
+import type { CreateContactImportResponseSuccess } from 'resend';
+import { runCreate } from '../../../lib/actions';
+import type { GlobalOpts } from '../../../lib/client';
+import { buildHelpText } from '../../../lib/help-text';
+import { outputError } from '../../../lib/output';
+import { requireText } from '../../../lib/prompts';
+import { parseTopicsJson } from '../utils';
+import { parseColumnMapJson } from './utils';
+
+export const createContactImportCommand = new Command('create')
+  .description('Import contacts in bulk from a local CSV file')
+  .option('--file <path>', 'Path to the CSV file to import (required)')
+  .option(
+    '--column-map <json>',
+    'Map CSV columns to contact fields as a JSON object (e.g. \'{"email":"Email","firstName":"First Name"}\')',
+  )
+  .addOption(
+    new Option(
+      '--on-conflict <strategy>',
+      'How to handle contacts that already exist',
+    ).choices(['upsert', 'skip'] as const),
+  )
+  .option(
+    '--segment-id <id...>',
+    'Segment ID to add imported contacts to (repeatable: --segment-id abc --segment-id def)',
+  )
+  .option(
+    '--topics <json>',
+    'Topic subscriptions as a JSON array of {id, subscription} objects',
+  )
+  .addHelpText(
+    'after',
+    buildHelpText({
+      context: `Non-interactive: --file is required. All other flags are optional.
+
+The CSV file is uploaded as multipart form data (max 100MB).
+
+Column map: pass a JSON object to --column-map that maps CSV column headers to contact
+  fields (email, firstName, lastName, unsubscribed, properties). Example:
+  '{"email":"Email","firstName":"First Name","properties":{"plan":{"column":"Plan","type":"string"}}}'
+
+On conflict: --on-conflict upsert (default) updates existing contacts; skip leaves them unchanged.
+
+Segments: use --segment-id once per segment to add imported contacts to one or more segments.
+
+Topics: pass a JSON array of {id, subscription} objects (subscription is "opt_in" or "opt_out").`,
+      output: `  {"object":"contact_import","id":"<id>"}`,
+      errorCodes: [
+        'auth_error',
+        'missing_file',
+        'file_read_error',
+        'invalid_column_map',
+        'invalid_topics',
+        'create_error',
+      ],
+      examples: [
+        'resend contacts imports create --file ./contacts.csv',
+        `resend contacts imports create --file ./contacts.csv --column-map '{"email":"Email","firstName":"First Name"}'`,
+        'resend contacts imports create --file ./contacts.csv --on-conflict skip --segment-id 78261eea-8f8b-4381-83c6-79fa7120f1cf',
+      ],
+    }),
+  )
+  .action(async (opts, cmd) => {
+    const globalOpts = cmd.optsWithGlobals() as GlobalOpts;
+
+    const filePath = await requireText(
+      opts.file,
+      { message: 'Path to the CSV file', placeholder: './contacts.csv' },
+      { message: 'Missing --file flag.', code: 'missing_file' },
+      globalOpts,
+    );
+
+    let fileContent: Buffer;
+    try {
+      fileContent = readFileSync(filePath);
+    } catch {
+      outputError(
+        {
+          message: `Failed to read file: ${filePath}`,
+          code: 'file_read_error',
+        },
+        { json: globalOpts.json },
+      );
+    }
+
+    const file = new File([new Uint8Array(fileContent)], basename(filePath), {
+      type: 'text/csv',
+    });
+
+    const columnMap = parseColumnMapJson(opts.columnMap, globalOpts);
+    const segments = (opts.segmentId ?? []).map((id) => ({ id }));
+    const topics = opts.topics
+      ? parseTopicsJson(opts.topics, globalOpts)
+      : undefined;
+
+    await runCreate<CreateContactImportResponseSuccess>(
+      {
+        loading: 'Starting contact import...',
+        sdkCall: (resend) =>
+          resend.contacts.imports.create({
+            file,
+            ...(columnMap && { columnMap }),
+            ...(opts.onConflict && { onConflict: opts.onConflict }),
+            ...(segments.length > 0 && { segments }),
+            ...(topics && { topics }),
+          }),
+        onInteractive: (data) => {
+          console.log(`Contact import started: ${data.id}`);
+        },
+      },
+      globalOpts,
+    );
+  });

--- a/src/commands/contacts/imports/get.ts
+++ b/src/commands/contacts/imports/get.ts
@@ -1,0 +1,44 @@
+import { Command } from '@commander-js/extra-typings';
+import type { GetContactImportResponseSuccess } from 'resend';
+import { runGet } from '../../../lib/actions';
+import type { GlobalOpts } from '../../../lib/client';
+import { buildHelpText } from '../../../lib/help-text';
+import { pickId } from '../../../lib/prompts';
+import { contactImportPickerConfig } from './utils';
+
+export const getContactImportCommand = new Command('get')
+  .description('Retrieve a contact import by ID')
+  .argument('[id]', 'Contact import ID')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      output: `  {\n    "object": "contact_import",\n    "id": "479e3145-dd38-476b-932c-529ceb705947",\n    "status": "completed",\n    "created_at": "2026-05-15T18:32:37.823Z",\n    "completed_at": "2026-05-15T18:33:42.916Z",\n    "counts": {"total":1200,"created":800,"updated":300,"skipped":75,"failed":25}\n  }`,
+      errorCodes: ['auth_error', 'fetch_error', 'not_found'],
+      examples: [
+        'resend contacts imports get 479e3145-dd38-476b-932c-529ceb705947',
+        'resend contacts imports get 479e3145-dd38-476b-932c-529ceb705947 --json',
+      ],
+    }),
+  )
+  .action(async (idArg, _opts, cmd) => {
+    const globalOpts = cmd.optsWithGlobals() as GlobalOpts;
+    const id = await pickId(idArg, contactImportPickerConfig, globalOpts);
+    await runGet<GetContactImportResponseSuccess>(
+      {
+        loading: 'Fetching contact import...',
+        sdkCall: (resend) => resend.contacts.imports.get(id),
+        onInteractive: (imp) => {
+          console.log(`${imp.id} - ${imp.status}`);
+          console.log(`Created: ${imp.created_at}`);
+          if (imp.completed_at) {
+            console.log(`Completed: ${imp.completed_at}`);
+          }
+          const c = imp.counts;
+          console.log(
+            `Counts: ${c.total} total, ${c.created} created, ${c.updated} updated, ${c.skipped} skipped, ${c.failed} failed`,
+          );
+        },
+      },
+      globalOpts,
+    );
+  });

--- a/src/commands/contacts/imports/get.ts
+++ b/src/commands/contacts/imports/get.ts
@@ -13,7 +13,7 @@ export const getContactImportCommand = new Command('get')
     'after',
     buildHelpText({
       output: `  {\n    "object": "contact_import",\n    "id": "479e3145-dd38-476b-932c-529ceb705947",\n    "status": "completed",\n    "created_at": "2026-05-15T18:32:37.823Z",\n    "completed_at": "2026-05-15T18:33:42.916Z",\n    "counts": {"total":1200,"created":800,"updated":300,"skipped":75,"failed":25}\n  }`,
-      errorCodes: ['auth_error', 'fetch_error', 'not_found'],
+      errorCodes: ['auth_error', 'fetch_error'],
       examples: [
         'resend contacts imports get 479e3145-dd38-476b-932c-529ceb705947',
         'resend contacts imports get 479e3145-dd38-476b-932c-529ceb705947 --json',

--- a/src/commands/contacts/imports/index.ts
+++ b/src/commands/contacts/imports/index.ts
@@ -1,0 +1,28 @@
+import { Command } from '@commander-js/extra-typings';
+import { buildHelpText } from '../../../lib/help-text';
+import { createContactImportCommand } from './create';
+import { getContactImportCommand } from './get';
+import { listContactImportsCommand } from './list';
+
+export const contactImportsCommand = new Command('imports')
+  .description('Import contacts in bulk from a CSV file')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      context: `Import lifecycle:
+  1. resend contacts imports create --file ./contacts.csv   (returns the import id)
+  2. resend contacts imports get <id>                       (poll until "completed")
+  3. resend contacts imports list                           (review past imports)
+
+Imports run asynchronously. The create command returns immediately with an id while
+the file is processed in the background.`,
+      examples: [
+        'resend contacts imports create --file ./contacts.csv',
+        'resend contacts imports get 479e3145-dd38-476b-932c-529ceb705947',
+        'resend contacts imports list --status completed',
+      ],
+    }),
+  )
+  .addCommand(createContactImportCommand)
+  .addCommand(getContactImportCommand)
+  .addCommand(listContactImportsCommand, { isDefault: true });

--- a/src/commands/contacts/imports/list.ts
+++ b/src/commands/contacts/imports/list.ts
@@ -1,0 +1,78 @@
+import { Command, Option } from '@commander-js/extra-typings';
+import type { ListContactImportsResponseSuccess } from 'resend';
+import { runList } from '../../../lib/actions';
+import type { GlobalOpts } from '../../../lib/client';
+import { buildHelpText } from '../../../lib/help-text';
+import {
+  buildPaginationOpts,
+  parseLimitOpt,
+  printPaginationHint,
+} from '../../../lib/pagination';
+import { renderContactImportsTable } from './utils';
+
+export const listContactImportsCommand = new Command('list')
+  .alias('ls')
+  .description('List contact imports')
+  .option(
+    '--limit <n>',
+    'Maximum number of contact imports to return (1-100)',
+    '10',
+  )
+  .option('--after <cursor>', 'Return imports after this cursor (next page)')
+  .option(
+    '--before <cursor>',
+    'Return imports before this cursor (previous page)',
+  )
+  .addOption(
+    new Option('--status <status>', 'Filter by import status').choices([
+      'queued',
+      'in_progress',
+      'completed',
+      'failed',
+    ] as const),
+  )
+  .addHelpText(
+    'after',
+    buildHelpText({
+      context: `Pagination: use --after or --before with a contact import ID as the cursor.
+  Only one of --after or --before may be used at a time.
+  The response includes has_more: true when additional pages exist.`,
+      output: `  {"object":"list","has_more":false,"data":[{"object":"contact_import","id":"...","status":"completed","counts":{"total":1200,"created":800,"updated":300,"skipped":75,"failed":25}}]}`,
+      errorCodes: ['auth_error', 'invalid_limit', 'list_error'],
+      examples: [
+        'resend contacts imports list',
+        'resend contacts imports list --status completed --json',
+        'resend contacts imports list --after 479e3145-dd38-476b-932c-529ceb705947 --json',
+      ],
+    }),
+  )
+  .action(async (opts, cmd) => {
+    const globalOpts = cmd.optsWithGlobals() as GlobalOpts;
+    const limit = parseLimitOpt(opts.limit, globalOpts);
+    const paginationOpts = buildPaginationOpts(
+      limit,
+      opts.after,
+      opts.before,
+      globalOpts,
+    );
+    await runList<ListContactImportsResponseSuccess>(
+      {
+        loading: 'Fetching contact imports...',
+        sdkCall: (resend) =>
+          resend.contacts.imports.list({
+            ...paginationOpts,
+            ...(opts.status && { status: opts.status }),
+          }),
+        onInteractive: (list) => {
+          console.log(renderContactImportsTable(list.data));
+          printPaginationHint(list, 'contacts imports list', {
+            limit,
+            before: opts.before,
+            apiKey: globalOpts.apiKey,
+            profile: globalOpts.profile,
+          });
+        },
+      },
+      globalOpts,
+    );
+  });

--- a/src/commands/contacts/imports/utils.ts
+++ b/src/commands/contacts/imports/utils.ts
@@ -1,0 +1,76 @@
+import type { ContactImport, ContactImportColumnMap } from 'resend';
+import type { GlobalOpts } from '../../../lib/client';
+import { outputError } from '../../../lib/output';
+import type { PickerConfig } from '../../../lib/prompts';
+import { renderTable } from '../../../lib/table';
+
+// ─── Table renderer ────────────────────────────────────────────────────────
+
+export function renderContactImportsTable(imports: ContactImport[]): string {
+  const rows = imports.map((imp) => [
+    imp.status,
+    String(imp.counts.total),
+    String(imp.counts.created),
+    String(imp.counts.updated),
+    String(imp.counts.skipped),
+    String(imp.counts.failed),
+    imp.created_at,
+    imp.id,
+  ]);
+  return renderTable(
+    [
+      'Status',
+      'Total',
+      'Created',
+      'Updated',
+      'Skipped',
+      'Failed',
+      'Created At',
+      'ID',
+    ],
+    rows,
+    '(no contact imports)',
+  );
+}
+
+export const contactImportPickerConfig: PickerConfig<ContactImport> = {
+  resource: 'contact import',
+  resourcePlural: 'contact imports',
+  fetchItems: (resend, { limit, after }) =>
+    resend.contacts.imports.list({ limit, ...(after && { after }) }),
+  display: (imp) => ({
+    label: `${imp.status} - ${imp.counts.total} contacts`,
+    hint: imp.id,
+  }),
+};
+
+// ─── JSON flag helpers ───────────────────────────────────────────────────────
+
+export function parseColumnMapJson(
+  raw: string | undefined,
+  globalOpts: GlobalOpts,
+): ContactImportColumnMap | undefined {
+  if (!raw) {
+    return undefined;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    outputError(
+      { message: 'Invalid --column-map JSON.', code: 'invalid_column_map' },
+      { json: globalOpts.json },
+    );
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    outputError(
+      {
+        message:
+          'Invalid --column-map JSON. Expected an object mapping contact fields to CSV column headers.',
+        code: 'invalid_column_map',
+      },
+      { json: globalOpts.json },
+    );
+  }
+  return parsed as ContactImportColumnMap;
+}

--- a/src/commands/contacts/index.ts
+++ b/src/commands/contacts/index.ts
@@ -4,6 +4,7 @@ import { addContactSegmentCommand } from './add-segment';
 import { createContactCommand } from './create';
 import { deleteContactCommand } from './delete';
 import { getContactCommand } from './get';
+import { contactImportsCommand } from './imports';
 import { listContactsCommand } from './list';
 import { removeContactSegmentCommand } from './remove-segment';
 import { listContactSegmentsCommand } from './segments';
@@ -30,7 +31,10 @@ Subscription:
 
 Segments:
   Contacts can belong to multiple segments. Segments determine which contacts receive a broadcast.
-  Manage membership with "resend contacts add-segment" and "resend contacts remove-segment".`,
+  Manage membership with "resend contacts add-segment" and "resend contacts remove-segment".
+
+Imports:
+  Bulk-import contacts from a CSV file with "resend contacts imports create --file <path>".`,
       examples: [
         'resend contacts list',
         'resend contacts create --email steve.wozniak@gmail.com --first-name Steve',
@@ -43,6 +47,7 @@ Segments:
         'resend contacts remove-segment steve.wozniak@gmail.com 78261eea-8f8b-4381-83c6-79fa7120f1cf',
         'resend contacts topics steve.wozniak@gmail.com',
         `resend contacts update-topics steve.wozniak@gmail.com --topics '[{"id":"b6d24b8e-af0b-4c3c-be0c-359bbd97381e","subscription":"opt_in"}]'`,
+        'resend contacts imports create --file ./contacts.csv',
       ],
     }),
   )
@@ -55,4 +60,5 @@ Segments:
   .addCommand(addContactSegmentCommand)
   .addCommand(removeContactSegmentCommand)
   .addCommand(listContactTopicsCommand)
-  .addCommand(updateContactTopicsCommand);
+  .addCommand(updateContactTopicsCommand)
+  .addCommand(contactImportsCommand);

--- a/tests/commands/contacts/imports/create.test.ts
+++ b/tests/commands/contacts/imports/create.test.ts
@@ -1,0 +1,285 @@
+import { unlinkSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from 'vitest';
+import {
+  captureTestEnv,
+  expectExit1,
+  mockExitThrow,
+  mockSdkError,
+  setNonInteractive,
+  setupOutputSpies,
+} from '../../../helpers';
+
+const mockCreate = vi.fn(async () => ({
+  data: {
+    object: 'contact_import' as const,
+    id: '479e3145-dd38-476b-932c-529ceb705947',
+  },
+  error: null,
+}));
+
+vi.mock('resend', () => ({
+  Resend: class MockResend {
+    constructor(public key: string) {}
+    contacts = { imports: { create: mockCreate } };
+  },
+}));
+
+const tmpFile = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '__test_contacts.csv',
+);
+
+describe('contacts imports create command', () => {
+  const restoreEnv = captureTestEnv();
+  let spies: ReturnType<typeof setupOutputSpies> | undefined;
+  let errorSpy: MockInstance | undefined;
+  let stderrSpy: MockInstance | undefined;
+  let exitSpy: MockInstance | undefined;
+
+  beforeEach(() => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    mockCreate.mockClear();
+    writeFileSync(tmpFile, 'email,first_name\njane@example.com,Jane\n');
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    errorSpy?.mockRestore();
+    stderrSpy?.mockRestore();
+    exitSpy?.mockRestore();
+    spies = undefined;
+    errorSpy = undefined;
+    stderrSpy = undefined;
+    exitSpy = undefined;
+    try {
+      unlinkSync(tmpFile);
+    } catch {
+      // already removed
+    }
+  });
+
+  it('reads the CSV file and passes it to the SDK as a File', async () => {
+    spies = setupOutputSpies();
+
+    const { createContactImportCommand } = await import(
+      '../../../../src/commands/contacts/imports/create'
+    );
+    await createContactImportCommand.parseAsync(['--file', tmpFile], {
+      from: 'user',
+    });
+
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    const args = mockCreate.mock.calls[0][0] as { file: File };
+    expect(args.file).toBeInstanceOf(File);
+    expect(args.file.name).toBe('__test_contacts.csv');
+  });
+
+  it('outputs JSON contact_import id when non-interactive', async () => {
+    spies = setupOutputSpies();
+
+    const { createContactImportCommand } = await import(
+      '../../../../src/commands/contacts/imports/create'
+    );
+    await createContactImportCommand.parseAsync(['--file', tmpFile], {
+      from: 'user',
+    });
+
+    const output = spies.logSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output);
+    expect(parsed.id).toBe('479e3145-dd38-476b-932c-529ceb705947');
+    expect(parsed.object).toBe('contact_import');
+  });
+
+  it('parses --column-map JSON and passes it to the SDK', async () => {
+    spies = setupOutputSpies();
+
+    const { createContactImportCommand } = await import(
+      '../../../../src/commands/contacts/imports/create'
+    );
+    await createContactImportCommand.parseAsync(
+      [
+        '--file',
+        tmpFile,
+        '--column-map',
+        '{"email":"Email","firstName":"First Name"}',
+      ],
+      { from: 'user' },
+    );
+
+    const args = mockCreate.mock.calls[0][0] as Record<string, unknown>;
+    expect(args.columnMap).toEqual({
+      email: 'Email',
+      firstName: 'First Name',
+    });
+  });
+
+  it('passes --on-conflict to the SDK', async () => {
+    spies = setupOutputSpies();
+
+    const { createContactImportCommand } = await import(
+      '../../../../src/commands/contacts/imports/create'
+    );
+    await createContactImportCommand.parseAsync(
+      ['--file', tmpFile, '--on-conflict', 'skip'],
+      { from: 'user' },
+    );
+
+    const args = mockCreate.mock.calls[0][0] as Record<string, unknown>;
+    expect(args.onConflict).toBe('skip');
+  });
+
+  it('maps multiple --segment-id values to a segments array', async () => {
+    spies = setupOutputSpies();
+
+    const { createContactImportCommand } = await import(
+      '../../../../src/commands/contacts/imports/create'
+    );
+    await createContactImportCommand.parseAsync(
+      [
+        '--file',
+        tmpFile,
+        '--segment-id',
+        '3f2a1b4c-5d6e-7f8a-9b0c-1d2e3f4a5b6c',
+        '--segment-id',
+        'e8d7c6b5-a4f3-2e1d-0c9b-8a7f6e5d4c3b',
+      ],
+      { from: 'user' },
+    );
+
+    const args = mockCreate.mock.calls[0][0] as Record<string, unknown>;
+    expect(args.segments).toEqual([
+      { id: '3f2a1b4c-5d6e-7f8a-9b0c-1d2e3f4a5b6c' },
+      { id: 'e8d7c6b5-a4f3-2e1d-0c9b-8a7f6e5d4c3b' },
+    ]);
+  });
+
+  it('parses --topics JSON and passes it to the SDK', async () => {
+    spies = setupOutputSpies();
+
+    const { createContactImportCommand } = await import(
+      '../../../../src/commands/contacts/imports/create'
+    );
+    await createContactImportCommand.parseAsync(
+      [
+        '--file',
+        tmpFile,
+        '--topics',
+        '[{"id":"b6d24b8e-af0b-4c3c-be0c-359bbd97381e","subscription":"opt_in"}]',
+      ],
+      { from: 'user' },
+    );
+
+    const args = mockCreate.mock.calls[0][0] as Record<string, unknown>;
+    expect(args.topics).toEqual([
+      { id: 'b6d24b8e-af0b-4c3c-be0c-359bbd97381e', subscription: 'opt_in' },
+    ]);
+  });
+
+  it('errors with missing_file in non-interactive mode', async () => {
+    setNonInteractive();
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = mockExitThrow();
+
+    const { createContactImportCommand } = await import(
+      '../../../../src/commands/contacts/imports/create'
+    );
+    await expectExit1(() =>
+      createContactImportCommand.parseAsync([], { from: 'user' }),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('missing_file');
+  });
+
+  it('errors with file_read_error when the file does not exist', async () => {
+    setNonInteractive();
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = mockExitThrow();
+
+    const { createContactImportCommand } = await import(
+      '../../../../src/commands/contacts/imports/create'
+    );
+    await expectExit1(() =>
+      createContactImportCommand.parseAsync(
+        ['--file', '/tmp/nonexistent-resend-contacts.csv'],
+        { from: 'user' },
+      ),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('file_read_error');
+  });
+
+  it('errors with invalid_column_map when --column-map is not valid JSON', async () => {
+    setNonInteractive();
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = mockExitThrow();
+
+    const { createContactImportCommand } = await import(
+      '../../../../src/commands/contacts/imports/create'
+    );
+    await expectExit1(() =>
+      createContactImportCommand.parseAsync(
+        ['--file', tmpFile, '--column-map', 'not-json'],
+        { from: 'user' },
+      ),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('invalid_column_map');
+  });
+
+  it('errors with invalid_column_map when --column-map is valid JSON but not an object', async () => {
+    setNonInteractive();
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = mockExitThrow();
+
+    const { createContactImportCommand } = await import(
+      '../../../../src/commands/contacts/imports/create'
+    );
+    await expectExit1(() =>
+      createContactImportCommand.parseAsync(
+        ['--file', tmpFile, '--column-map', '["email"]'],
+        { from: 'user' },
+      ),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('invalid_column_map');
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it('errors with create_error when the SDK returns an error', async () => {
+    setNonInteractive();
+    mockCreate.mockResolvedValueOnce(
+      mockSdkError('File too large', 'validation_error'),
+    );
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    exitSpy = mockExitThrow();
+
+    const { createContactImportCommand } = await import(
+      '../../../../src/commands/contacts/imports/create'
+    );
+    await expectExit1(() =>
+      createContactImportCommand.parseAsync(['--file', tmpFile], {
+        from: 'user',
+      }),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('create_error');
+  });
+});

--- a/tests/commands/contacts/imports/get.test.ts
+++ b/tests/commands/contacts/imports/get.test.ts
@@ -1,0 +1,105 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from 'vitest';
+import {
+  captureTestEnv,
+  expectExit1,
+  mockExitThrow,
+  mockSdkError,
+  setNonInteractive,
+  setupOutputSpies,
+} from '../../../helpers';
+
+const contactImport = {
+  object: 'contact_import',
+  id: '479e3145-dd38-476b-932c-529ceb705947',
+  status: 'completed',
+  created_at: '2026-05-15T18:32:37.823Z',
+  completed_at: '2026-05-15T18:33:42.916Z',
+  counts: { total: 1200, created: 800, updated: 300, skipped: 75, failed: 25 },
+};
+
+const mockGet = vi.fn(async () => ({ data: contactImport, error: null }));
+
+vi.mock('resend', () => ({
+  Resend: class MockResend {
+    constructor(public key: string) {}
+    contacts = { imports: { get: mockGet } };
+  },
+}));
+
+describe('contacts imports get command', () => {
+  const restoreEnv = captureTestEnv();
+  let spies: ReturnType<typeof setupOutputSpies> | undefined;
+  let errorSpy: MockInstance | undefined;
+  let stderrSpy: MockInstance | undefined;
+  let exitSpy: MockInstance | undefined;
+
+  beforeEach(() => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    mockGet.mockClear();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    errorSpy?.mockRestore();
+    stderrSpy?.mockRestore();
+    exitSpy?.mockRestore();
+    spies = undefined;
+    errorSpy = undefined;
+    stderrSpy = undefined;
+    exitSpy = undefined;
+  });
+
+  it('calls SDK imports.get with the id and outputs JSON', async () => {
+    spies = setupOutputSpies();
+
+    const { getContactImportCommand } = await import(
+      '../../../../src/commands/contacts/imports/get'
+    );
+    await getContactImportCommand.parseAsync(
+      ['479e3145-dd38-476b-932c-529ceb705947'],
+      { from: 'user' },
+    );
+
+    expect(mockGet).toHaveBeenCalledWith(
+      '479e3145-dd38-476b-932c-529ceb705947',
+    );
+    const output = spies.logSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output);
+    expect(parsed.object).toBe('contact_import');
+    expect(parsed.status).toBe('completed');
+    expect(parsed.counts.total).toBe(1200);
+  });
+
+  it('errors with fetch_error when the SDK returns an error', async () => {
+    setNonInteractive();
+    mockGet.mockResolvedValueOnce(
+      mockSdkError('Contact import not found', 'not_found'),
+    );
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    exitSpy = mockExitThrow();
+
+    const { getContactImportCommand } = await import(
+      '../../../../src/commands/contacts/imports/get'
+    );
+    await expectExit1(() =>
+      getContactImportCommand.parseAsync(
+        ['479e3145-dd38-476b-932c-529ceb705947'],
+        { from: 'user' },
+      ),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('fetch_error');
+  });
+});

--- a/tests/commands/contacts/imports/list.test.ts
+++ b/tests/commands/contacts/imports/list.test.ts
@@ -1,0 +1,139 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from 'vitest';
+import {
+  captureTestEnv,
+  expectExit1,
+  mockExitThrow,
+  mockSdkError,
+  setNonInteractive,
+  setupOutputSpies,
+} from '../../../helpers';
+
+const contactImport = {
+  object: 'contact_import',
+  id: '479e3145-dd38-476b-932c-529ceb705947',
+  status: 'completed',
+  created_at: '2026-05-15T18:32:37.823Z',
+  completed_at: '2026-05-15T18:33:42.916Z',
+  counts: { total: 1200, created: 800, updated: 300, skipped: 75, failed: 25 },
+};
+
+const mockList = vi.fn(async () => ({
+  data: { object: 'list', has_more: false, data: [contactImport] },
+  error: null,
+}));
+
+vi.mock('resend', () => ({
+  Resend: class MockResend {
+    constructor(public key: string) {}
+    contacts = { imports: { list: mockList } };
+  },
+}));
+
+describe('contacts imports list command', () => {
+  const restoreEnv = captureTestEnv();
+  let spies: ReturnType<typeof setupOutputSpies> | undefined;
+  let errorSpy: MockInstance | undefined;
+  let exitSpy: MockInstance | undefined;
+
+  beforeEach(() => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    mockList.mockClear();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    errorSpy?.mockRestore();
+    exitSpy?.mockRestore();
+    spies = undefined;
+    errorSpy = undefined;
+    exitSpy = undefined;
+  });
+
+  it('calls SDK imports.list with the default limit and outputs JSON', async () => {
+    spies = setupOutputSpies();
+
+    const { listContactImportsCommand } = await import(
+      '../../../../src/commands/contacts/imports/list'
+    );
+    await listContactImportsCommand.parseAsync([], { from: 'user' });
+
+    expect(mockList).toHaveBeenCalledWith({ limit: 10 });
+    const output = spies.logSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output);
+    expect(parsed.object).toBe('list');
+    expect(parsed.data[0].id).toBe('479e3145-dd38-476b-932c-529ceb705947');
+  });
+
+  it('passes --status filter to the SDK', async () => {
+    spies = setupOutputSpies();
+
+    const { listContactImportsCommand } = await import(
+      '../../../../src/commands/contacts/imports/list'
+    );
+    await listContactImportsCommand.parseAsync(['--status', 'completed'], {
+      from: 'user',
+    });
+
+    expect(mockList).toHaveBeenCalledWith({ limit: 10, status: 'completed' });
+  });
+
+  it('passes --after cursor to the SDK', async () => {
+    spies = setupOutputSpies();
+
+    const { listContactImportsCommand } = await import(
+      '../../../../src/commands/contacts/imports/list'
+    );
+    await listContactImportsCommand.parseAsync(
+      ['--after', '479e3145-dd38-476b-932c-529ceb705947'],
+      { from: 'user' },
+    );
+
+    expect(mockList).toHaveBeenCalledWith({
+      limit: 10,
+      after: '479e3145-dd38-476b-932c-529ceb705947',
+    });
+  });
+
+  it('errors with invalid_limit when --limit is out of range', async () => {
+    setNonInteractive();
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = mockExitThrow();
+
+    const { listContactImportsCommand } = await import(
+      '../../../../src/commands/contacts/imports/list'
+    );
+    await expectExit1(() =>
+      listContactImportsCommand.parseAsync(['--limit', '999'], {
+        from: 'user',
+      }),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('invalid_limit');
+  });
+
+  it('errors with list_error when the SDK returns an error', async () => {
+    setNonInteractive();
+    mockList.mockResolvedValueOnce(mockSdkError('Boom', 'application_error'));
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = mockExitThrow();
+
+    const { listContactImportsCommand } = await import(
+      '../../../../src/commands/contacts/imports/list'
+    );
+    await expectExit1(() =>
+      listContactImportsCommand.parseAsync([], { from: 'user' }),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('list_error');
+  });
+});


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>: <message>`

Examples:
- New feature: `feat: add new thing`
- Fix: `fix: resolve issue with send command`
- Misc/Chore: `chore: update readme.md`
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `resend contacts imports` to bulk-import contacts from CSV with create/get/list commands. Async flow with status tracking, pagination, and clearer docs to avoid common import failures.

- **New Features**
  - `contacts imports create`: upload CSV (`--file`), with `--column-map`, `--on-conflict` (`upsert|skip`), repeatable `--segment-id`, and `--topics`; returns an import id immediately.
  - `contacts imports get [id]`: fetch import status and counts; supports an interactive id picker.
  - `contacts imports list` (`ls`): paginate with `--limit`, `--after|--before`, filter by `--status`; interactive table and `--json`.
  - Docs: added command specs, workflow recipe, and error codes (`missing_file`, `invalid_column_map`, `invalid_topics`, `create_error`); clarified default column matching is case-sensitive lowercase (`email`, `first_name`, `last_name`); broadened `file_read_error`; added common pitfalls and listed `imports` under `contacts`.

- **Bug Fixes**
  - Validate explicitly provided empty `--topics` in `create` and surface `invalid_topics` instead of ignoring the flag.
  - `get` help now shows `fetch_error` (dropped `not_found`) to match standardized runtime errors.

<sup>Written for commit cbb7a4b8c2fc6e7212582f190f96a7563b01dc16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-cli/pull/329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

