### PR TITLE
feat: add oauth-grants list and revoke commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-cli",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "The official CLI for Resend",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "esbuild": "0.28.1",
     "esbuild-wasm": "0.28.0",
     "picocolors": "1.1.1",
-    "resend": "6.14.0"
+    "resend": "6.17.0"
   },
   "pkg": {
     "scripts": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: 1.1.1
         version: 1.1.1
       resend:
-        specifier: 6.14.0
-        version: 6.14.0
+        specifier: 6.17.0
+        version: 6.17.0
     devDependencies:
       '@biomejs/biome':
         specifier: 2.4.11
@@ -1226,8 +1226,8 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
-  resend@6.14.0:
-    resolution: {integrity: sha512-jVdpUgOoWGLjaP64lo8KwzHT9gY4w6Dl8c36CIb2F+ayYOMLr3khqs8xrNjXM2k19b+lPoj0VWQFhVNLiToBjA==}
+  resend@6.17.0:
+    resolution: {integrity: sha512-hYNLU58nKg1Sx9kPF1E6fo447/9OMNbk3pOzuQGZMtoRU4FhtNTrW7SHFLPT8F8quTcIAa6Cs5Q5hEuWHJNTpA==}
     engines: {node: '>=20'}
     peerDependencies:
       '@react-email/render': '*'
@@ -2431,7 +2431,7 @@ snapshots:
 
   require-directory@2.1.1: {}
 
-  resend@6.14.0:
+  resend@6.17.0:
     dependencies:
       postal-mime: 2.7.4
       standardwebhooks: 1.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,5 +2,4 @@ allowBuilds:
   esbuild: true
   '@biomejs/biome': true
 minimumReleaseAgeExclude:
-  - resend@6.14.0
   - resend@6.17.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,4 @@ allowBuilds:
   '@biomejs/biome': true
 minimumReleaseAgeExclude:
   - resend@6.14.0
+  - resend@6.17.0

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,6 +17,7 @@ import { domainsCommand } from './commands/domains/index';
 import { emailsCommand } from './commands/emails/index';
 import { eventsCommand } from './commands/events/index';
 import { logsCommand } from './commands/logs/index';
+import { oauthGrantsCommand } from './commands/oauth-grants/index';
 import { openCommand } from './commands/open';
 import { segmentsCommand } from './commands/segments/index';
 import { templatesCommand } from './commands/templates/index';
@@ -141,6 +142,7 @@ ${pc.gray('Examples:')}
   .addCommand(logsCommand)
   .addCommand(apiKeysCommand)
   .addCommand(webhooksCommand)
+  .addCommand(oauthGrantsCommand)
   .addCommand(authCommand)
   .addCommand(logoutCommand)
   .addCommand(whoamiCommand)

--- a/src/commands/oauth-grants/index.ts
+++ b/src/commands/oauth-grants/index.ts
@@ -1,0 +1,22 @@
+import { Command } from '@commander-js/extra-typings';
+import { buildHelpText } from '../../lib/help-text';
+import { listOAuthGrantsCommand } from './list';
+import { revokeOAuthGrantCommand } from './revoke';
+
+export const oauthGrantsCommand = new Command('oauth-grants')
+  .description('Manage OAuth grants (apps authorized to act on the team)')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      context: `An OAuth grant is a durable record of a client (app) authorized by the team.
+  - Listing returns every grant, active and revoked. revoked_at/revoked_reason are null while active.
+  - Revoking is immediate: all access and refresh tokens issued under the grant stop working.`,
+      examples: [
+        'resend oauth-grants list',
+        'resend oauth-grants list --limit 25 --json',
+        'resend oauth-grants revoke <id> --yes',
+      ],
+    }),
+  )
+  .addCommand(listOAuthGrantsCommand, { isDefault: true })
+  .addCommand(revokeOAuthGrantCommand);

--- a/src/commands/oauth-grants/list.ts
+++ b/src/commands/oauth-grants/list.ts
@@ -1,0 +1,68 @@
+import { Command } from '@commander-js/extra-typings';
+import { runList } from '../../lib/actions';
+import type { GlobalOpts } from '../../lib/client';
+import { buildHelpText } from '../../lib/help-text';
+import {
+  buildPaginationOpts,
+  parseLimitOpt,
+  printPaginationHint,
+} from '../../lib/pagination';
+import { renderOAuthGrantsTable } from './utils';
+
+export const listOAuthGrantsCommand = new Command('list')
+  .alias('ls')
+  .description(
+    "List OAuth grants for the team (both active and revoked), including each grant's client, scopes, and revocation status",
+  )
+  .option(
+    '--limit <n>',
+    'Maximum number of OAuth grants to return (1-100)',
+    '10',
+  )
+  .option(
+    '--after <cursor>',
+    'Cursor for forward pagination — list items after this ID',
+  )
+  .option(
+    '--before <cursor>',
+    'Cursor for backward pagination — list items before this ID',
+  )
+  .addHelpText(
+    'after',
+    buildHelpText({
+      output: `  {"object":"list","has_more":false,"data":[{"id":"<id>","client_id":"<id>","scopes":["<scope>"],"resource":"<url>|null","created_at":"<date>","revoked_at":"<date>|null","revoked_reason":"<reason>|null","client":{"name":"<name>","logo_uri":"<url>|null"}}]}
+  Revoked grants have non-null revoked_at and revoked_reason.`,
+      errorCodes: ['auth_error', 'invalid_limit', 'list_error'],
+      examples: [
+        'resend oauth-grants list',
+        'resend oauth-grants list --limit 25 --json',
+        'resend oauth-grants list --after <cursor> --json',
+      ],
+    }),
+  )
+  .action(async (opts, cmd) => {
+    const globalOpts = cmd.optsWithGlobals() as GlobalOpts;
+    const limit = parseLimitOpt(opts.limit, globalOpts);
+    const paginationOpts = buildPaginationOpts(
+      limit,
+      opts.after,
+      opts.before,
+      globalOpts,
+    );
+    await runList(
+      {
+        loading: 'Fetching OAuth grants...',
+        sdkCall: (resend) => resend.oauthGrants.list(paginationOpts),
+        onInteractive: (list) => {
+          console.log(renderOAuthGrantsTable(list.data));
+          printPaginationHint(list, 'oauth-grants list', {
+            limit,
+            before: opts.before,
+            apiKey: globalOpts.apiKey,
+            profile: globalOpts.profile,
+          });
+        },
+      },
+      globalOpts,
+    );
+  });

--- a/src/commands/oauth-grants/revoke.ts
+++ b/src/commands/oauth-grants/revoke.ts
@@ -1,0 +1,48 @@
+import { Command } from '@commander-js/extra-typings';
+import { runWrite } from '../../lib/actions';
+import type { GlobalOpts } from '../../lib/client';
+import { buildHelpText } from '../../lib/help-text';
+import { confirmDelete, pickItem } from '../../lib/prompts';
+import { oauthGrantPickerConfig } from './utils';
+
+export const revokeOAuthGrantCommand = new Command('revoke')
+  .description(
+    'Revoke an OAuth grant — every access and refresh token issued under it stops working immediately',
+  )
+  .argument('[id]', 'OAuth grant ID')
+  .option('--yes', 'Skip confirmation prompt')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      context: `Non-interactive: --yes is required to confirm revocation when stdin/stdout is not a TTY.
+
+Any team API key can revoke any of the team's grants. Revocation is immediate and
+irreversible — the client would need to re-authorize to regain access.`,
+      output: `  {"object":"oauth_grant","id":"<id>","revoked_at":"<date>","revoked_reason":"<reason>"}`,
+      errorCodes: ['auth_error', 'confirmation_required', 'revoke_error'],
+      examples: [
+        'resend oauth-grants revoke 650e8400-e29b-41d4-a716-446655440001 --yes',
+        'resend oauth-grants revoke 650e8400-e29b-41d4-a716-446655440001 --yes --json',
+      ],
+    }),
+  )
+  .action(async (idArg, opts, cmd) => {
+    const globalOpts = cmd.optsWithGlobals() as GlobalOpts;
+    const picked = await pickItem(idArg, oauthGrantPickerConfig, globalOpts);
+    if (!opts.yes) {
+      await confirmDelete(
+        picked.id,
+        `Revoke OAuth grant for "${picked.label}"?\nID: ${picked.id}\nEvery access and refresh token issued under it will stop working.`,
+        globalOpts,
+      );
+    }
+    await runWrite(
+      {
+        loading: 'Revoking OAuth grant...',
+        sdkCall: (resend) => resend.oauthGrants.revoke(picked.id),
+        errorCode: 'revoke_error',
+        successMsg: 'OAuth grant revoked',
+      },
+      globalOpts,
+    );
+  });

--- a/src/commands/oauth-grants/utils.ts
+++ b/src/commands/oauth-grants/utils.ts
@@ -1,0 +1,26 @@
+import type { OAuthGrant } from 'resend';
+import type { PickerConfig } from '../../lib/prompts';
+import { renderTable } from '../../lib/table';
+
+export const oauthGrantPickerConfig: PickerConfig<OAuthGrant> = {
+  resource: 'OAuth grant',
+  resourcePlural: 'OAuth grants',
+  fetchItems: (resend, { limit, after }) =>
+    resend.oauthGrants.list({ limit, ...(after && { after }) }),
+  display: (g) => ({ label: g.client.name, hint: g.id }),
+};
+
+export function renderOAuthGrantsTable(grants: OAuthGrant[]): string {
+  const rows = grants.map((g) => [
+    g.client.name,
+    g.id,
+    g.scopes.join(', '),
+    g.created_at,
+    g.revoked_at ?? '',
+  ]);
+  return renderTable(
+    ['Client', 'ID', 'Scopes', 'Created', 'Revoked'],
+    rows,
+    '(no OAuth grants)',
+  );
+}

--- a/tests/commands/oauth-grants/list.test.ts
+++ b/tests/commands/oauth-grants/list.test.ts
@@ -1,0 +1,138 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from 'vitest';
+import { captureTestEnv, setupOutputSpies } from '../../helpers';
+
+const mockList = vi.fn(async () => ({
+  data: {
+    object: 'list',
+    data: [
+      {
+        id: 'grant-id-1',
+        client_id: 'client-id-1',
+        scopes: ['emails:send'],
+        resource: null,
+        created_at: '2026-01-01T00:00:00.000Z',
+        revoked_at: null,
+        revoked_reason: null,
+        client: { name: 'Resend CLI', logo_uri: null },
+      },
+      {
+        id: 'grant-id-2',
+        client_id: 'client-id-1',
+        scopes: ['emails:send', 'domains:read'],
+        resource: 'https://api.resend.com',
+        created_at: '2026-01-02T00:00:00.000Z',
+        revoked_at: '2026-01-03T00:00:00.000Z',
+        revoked_reason: 'revoked_from_api',
+        client: { name: 'Resend CLI', logo_uri: null },
+      },
+    ],
+    has_more: false,
+  },
+  error: null,
+}));
+
+vi.mock('resend', () => ({
+  Resend: class MockResend {
+    constructor(public key: string) {}
+    oauthGrants = { list: mockList };
+  },
+}));
+
+describe('oauth-grants list command', () => {
+  const restoreEnv = captureTestEnv();
+  let spies: ReturnType<typeof setupOutputSpies> | undefined;
+
+  beforeEach(() => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    mockList.mockClear();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    spies = undefined;
+  });
+
+  function getFirstCallArgs(): unknown {
+    const firstCall = mockList.mock.calls.at(0);
+    if (!firstCall) {
+      throw new Error('Expected mockList to be called at least once');
+    }
+    return firstCall[0];
+  }
+
+  it('uses default limit of 10 when not specified', async () => {
+    spies = setupOutputSpies();
+
+    const { listOAuthGrantsCommand } = await import(
+      '../../../src/commands/oauth-grants/list'
+    );
+    await listOAuthGrantsCommand.parseAsync([], { from: 'user' });
+
+    expect(mockList).toHaveBeenCalledTimes(1);
+    expect(getFirstCallArgs()).toMatchObject({ limit: 10 });
+  });
+
+  it('outputs JSON list when non-interactive', async () => {
+    spies = setupOutputSpies();
+
+    const { listOAuthGrantsCommand } = await import(
+      '../../../src/commands/oauth-grants/list'
+    );
+    await listOAuthGrantsCommand.parseAsync([], { from: 'user' });
+
+    const output = (spies.logSpy.mock.calls[0] as unknown[])[0] as string;
+    const parsed = JSON.parse(output);
+    expect(parsed.object).toBe('list');
+    expect(parsed.data).toHaveLength(2);
+    expect(parsed.data[0].id).toBe('grant-id-1');
+    expect(parsed.data[0].client.name).toBe('Resend CLI');
+    expect(parsed.data[1].revoked_reason).toBe('revoked_from_api');
+  });
+
+  it('passes limit to SDK', async () => {
+    spies = setupOutputSpies();
+
+    const { listOAuthGrantsCommand } = await import(
+      '../../../src/commands/oauth-grants/list'
+    );
+    await listOAuthGrantsCommand.parseAsync(['--limit', '25'], {
+      from: 'user',
+    });
+
+    expect(getFirstCallArgs()).toMatchObject({ limit: 25 });
+  });
+
+  it('passes after cursor to SDK', async () => {
+    spies = setupOutputSpies();
+
+    const { listOAuthGrantsCommand } = await import(
+      '../../../src/commands/oauth-grants/list'
+    );
+    await listOAuthGrantsCommand.parseAsync(['--after', 'some-cursor'], {
+      from: 'user',
+    });
+
+    expect(getFirstCallArgs()).toMatchObject({ after: 'some-cursor' });
+  });
+
+  it('passes before cursor to SDK', async () => {
+    spies = setupOutputSpies();
+
+    const { listOAuthGrantsCommand } = await import(
+      '../../../src/commands/oauth-grants/list'
+    );
+    await listOAuthGrantsCommand.parseAsync(['--before', 'some-cursor'], {
+      from: 'user',
+    });
+
+    expect(getFirstCallArgs()).toMatchObject({ before: 'some-cursor' });
+  });
+});

--- a/tests/commands/oauth-grants/list.test.ts
+++ b/tests/commands/oauth-grants/list.test.ts
@@ -1,12 +1,4 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  type MockInstance,
-  vi,
-} from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { captureTestEnv, setupOutputSpies } from '../../helpers';
 
 const mockList = vi.fn(async () => ({

--- a/tests/commands/oauth-grants/revoke.test.ts
+++ b/tests/commands/oauth-grants/revoke.test.ts
@@ -1,0 +1,143 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from 'vitest';
+import {
+  captureTestEnv,
+  expectExit1,
+  mockExitThrow,
+  mockSdkError,
+  setNonInteractive,
+  setupOutputSpies,
+} from '../../helpers';
+
+const mockRevoke = vi.fn(async () => ({
+  data: {
+    object: 'oauth_grant',
+    id: 'test-grant-id',
+    revoked_at: '2026-01-03T00:00:00.000Z',
+    revoked_reason: 'revoked_from_api',
+  },
+  error: null,
+}));
+
+vi.mock('resend', () => ({
+  Resend: class MockResend {
+    constructor(public key: string) {}
+    oauthGrants = { revoke: mockRevoke };
+  },
+}));
+
+describe('oauth-grants revoke command', () => {
+  const restoreEnv = captureTestEnv();
+  let spies: ReturnType<typeof setupOutputSpies> | undefined;
+  let errorSpy: MockInstance | undefined;
+  let stderrSpy: MockInstance | undefined;
+  let exitSpy: MockInstance | undefined;
+
+  beforeEach(() => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    mockRevoke.mockClear();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    errorSpy?.mockRestore();
+    stderrSpy?.mockRestore();
+    exitSpy?.mockRestore();
+    spies = undefined;
+    errorSpy = undefined;
+    stderrSpy = undefined;
+    exitSpy = undefined;
+  });
+
+  it('revokes an OAuth grant with the --yes flag', async () => {
+    spies = setupOutputSpies();
+
+    const { revokeOAuthGrantCommand } = await import(
+      '../../../src/commands/oauth-grants/revoke'
+    );
+    await revokeOAuthGrantCommand.parseAsync(['test-grant-id', '--yes'], {
+      from: 'user',
+    });
+
+    expect(mockRevoke).toHaveBeenCalledWith('test-grant-id');
+  });
+
+  it('outputs the revoked grant JSON on success', async () => {
+    spies = setupOutputSpies();
+
+    const { revokeOAuthGrantCommand } = await import(
+      '../../../src/commands/oauth-grants/revoke'
+    );
+    await revokeOAuthGrantCommand.parseAsync(['test-grant-id', '--yes'], {
+      from: 'user',
+    });
+
+    const output = (spies.logSpy.mock.calls[0] as unknown[])[0] as string;
+    const parsed = JSON.parse(output);
+    expect(parsed.object).toBe('oauth_grant');
+    expect(parsed.id).toBe('test-grant-id');
+    expect(parsed.revoked_reason).toBe('revoked_from_api');
+  });
+
+  it('errors with confirmation_required when --yes absent in non-interactive mode', async () => {
+    setNonInteractive();
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = mockExitThrow();
+
+    const { revokeOAuthGrantCommand } = await import(
+      '../../../src/commands/oauth-grants/revoke'
+    );
+    await expectExit1(() =>
+      revokeOAuthGrantCommand.parseAsync(['test-grant-id'], { from: 'user' }),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('confirmation_required');
+  });
+
+  it('does not call the SDK when confirmation is required but not given', async () => {
+    setNonInteractive();
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = mockExitThrow();
+
+    const { revokeOAuthGrantCommand } = await import(
+      '../../../src/commands/oauth-grants/revoke'
+    );
+    await expectExit1(() =>
+      revokeOAuthGrantCommand.parseAsync(['test-grant-id'], { from: 'user' }),
+    );
+
+    expect(mockRevoke).not.toHaveBeenCalled();
+  });
+
+  it('errors with revoke_error when the SDK returns an error', async () => {
+    setNonInteractive();
+    mockRevoke.mockResolvedValueOnce(
+      mockSdkError('OAuth grant not found', 'not_found'),
+    );
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    exitSpy = mockExitThrow();
+
+    const { revokeOAuthGrantCommand } = await import(
+      '../../../src/commands/oauth-grants/revoke'
+    );
+    await expectExit1(() =>
+      revokeOAuthGrantCommand.parseAsync(['test-grant-id', '--yes'], {
+        from: 'user',
+      }),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('revoke_error');
+  });
+});

--- a/tests/commands/oauth-grants/utils.test.ts
+++ b/tests/commands/oauth-grants/utils.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  oauthGrantPickerConfig,
+  renderOAuthGrantsTable,
+} from '../../../src/commands/oauth-grants/utils';
+
+const grant = {
+  id: 'grant-1',
+  client_id: 'client-1',
+  scopes: ['emails:send'],
+  resource: null,
+  created_at: '2026-01-01T00:00:00.000Z',
+  revoked_at: null,
+  revoked_reason: null,
+  client: { name: 'Resend CLI', logo_uri: null },
+};
+
+describe('oauthGrantPickerConfig', () => {
+  it('forwards limit and after to resend.oauthGrants.list', async () => {
+    const mockList = vi.fn(async () => ({
+      data: { data: [grant], has_more: true },
+      error: null,
+    }));
+    const resend = { oauthGrants: { list: mockList } } as never;
+
+    const result = await oauthGrantPickerConfig.fetchItems(resend, {
+      limit: 20,
+      after: 'cursor-abc',
+    });
+
+    expect(mockList).toHaveBeenCalledWith({ limit: 20, after: 'cursor-abc' });
+    expect(result.data?.has_more).toBe(true);
+  });
+
+  it('omits after when not provided', async () => {
+    const mockList = vi.fn(async () => ({
+      data: { data: [grant], has_more: false },
+      error: null,
+    }));
+    const resend = { oauthGrants: { list: mockList } } as never;
+
+    await oauthGrantPickerConfig.fetchItems(resend, { limit: 20 });
+
+    expect(mockList).toHaveBeenCalledWith({ limit: 20 });
+  });
+
+  it('displays the client name as label and id as hint', () => {
+    const display = oauthGrantPickerConfig.display(grant);
+    expect(display).toEqual({ label: 'Resend CLI', hint: 'grant-1' });
+  });
+});
+
+describe('renderOAuthGrantsTable', () => {
+  it('renders client, scopes, and revocation status', () => {
+    const table = renderOAuthGrantsTable([
+      grant,
+      {
+        ...grant,
+        id: 'grant-2',
+        scopes: ['emails:send', 'domains:read'],
+        revoked_at: '2026-01-02T00:00:00.000Z',
+        revoked_reason: 'revoked_from_api',
+      },
+    ]);
+
+    expect(table).toContain('Resend CLI');
+    expect(table).toContain('grant-1');
+    expect(table).toContain('emails:send, domains:read');
+    expect(table).toContain('2026-01-02T00:00:00.000Z');
+  });
+
+  it('shows an empty message when there are no grants', () => {
+    expect(renderOAuthGrantsTable([])).toContain('(no OAuth grants)');
+  });
+});


### PR DESCRIPTION
## What

Adds `resend oauth-grants` commands to manage a team's OAuth grants:

- **`resend oauth-grants list`** (alias `ls`, default subcommand) — lists all grants (active and revoked) with client, scopes, created, and revocation status. Supports `--limit` / `--after` / `--before`.
- **`resend oauth-grants revoke <id>`** — revokes a grant. `--yes` to skip confirmation (required in non-interactive mode). Interactive picker when no id is given.

Mirrors the existing `api-keys` command pattern (`runList`, `pickItem`, help text, table rendering).

## Notes

- Revoke uses `runWrite`, so JSON mode returns the **real** API response `{object:"oauth_grant", id, revoked_at, revoked_reason}` rather than a synthesized `{deleted:true}` — the revocation metadata is useful to agents/scripts.
- No README change: the README documents only a curated subset of commands (api-keys/contacts/etc. aren't listed either); `resend commands` picks up the new group automatically.

## Dependency — blocks merge

Requires **`resend@6.17.0`** (oauth grants SDK support, resend/resend-node#998), which is merged to the SDK's `canary` branch but **not yet published to npm**. This PR bumps `dependencies.resend` to `6.17.0`.

- Verified locally by building the canary SDK and running against it: **typecheck ✓, biome ✓, full test suite 1017 passed / 1 skipped ✓** (15 new tests for list/revoke/utils).
- The lockfile is intentionally left untouched — once `resend@6.17.0` is on npm, run `pnpm install` to sync it. CI install / `--frozen-lockfile` will stay red until then.

## Related

- Public API: resend/resend-monorepo#5275 (list), #5260 (revoke, merged)
- OpenAPI: resend/resend-openapi#70
- Node SDK: resend/resend-node#998
- Docs: resend/resend-docs#1618

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add OAuth grant management to the CLI with list and revoke commands. Teams can see all authorized apps and revoke access immediately.

- **New Features**
  - Added `oauth-grants` command group.
  - `list` (alias `ls`): shows client, ID, scopes, created, and revoked; supports `--limit`, `--after`, `--before`.
  - `revoke <id>`: revokes a grant; supports `--yes` and an interactive picker when no ID is provided; JSON returns `{object:"oauth_grant", id, revoked_at, revoked_reason}`.
  - Mirrors the existing `api-keys` command pattern.

- **Dependencies**
  - Bumps `resend` to `6.17.0` for OAuth grants SDK support and syncs the lockfile.
  - Excludes `resend@6.17.0` from the pnpm minimum-release-age policy to unblock installs.
  - Bumps CLI version to `2.8.0`.

<sup>Written for commit 37b58061ef72a497bb066049712d4c21d69453e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-cli/pull/340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

