### PR TITLE
chore: bump to 2.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-cli",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "The official CLI for Resend",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Bump version 2.5.0 → 2.6.0.

## Included since 2.5.0
- **feat:** `contacts imports` commands — bulk-import contacts from CSV (create/get/list) (#329)
- **docs:** note default CSV column matching in `imports create` help (#332)
- **fix(deps):** esbuild 0.28.1 (security) (#324)
- **chore(deps):** vitest, tsx, @yao-pkg/pkg, pnpm bumps (#319, #318, #310, #308)

## Release steps after squash-merge
Per the [release runbook](https://app.notion.com/p/321c40d6c4ef8079a857fa54944c5403): tag the squash-merge commit on `main` with `v2.6.0` (not the branch commit), then the release workflow builds binaries, publishes to NPM, and opens the Homebrew tap PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `resend-cli` to 2.6.0 to ship the new `contacts imports` commands and a security update.

- **New Features**
  - Add `contacts imports` commands for bulk CSV import (create/get/list).

- **Dependencies**
  - Update `esbuild` to 0.28.1 (security).
  - Bump `vitest`, `tsx`, `@yao-pkg/pkg`, and `pnpm`.

<sup>Written for commit 85245140481e3c0f42c344d047348ca62d61ab19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-cli/pull/333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

