### PR TITLE
feat: drop resource field from oauth-grants

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "esbuild": "0.28.1",
     "esbuild-wasm": "0.28.0",
     "picocolors": "1.1.1",
-    "resend": "6.17.0"
+    "resend": "6.17.1"
   },
   "pkg": {
     "scripts": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-cli",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "The official CLI for Resend",
   "license": "MIT",
   "repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: 1.1.1
         version: 1.1.1
       resend:
-        specifier: 6.17.0
-        version: 6.17.0
+        specifier: 6.17.1
+        version: 6.17.1
     devDependencies:
       '@biomejs/biome':
         specifier: 2.4.11
@@ -1226,8 +1226,8 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
-  resend@6.17.0:
-    resolution: {integrity: sha512-hYNLU58nKg1Sx9kPF1E6fo447/9OMNbk3pOzuQGZMtoRU4FhtNTrW7SHFLPT8F8quTcIAa6Cs5Q5hEuWHJNTpA==}
+  resend@6.17.1:
+    resolution: {integrity: sha512-QhHHIRPPM9Tq2uilWmNF8C8kd6nLkUmiFgDQCt1v4eR4o+6p86qrK+Vn12jnAs0jR8Gf6ABdxI18/90LGQ7GVA==}
     engines: {node: '>=20'}
     peerDependencies:
       '@react-email/render': '*'
@@ -2431,7 +2431,7 @@ snapshots:
 
   require-directory@2.1.1: {}
 
-  resend@6.17.0:
+  resend@6.17.1:
     dependencies:
       postal-mime: 2.7.4
       standardwebhooks: 1.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,4 +2,4 @@ allowBuilds:
   esbuild: true
   '@biomejs/biome': true
 minimumReleaseAgeExclude:
-  - resend@6.17.0
+  - resend@6.17.1

--- a/src/commands/oauth-grants/list.ts
+++ b/src/commands/oauth-grants/list.ts
@@ -30,7 +30,7 @@ export const listOAuthGrantsCommand = new Command('list')
   .addHelpText(
     'after',
     buildHelpText({
-      output: `  {"object":"list","has_more":false,"data":[{"id":"<id>","client_id":"<id>","scopes":["<scope>"],"resource":"<url>|null","created_at":"<date>","revoked_at":"<date>|null","revoked_reason":"<reason>|null","client":{"name":"<name>","logo_uri":"<url>|null"}}]}
+      output: `  {"object":"list","has_more":false,"data":[{"id":"<id>","client_id":"<id>","scopes":["<scope>"],"created_at":"<date>","revoked_at":"<date>|null","revoked_reason":"<reason>|null","client":{"name":"<name>","logo_uri":"<url>|null"}}]}
   Revoked grants have non-null revoked_at and revoked_reason.`,
       errorCodes: ['auth_error', 'invalid_limit', 'list_error'],
       examples: [


### PR DESCRIPTION
Removes the unused `resource` field from the oauth-grants list command, following its removal from the API (resend/resend-monorepo#5372) and the SDK (resend/resend-node#1000).

## Changes
- Drop `resource` from the `oauth-grants list` help-text output example
- Bump `resend` dep `6.17.0` → `6.17.1` to pick up the updated `OAuthGrant` type (published to npm)
- Update lockfile + build-allowlist for 6.17.1
- Bump CLI version to 2.8.1

All 1017 tests pass; typecheck + supply-chain policy pass.

Part of the chain: OpenAPI (resend/resend-openapi#71) → resend-node#1000 → **resend-cli (this)** → remono MCP → OSS MCP.