### PR TITLE
feat: document and pass through tags in emails batch

### DIFF
--- a/src/commands/emails/batch.ts
+++ b/src/commands/emails/batch.ts
@@ -34,7 +34,7 @@ export const batchCommand = new Command('batch')
     'after',
     buildHelpText({
       context:
-        'Non-interactive: --file\nLimit: 100 emails per request (API hard limit — warned if exceeded)\nUnsupported per-email fields: attachments, scheduled_at\nPer-email tags supported: [{"name":"category","value":"welcome"}]\n\nFile format (--file path):\n  [\n    {"from":"onboarding@resend.com","to":["delivered@resend.com"],"subject":"Hello","text":"Hi"},\n    {"from":"onboarding@resend.com","to":["delivered@resend.com"],"subject":"Hello","html":"<b>Hi</b>","tags":[{"name":"category","value":"welcome"}]}\n  ]',
+        'Non-interactive: --file\nLimit: 100 emails per request (API hard limit — warned if exceeded)\nPer-email tags supported: [{"name":"category","value":"welcome"}]\nUnsupported per-email field: scheduled_at\n\nFile format (--file path):\n  [\n    {"from":"onboarding@resend.com","to":["delivered@resend.com"],"subject":"Hello","text":"Hi"},\n    {"from":"onboarding@resend.com","to":["delivered@resend.com"],"subject":"Hello","html":"<b>Hi</b>","tags":[{"name":"category","value":"welcome"}]}\n  ]',
       output: '  [{"id":"<email-id>"},{"id":"<email-id>"}]',
       errorCodes: [
         'auth_error',

--- a/src/commands/emails/batch.ts
+++ b/src/commands/emails/batch.ts
@@ -10,42 +10,6 @@ import { buildReactEmailHtml } from '../../lib/react-email';
 import { withSpinner } from '../../lib/spinner';
 import { isInteractive } from '../../lib/tty';
 
-/** Map API snake_case fields in batch JSON to SDK camelCase before send. */
-function normalizeBatchEmail(
-  email: Record<string, unknown>,
-): Record<string, unknown> {
-  const out = { ...email };
-
-  if ('scheduled_at' in out && !('scheduledAt' in out)) {
-    out.scheduledAt = out.scheduled_at;
-  }
-  if ('reply_to' in out && !('replyTo' in out)) {
-    out.replyTo = out.reply_to;
-  }
-  if ('topic_id' in out && !('topicId' in out)) {
-    out.topicId = out.topic_id;
-  }
-
-  const attachments = out.attachments;
-  if (Array.isArray(attachments)) {
-    out.attachments = attachments.map((item) => {
-      if (item === null || typeof item !== 'object' || Array.isArray(item)) {
-        return item;
-      }
-      const attachment = { ...(item as Record<string, unknown>) };
-      if ('content_type' in attachment && !('contentType' in attachment)) {
-        attachment.contentType = attachment.content_type;
-      }
-      if ('content_id' in attachment && !('contentId' in attachment)) {
-        attachment.contentId = attachment.content_id;
-      }
-      return attachment;
-    });
-  }
-
-  return out;
-}
-
 export const batchCommand = new Command('batch')
   .description('Send up to 100 emails in a single API request from a JSON file')
   .option(
@@ -70,7 +34,7 @@ export const batchCommand = new Command('batch')
     'after',
     buildHelpText({
       context:
-        'Non-interactive: --file\nLimit: 100 emails per request (API hard limit — warned if exceeded)\nPer-email fields: attachments, scheduled_at, tags (and all single-send fields)\n\nFile format (--file path):\n  [\n    {"from":"onboarding@resend.com","to":["delivered@resend.com"],"subject":"Hello","text":"Hi"},\n    {"from":"onboarding@resend.com","to":["delivered@resend.com"],"subject":"Hello","html":"<b>Hi</b>","scheduled_at":"2026-01-01T00:00:00Z","tags":[{"name":"category","value":"welcome"}],"attachments":[{"filename":"doc.pdf","content":"<base64>"}]}\n  ]',
+        'Non-interactive: --file\nLimit: 100 emails per request (API hard limit — warned if exceeded)\nUnsupported per-email fields: attachments, scheduled_at\nPer-email tags supported: [{"name":"category","value":"welcome"}]\n\nFile format (--file path):\n  [\n    {"from":"onboarding@resend.com","to":["delivered@resend.com"],"subject":"Hello","text":"Hi"},\n    {"from":"onboarding@resend.com","to":["delivered@resend.com"],"subject":"Hello","html":"<b>Hi</b>","tags":[{"name":"category","value":"welcome"}]}\n  ]',
       output: '  [{"id":"<email-id>"},{"id":"<email-id>"}]',
       errorCodes: [
         'auth_error',
@@ -156,6 +120,25 @@ export const batchCommand = new Command('batch')
           { json: globalOpts.json },
         );
       }
+
+      if ('attachments' in email) {
+        outputError(
+          {
+            message: `Email at index ${i} contains "attachments", which is not supported in batch sends.`,
+            code: 'batch_error',
+          },
+          { json: globalOpts.json },
+        );
+      }
+      if ('scheduled_at' in email) {
+        outputError(
+          {
+            message: `Email at index ${i} contains "scheduled_at", which is not supported in batch sends.`,
+            code: 'batch_error',
+          },
+          { json: globalOpts.json },
+        );
+      }
     }
 
     const batchData = await withSpinner(
@@ -168,9 +151,7 @@ export const batchCommand = new Command('batch')
           }),
         };
         return resend.batch.send(
-          emails.map((email) =>
-            normalizeBatchEmail(email as Record<string, unknown>),
-          ) as CreateBatchOptions,
+          emails as CreateBatchOptions,
           Object.keys(options).length > 0 ? options : undefined,
         );
       },

--- a/src/commands/emails/batch.ts
+++ b/src/commands/emails/batch.ts
@@ -10,6 +10,42 @@ import { buildReactEmailHtml } from '../../lib/react-email';
 import { withSpinner } from '../../lib/spinner';
 import { isInteractive } from '../../lib/tty';
 
+/** Map API snake_case fields in batch JSON to SDK camelCase before send. */
+function normalizeBatchEmail(
+  email: Record<string, unknown>,
+): Record<string, unknown> {
+  const out = { ...email };
+
+  if ('scheduled_at' in out && !('scheduledAt' in out)) {
+    out.scheduledAt = out.scheduled_at;
+  }
+  if ('reply_to' in out && !('replyTo' in out)) {
+    out.replyTo = out.reply_to;
+  }
+  if ('topic_id' in out && !('topicId' in out)) {
+    out.topicId = out.topic_id;
+  }
+
+  const attachments = out.attachments;
+  if (Array.isArray(attachments)) {
+    out.attachments = attachments.map((item) => {
+      if (item === null || typeof item !== 'object' || Array.isArray(item)) {
+        return item;
+      }
+      const attachment = { ...(item as Record<string, unknown>) };
+      if ('content_type' in attachment && !('contentType' in attachment)) {
+        attachment.contentType = attachment.content_type;
+      }
+      if ('content_id' in attachment && !('contentId' in attachment)) {
+        attachment.contentId = attachment.content_id;
+      }
+      return attachment;
+    });
+  }
+
+  return out;
+}
+
 export const batchCommand = new Command('batch')
   .description('Send up to 100 emails in a single API request from a JSON file')
   .option(
@@ -34,7 +70,7 @@ export const batchCommand = new Command('batch')
     'after',
     buildHelpText({
       context:
-        'Non-interactive: --file\nLimit: 100 emails per request (API hard limit — warned if exceeded)\nUnsupported per-email fields: attachments, scheduled_at\n\nFile format (--file path):\n  [\n    {"from":"onboarding@resend.com","to":["delivered@resend.com"],"subject":"Hello","text":"Hi"},\n    {"from":"onboarding@resend.com","to":["delivered@resend.com"],"subject":"Hello","html":"<b>Hi</b>"}\n  ]',
+        'Non-interactive: --file\nLimit: 100 emails per request (API hard limit — warned if exceeded)\nPer-email fields: attachments, scheduled_at, tags (and all single-send fields)\n\nFile format (--file path):\n  [\n    {"from":"onboarding@resend.com","to":["delivered@resend.com"],"subject":"Hello","text":"Hi"},\n    {"from":"onboarding@resend.com","to":["delivered@resend.com"],"subject":"Hello","html":"<b>Hi</b>","scheduled_at":"2026-01-01T00:00:00Z","tags":[{"name":"category","value":"welcome"}],"attachments":[{"filename":"doc.pdf","content":"<base64>"}]}\n  ]',
       output: '  [{"id":"<email-id>"},{"id":"<email-id>"}]',
       errorCodes: [
         'auth_error',
@@ -120,25 +156,6 @@ export const batchCommand = new Command('batch')
           { json: globalOpts.json },
         );
       }
-
-      if ('attachments' in email) {
-        outputError(
-          {
-            message: `Email at index ${i} contains "attachments", which is not supported in batch sends.`,
-            code: 'batch_error',
-          },
-          { json: globalOpts.json },
-        );
-      }
-      if ('scheduled_at' in email) {
-        outputError(
-          {
-            message: `Email at index ${i} contains "scheduled_at", which is not supported in batch sends.`,
-            code: 'batch_error',
-          },
-          { json: globalOpts.json },
-        );
-      }
     }
 
     const batchData = await withSpinner(
@@ -151,7 +168,9 @@ export const batchCommand = new Command('batch')
           }),
         };
         return resend.batch.send(
-          emails as CreateBatchOptions,
+          emails.map((email) =>
+            normalizeBatchEmail(email as Record<string, unknown>),
+          ) as CreateBatchOptions,
           Object.keys(options).length > 0 ? options : undefined,
         );
       },

--- a/tests/commands/emails/batch.test.ts
+++ b/tests/commands/emails/batch.test.ts
@@ -212,43 +212,43 @@ describe('batch command', () => {
     expect(output).toContain('Email at index 0 must be a JSON object.');
   });
 
-  it('passes entries with attachments through to batch.send', async () => {
-    spies = setupOutputSpies();
+  it('rejects entries with attachments', async () => {
+    setNonInteractive();
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = mockExitThrow();
 
     const emails = [
       {
         ...VALID_EMAILS[0],
-        attachments: [{ filename: 'test.txt', content: 'aGVsbG8=' }],
+        attachments: [{ filename: 'test.txt', content: 'hello' }],
       },
     ];
     const file = await writeTmpJson(emails);
     const { batchCommand } = await import('../../../src/commands/emails/batch');
-    await batchCommand.parseAsync(['--file', file], { from: 'user' });
+    await expectExit1(() =>
+      batchCommand.parseAsync(['--file', file], { from: 'user' }),
+    );
 
-    expect(mockBatchSend).toHaveBeenCalledTimes(1);
-    const sent = mockBatchSend.mock.calls[0][0] as Array<
-      Record<string, unknown>
-    >;
-    expect(sent[0].attachments).toEqual([
-      { filename: 'test.txt', content: 'aGVsbG8=' },
-    ]);
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('attachments');
   });
 
-  it('passes entries with scheduled_at through to batch.send', async () => {
-    spies = setupOutputSpies();
+  it('rejects entries with scheduled_at', async () => {
+    setNonInteractive();
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = mockExitThrow();
 
     const emails = [
       { ...VALID_EMAILS[0], scheduled_at: '2026-01-01T00:00:00Z' },
     ];
     const file = await writeTmpJson(emails);
     const { batchCommand } = await import('../../../src/commands/emails/batch');
-    await batchCommand.parseAsync(['--file', file], { from: 'user' });
+    await expectExit1(() =>
+      batchCommand.parseAsync(['--file', file], { from: 'user' }),
+    );
 
-    expect(mockBatchSend).toHaveBeenCalledTimes(1);
-    const sent = mockBatchSend.mock.calls[0][0] as Array<
-      Record<string, unknown>
-    >;
-    expect(sent[0].scheduledAt).toBe('2026-01-01T00:00:00Z');
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('scheduled_at');
   });
 
   it('passes entries with tags through to batch.send', async () => {

--- a/tests/commands/emails/batch.test.ts
+++ b/tests/commands/emails/batch.test.ts
@@ -212,43 +212,63 @@ describe('batch command', () => {
     expect(output).toContain('Email at index 0 must be a JSON object.');
   });
 
-  it('rejects entries with attachments', async () => {
-    setNonInteractive();
-    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    exitSpy = mockExitThrow();
+  it('passes entries with attachments through to batch.send', async () => {
+    spies = setupOutputSpies();
 
     const emails = [
       {
         ...VALID_EMAILS[0],
-        attachments: [{ filename: 'test.txt', content: 'hello' }],
+        attachments: [{ filename: 'test.txt', content: 'aGVsbG8=' }],
       },
     ];
     const file = await writeTmpJson(emails);
     const { batchCommand } = await import('../../../src/commands/emails/batch');
-    await expectExit1(() =>
-      batchCommand.parseAsync(['--file', file], { from: 'user' }),
-    );
+    await batchCommand.parseAsync(['--file', file], { from: 'user' });
 
-    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
-    expect(output).toContain('attachments');
+    expect(mockBatchSend).toHaveBeenCalledTimes(1);
+    const sent = mockBatchSend.mock.calls[0][0] as Array<
+      Record<string, unknown>
+    >;
+    expect(sent[0].attachments).toEqual([
+      { filename: 'test.txt', content: 'aGVsbG8=' },
+    ]);
   });
 
-  it('rejects entries with scheduled_at', async () => {
-    setNonInteractive();
-    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    exitSpy = mockExitThrow();
+  it('passes entries with scheduled_at through to batch.send', async () => {
+    spies = setupOutputSpies();
 
     const emails = [
       { ...VALID_EMAILS[0], scheduled_at: '2026-01-01T00:00:00Z' },
     ];
     const file = await writeTmpJson(emails);
     const { batchCommand } = await import('../../../src/commands/emails/batch');
-    await expectExit1(() =>
-      batchCommand.parseAsync(['--file', file], { from: 'user' }),
-    );
+    await batchCommand.parseAsync(['--file', file], { from: 'user' });
 
-    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
-    expect(output).toContain('scheduled_at');
+    expect(mockBatchSend).toHaveBeenCalledTimes(1);
+    const sent = mockBatchSend.mock.calls[0][0] as Array<
+      Record<string, unknown>
+    >;
+    expect(sent[0].scheduledAt).toBe('2026-01-01T00:00:00Z');
+  });
+
+  it('passes entries with tags through to batch.send', async () => {
+    spies = setupOutputSpies();
+
+    const emails = [
+      {
+        ...VALID_EMAILS[0],
+        tags: [{ name: 'category', value: 'welcome' }],
+      },
+    ];
+    const file = await writeTmpJson(emails);
+    const { batchCommand } = await import('../../../src/commands/emails/batch');
+    await batchCommand.parseAsync(['--file', file], { from: 'user' });
+
+    expect(mockBatchSend).toHaveBeenCalledTimes(1);
+    const sent = mockBatchSend.mock.calls[0][0] as Array<
+      Record<string, unknown>
+    >;
+    expect(sent[0].tags).toEqual([{ name: 'category', value: 'welcome' }]);
   });
 
   it('warns but continues when array length exceeds 100', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Document per-email `tags` support in `emails batch` help text.
- Add a test confirming tags pass through to `batch.send`.

## Test plan

- [x] `pnpm test tests/commands/emails/batch.test.ts`
- [x] `pnpm biome check src/commands/emails/batch.ts tests/commands/emails/batch.test.ts`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cc59d0b3-0ba2-4687-9e40-b7398a869783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cc59d0b3-0ba2-4687-9e40-b7398a869783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents and passes through per-email `tags` in the `emails batch` CLI, while continuing to reject `scheduled_at`. Updates help text to show tags support and remove the attachments note, and adds a test to confirm tags are sent to `batch.send`.

<sup>Written for commit 78e998152f8ece4a346ea18deda8abbbb13f8ccf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-cli/pull/344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

