### PR TITLE
chore: note default CSV column matching in imports create help

### DIFF
--- a/src/commands/contacts/imports/create.ts
+++ b/src/commands/contacts/imports/create.ts
@@ -38,6 +38,10 @@ export const createContactImportCommand = new Command('create')
 
 The CSV file is uploaded as multipart form data (max 100MB).
 
+Without --column-map, columns are matched case-sensitively by the lowercase names
+  email (required), first_name, last_name. A CSV with headers like "Email" or
+  "First Name" fails unless mapped with --column-map.
+
 Column map: pass a JSON object to --column-map that maps CSV column headers to contact
   fields (email, firstName, lastName, unsubscribed, properties). Example:
   '{"email":"Email","firstName":"First Name","properties":{"plan":{"column":"Plan","type":"string"}}}'


### PR DESCRIPTION
The contacts imports create help describes --column-map but never states that without it, columns are matched case-sensitively by the lowercase names email/first_name/last_name. A CSV with Email/First Name headers then fails with a 422 create_error. Surface this in --help to match the agent skill docs.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

The PR name should follow `<type>: <message>`

Examples:
- New feature: `feat: add new thing`
- Fix: `fix: resolve issue with send command`
- Misc/Chore: `chore: update readme.md`
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarify default CSV column matching in `contacts imports create` help to prevent unexpected 422s. Without `--column-map`, headers must match lowercase `email` (required), `first_name`, and `last_name` exactly; title-cased headers like "Email" or "First Name" must be mapped.

<sup>Written for commit 548e505de018d346f17ac397341584291450afc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-cli/pull/332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

