### PR TITLE
feat: add suppressions command group (beta)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-cli",
-  "version": "2.8.1",
+  "version": "2.9.0",
   "description": "The official CLI for Resend",
   "license": "MIT",
   "repository": {
@@ -46,7 +46,7 @@
     "esbuild": "0.28.1",
     "esbuild-wasm": "0.28.0",
     "picocolors": "1.1.1",
-    "resend": "6.17.1"
+    "resend": "6.18.0-canary.0"
   },
   "pkg": {
     "scripts": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-cli",
-  "version": "2.9.0",
+  "version": "2.8.1",
   "description": "The official CLI for Resend",
   "license": "MIT",
   "repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: 1.1.1
         version: 1.1.1
       resend:
-        specifier: 6.17.1
-        version: 6.17.1
+        specifier: 6.18.0-canary.0
+        version: 6.18.0-canary.0
     devDependencies:
       '@biomejs/biome':
         specifier: 2.4.11
@@ -1183,8 +1183,8 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  postal-mime@2.7.4:
-    resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
+  postal-mime@2.7.5:
+    resolution: {integrity: sha512-GNEXKvWFQnbgO5NlrGzVa0FmWzBZ24PersAWErttSg1Hjpf0ATxTwS5DOMGaOpTG6bUh5cTr7xi0jAD942wCJA==}
 
   postcss@8.5.14:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
@@ -1226,8 +1226,8 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
-  resend@6.17.1:
-    resolution: {integrity: sha512-QhHHIRPPM9Tq2uilWmNF8C8kd6nLkUmiFgDQCt1v4eR4o+6p86qrK+Vn12jnAs0jR8Gf6ABdxI18/90LGQ7GVA==}
+  resend@6.18.0-canary.0:
+    resolution: {integrity: sha512-XDP/rAa5phbGlmb/Hy+uqVlKKwNPBSUXFdwQVVdCi46brbBim/E0JsBkvvZ6UJdz7YePNOw8PSu4fqK5hPH80Q==}
     engines: {node: '>=20'}
     peerDependencies:
       '@react-email/render': '*'
@@ -2370,7 +2370,7 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  postal-mime@2.7.4: {}
+  postal-mime@2.7.5: {}
 
   postcss@8.5.14:
     dependencies:
@@ -2431,9 +2431,9 @@ snapshots:
 
   require-directory@2.1.1: {}
 
-  resend@6.17.1:
+  resend@6.18.0-canary.0:
     dependencies:
-      postal-mime: 2.7.4
+      postal-mime: 2.7.5
       standardwebhooks: 1.0.0
 
   resolve.exports@2.0.3: {}

--- a/skills/resend-cli/SKILL.md
+++ b/skills/resend-cli/SKILL.md
@@ -13,7 +13,7 @@ metadata:
   author: resend
   # Skill version is independent from the CLI/package.json version —
   # bump it on skill content changes, not CLI releases.
-  version: "2.3.1"
+  version: "2.4.0"
   homepage: https://resend.com/docs/cli-agents
   source: https://github.com/resend/resend-cli
   openclaw:
@@ -57,6 +57,7 @@ references:
   - references/templates.md
   - references/topics.md
   - references/logs.md
+  - references/suppressions.md
   - references/webhooks.md
   - references/auth.md
   - references/workflows.md
@@ -143,6 +144,7 @@ Auth resolves: `--api-key` flag > `RESEND_API_KEY` env > config file (`resend lo
 | `emails receiving` | list, get, attachments, forward, listen |
 | `domains` | create, verify, get, claim, update, delete, list |
 | `logs` | list, get, open |
+| `suppressions` _(beta)_ | list, add, get, delete, batch — requires account enrollment |
 | `api-keys` | create, list, delete |
 | `automations` | create, get, list, update, delete, stop, open, runs |
 | `events` | create, get, list, update, delete, send, open |
@@ -220,6 +222,7 @@ resend doctor -q
 - **Defining contact properties** → [references/contact-properties.md](references/contact-properties.md)
 - **Working with templates** → [references/templates.md](references/templates.md)
 - **Viewing API request logs** → [references/logs.md](references/logs.md)
+- **Managing the suppression list** (beta) → [references/suppressions.md](references/suppressions.md)
 - **Creating automations or sending events** → [references/automations.md](references/automations.md)
 - **Setting up webhooks or listening for events** → [references/webhooks.md](references/webhooks.md)
 - **Auth, profiles, or health checks** → [references/auth.md](references/auth.md)

--- a/skills/resend-cli/references/suppressions.md
+++ b/skills/resend-cli/references/suppressions.md
@@ -22,12 +22,12 @@ Suppressions block future sends to an address. Each entry has an `origin`:
 
 List suppressed addresses (default subcommand — `resend suppressions` alone runs it).
 
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--limit <n>` | number | No | Max results, 1-100 (default 10) |
-| `--after <cursor>` | string | No | Forward pagination cursor |
-| `--before <cursor>` | string | No | Backward pagination cursor |
-| `--origin <origin>` | string | No | Filter: `bounce` \| `complaint` \| `manual` |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--limit <n>` | number | 10 | Max results, 1-100 |
+| `--after <cursor>` | string | — | Forward pagination cursor |
+| `--before <cursor>` | string | — | Backward pagination cursor |
+| `--origin <origin>` | string | — | Filter: `bounce` \| `complaint` \| `manual` |
 
 **Alias:** `ls`
 

--- a/skills/resend-cli/references/suppressions.md
+++ b/skills/resend-cli/references/suppressions.md
@@ -1,0 +1,101 @@
+# suppressions
+
+Detailed flag specifications for `resend suppressions` commands.
+
+> **Beta:** Suppressions is a pre-GA feature gated per account. Commands appear in
+> `--help` but return an API error unless the suppression list is enabled for your
+> account. Reach out to Resend to join the beta.
+
+Suppressions block future sends to an address. Each entry has an `origin`:
+
+| Origin | Meaning |
+|--------|---------|
+| `bounce` | Added automatically after a hard bounce |
+| `complaint` | Added automatically after a spam complaint |
+| `manual` | Added by you via `suppressions add` |
+
+`get` and `delete` accept **either** a suppression ID **or** the email address.
+
+---
+
+## suppressions list
+
+List suppressed addresses (default subcommand — `resend suppressions` alone runs it).
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--limit <n>` | number | No | Max results, 1-100 (default 10) |
+| `--after <cursor>` | string | No | Forward pagination cursor |
+| `--before <cursor>` | string | No | Backward pagination cursor |
+| `--origin <origin>` | string | No | Filter: `bounce` \| `complaint` \| `manual` |
+
+**Alias:** `ls`
+
+**Output:** `{"object":"list","has_more":false,"data":[{"object":"suppression","id":"...","email":"...","origin":"bounce|complaint|manual","source_id":"..."|null,"created_at":"..."}]}`
+
+---
+
+## suppressions add
+
+Suppress a single email address (origin `manual`).
+
+**Argument:** `<email>` — email address to suppress (required in non-interactive mode)
+
+**Output:** `{"object":"suppression","id":"..."}`
+
+---
+
+## suppressions get
+
+Retrieve a single suppression.
+
+**Argument:** `<id-or-email>` — suppression ID or the suppressed email address
+
+**Output:** `{"object":"suppression","id":"...","email":"...","origin":"...","source_id":"..."|null,"created_at":"..."}`
+
+---
+
+## suppressions delete
+
+Remove a suppression so Resend can send to the address again.
+
+**Argument:** `<id-or-email>` — suppression ID or the suppressed email address
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--yes` | boolean | Yes (non-interactive) | Skip confirmation |
+
+**Alias:** `rm`
+
+**Output:** `{"object":"suppression","id":"...","deleted":true}`
+
+---
+
+## suppressions batch add
+
+Suppress up to 100 addresses in one request.
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--file <path>` | string | Yes (non-interactive) | JSON file with an array of email strings (`-` for stdin) |
+
+**File format:** `["a@example.com", "b@example.com"]`
+
+**Output:** `{"data":[{"object":"suppression","id":"..."}]}`
+
+---
+
+## suppressions batch remove
+
+Remove up to 100 suppressions in one request.
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--file <path>` | string | Yes (non-interactive) | JSON file with an array of strings (`-` for stdin) |
+| `--ids` | boolean | No | Treat file entries as suppression IDs instead of emails |
+
+**Alias:** `rm`
+
+**File format:** `["a@example.com", "b@example.com"]` (or IDs with `--ids`)
+
+**Output:** `{"data":[{"object":"suppression","id":"...","deleted":true}]}`

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,7 @@ import { logsCommand } from './commands/logs/index';
 import { oauthGrantsCommand } from './commands/oauth-grants/index';
 import { openCommand } from './commands/open';
 import { segmentsCommand } from './commands/segments/index';
+import { suppressionsCommand } from './commands/suppressions/index';
 import { templatesCommand } from './commands/templates/index';
 import { topicsCommand } from './commands/topics/index';
 import { updateCommand } from './commands/update';
@@ -140,6 +141,9 @@ ${pc.gray('Examples:')}
   .addCommand(topicsCommand)
   .addCommand(domainsCommand)
   .addCommand(logsCommand)
+  // Visible pre-GA with a [beta] marker in its description — the API gates usage
+  // per account, so non-enabled users see the command but get an API error until enrolled.
+  .addCommand(suppressionsCommand)
   .addCommand(apiKeysCommand)
   .addCommand(webhooksCommand)
   .addCommand(oauthGrantsCommand)

--- a/src/commands/suppressions/add.ts
+++ b/src/commands/suppressions/add.ts
@@ -1,0 +1,50 @@
+import { Command } from '@commander-js/extra-typings';
+import pc from 'picocolors';
+import { runCreate } from '../../lib/actions';
+import type { GlobalOpts } from '../../lib/client';
+import { buildHelpText } from '../../lib/help-text';
+import { requireText } from '../../lib/prompts';
+
+export const addSuppressionCommand = new Command('add')
+  .description('Suppress an email address so it stops receiving your emails')
+  .argument('[email]', 'Email address to suppress')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      context: `Non-interactive: <email> is required (no prompts when stdin/stdout is not a TTY).
+
+A suppressed address is skipped on future sends. Added this way, the entry has
+origin "manual". Use "suppressions delete" to remove it again.`,
+      output: `  {"object":"suppression","id":"<id>"}`,
+      errorCodes: ['auth_error', 'missing_email', 'create_error'],
+      examples: [
+        'resend suppressions add spam@example.com',
+        'resend suppressions add spam@example.com --json',
+      ],
+    }),
+  )
+  .action(async (emailArg, _opts, cmd) => {
+    const globalOpts = cmd.optsWithGlobals() as GlobalOpts;
+
+    const email = await requireText(
+      emailArg,
+      { message: 'Email to suppress', placeholder: 'e.g. spam@example.com' },
+      {
+        message: 'Missing <email> argument.',
+        code: 'missing_email',
+      },
+      globalOpts,
+    );
+
+    await runCreate(
+      {
+        loading: 'Suppressing address...',
+        sdkCall: (resend) => resend.suppressions.add({ email }),
+        onInteractive: (d) => {
+          console.log(`  ${pc.gray('Email:')}  ${email}`);
+          console.log(`  ${pc.gray('ID:')}     ${d.id}`);
+        },
+      },
+      globalOpts,
+    );
+  });

--- a/src/commands/suppressions/batch/add.ts
+++ b/src/commands/suppressions/batch/add.ts
@@ -1,0 +1,85 @@
+import { Command } from '@commander-js/extra-typings';
+import type { GlobalOpts } from '../../../lib/client';
+import { requireClient } from '../../../lib/client';
+import { readFile } from '../../../lib/files';
+import { buildHelpText } from '../../../lib/help-text';
+import { outputResult } from '../../../lib/output';
+import { requireText } from '../../../lib/prompts';
+import { withSpinner } from '../../../lib/spinner';
+import { isInteractive } from '../../../lib/tty';
+import { readEmailList } from './utils';
+
+export const batchAddSuppressionsCommand = new Command('add')
+  .description(
+    'Suppress up to 100 email addresses from a JSON file in one request',
+  )
+  .option(
+    '--file <path>',
+    'Path to a JSON file containing an array of email strings (use "-" for stdin; required in non-interactive mode)',
+  )
+  .addHelpText(
+    'after',
+    buildHelpText({
+      context: `Non-interactive: --file
+Limit: 100 emails per request (API hard limit — warned if exceeded)
+
+File format (--file path):
+  ["spam@example.com", "bounce@example.com"]`,
+      output: `  {"data":[{"object":"suppression","id":"<id>"}]}`,
+      errorCodes: [
+        'auth_error',
+        'missing_file',
+        'file_read_error',
+        'stdin_read_error',
+        'invalid_json',
+        'invalid_format',
+        'create_error',
+      ],
+      examples: [
+        'resend suppressions batch add --file ./emails.json',
+        'echo \'["a@example.com","b@example.com"]\' | resend suppressions batch add --file -',
+      ],
+    }),
+  )
+  .action(async (opts, cmd) => {
+    const globalOpts = cmd.optsWithGlobals() as GlobalOpts;
+    const resend = await requireClient(globalOpts);
+
+    const filePath = await requireText(
+      opts.file,
+      { message: 'Path to JSON file', placeholder: './emails.json' },
+      {
+        message:
+          'Missing --file flag. Provide a JSON file with an array of email strings.',
+        code: 'missing_file',
+      },
+      globalOpts,
+    );
+
+    const raw = readFile(filePath, globalOpts);
+    const emails = readEmailList(raw, globalOpts);
+
+    if (emails.length > 100) {
+      console.warn(
+        `Warning: ${emails.length} emails exceeds the 100-email limit. The API may reject this request.`,
+      );
+    }
+
+    const data = await withSpinner(
+      'Suppressing addresses...',
+      () => resend.suppressions.batch.add({ emails }),
+      'create_error',
+      globalOpts,
+    );
+
+    if (!globalOpts.json && isInteractive()) {
+      console.log(
+        `Suppressed ${data.data.length} address${data.data.length === 1 ? '' : 'es'}`,
+      );
+      for (const entry of data.data) {
+        console.log(`  ${entry.id}`);
+      }
+    } else {
+      outputResult(data, { json: globalOpts.json });
+    }
+  });

--- a/src/commands/suppressions/batch/index.ts
+++ b/src/commands/suppressions/batch/index.ts
@@ -1,0 +1,21 @@
+import { Command } from '@commander-js/extra-typings';
+import { buildHelpText } from '../../../lib/help-text';
+import { batchAddSuppressionsCommand } from './add';
+import { batchRemoveSuppressionsCommand } from './remove';
+
+export const batchSuppressionsCommand = new Command('batch')
+  .description('Suppress or remove many addresses in a single request')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      context: `Batch operations read a JSON array of strings from --file (up to 100 per request).
+"add" always operates on emails. "remove" defaults to emails; pass --ids to remove by ID.`,
+      examples: [
+        'resend suppressions batch add --file ./emails.json',
+        'resend suppressions batch remove --file ./emails.json',
+        'resend suppressions batch remove --file ./ids.json --ids',
+      ],
+    }),
+  )
+  .addCommand(batchAddSuppressionsCommand)
+  .addCommand(batchRemoveSuppressionsCommand);

--- a/src/commands/suppressions/batch/remove.ts
+++ b/src/commands/suppressions/batch/remove.ts
@@ -1,0 +1,93 @@
+import { Command } from '@commander-js/extra-typings';
+import type { GlobalOpts } from '../../../lib/client';
+import { requireClient } from '../../../lib/client';
+import { readFile } from '../../../lib/files';
+import { buildHelpText } from '../../../lib/help-text';
+import { outputResult } from '../../../lib/output';
+import { requireText } from '../../../lib/prompts';
+import { withSpinner } from '../../../lib/spinner';
+import { isInteractive } from '../../../lib/tty';
+import { readEmailList } from './utils';
+
+export const batchRemoveSuppressionsCommand = new Command('remove')
+  .alias('rm')
+  .description('Remove up to 100 suppressions from a JSON file in one request')
+  .option(
+    '--file <path>',
+    'Path to a JSON file containing an array of email strings (use "-" for stdin; required in non-interactive mode)',
+  )
+  .option(
+    '--ids',
+    'Treat the file entries as suppression IDs instead of email addresses',
+  )
+  .addHelpText(
+    'after',
+    buildHelpText({
+      context: `Non-interactive: --file
+Limit: 100 entries per request (API hard limit — warned if exceeded)
+By default entries are treated as email addresses; pass --ids to remove by suppression ID.
+
+File format (--file path):
+  ["spam@example.com", "bounce@example.com"]`,
+      output: `  {"data":[{"object":"suppression","id":"<id>","deleted":true}]}`,
+      errorCodes: [
+        'auth_error',
+        'missing_file',
+        'file_read_error',
+        'stdin_read_error',
+        'invalid_json',
+        'invalid_format',
+        'delete_error',
+      ],
+      examples: [
+        'resend suppressions batch remove --file ./emails.json',
+        'resend suppressions batch remove --file ./ids.json --ids',
+        'echo \'["a@example.com","b@example.com"]\' | resend suppressions batch rm --file -',
+      ],
+    }),
+  )
+  .action(async (opts, cmd) => {
+    const globalOpts = cmd.optsWithGlobals() as GlobalOpts;
+    const resend = await requireClient(globalOpts);
+
+    const filePath = await requireText(
+      opts.file,
+      { message: 'Path to JSON file', placeholder: './emails.json' },
+      {
+        message:
+          'Missing --file flag. Provide a JSON file with an array of strings.',
+        code: 'missing_file',
+      },
+      globalOpts,
+    );
+
+    const raw = readFile(filePath, globalOpts);
+    const values = readEmailList(raw, globalOpts);
+
+    if (values.length > 100) {
+      console.warn(
+        `Warning: ${values.length} entries exceeds the 100-entry limit. The API may reject this request.`,
+      );
+    }
+
+    const data = await withSpinner(
+      'Removing suppressions...',
+      () =>
+        resend.suppressions.batch.remove(
+          opts.ids ? { ids: values } : { emails: values },
+        ),
+      'delete_error',
+      globalOpts,
+    );
+
+    if (!globalOpts.json && isInteractive()) {
+      console.log(
+        `Removed ${data.data.length} suppression${data.data.length === 1 ? '' : 's'}`,
+      );
+      for (const entry of data.data) {
+        console.log(`  ${entry.id}`);
+      }
+    } else {
+      outputResult(data, { json: globalOpts.json });
+    }
+  });

--- a/src/commands/suppressions/batch/utils.ts
+++ b/src/commands/suppressions/batch/utils.ts
@@ -1,0 +1,41 @@
+import type { GlobalOpts } from '../../../lib/client';
+import { outputError } from '../../../lib/output';
+
+// Parse a batch file into a list of non-empty strings (emails or IDs).
+// Exits with a formatted error when the content is not a JSON array of strings.
+export function readEmailList(raw: string, globalOpts: GlobalOpts): string[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    outputError(
+      { message: 'File content is not valid JSON.', code: 'invalid_json' },
+      { json: globalOpts.json },
+    );
+  }
+
+  if (!Array.isArray(parsed)) {
+    outputError(
+      {
+        message: 'File content must be a JSON array of strings.',
+        code: 'invalid_format',
+      },
+      { json: globalOpts.json },
+    );
+  }
+
+  const items = parsed as unknown[];
+  for (let i = 0; i < items.length; i++) {
+    if (typeof items[i] !== 'string' || items[i] === '') {
+      outputError(
+        {
+          message: `Item at index ${i} must be a non-empty string.`,
+          code: 'invalid_format',
+        },
+        { json: globalOpts.json },
+      );
+    }
+  }
+
+  return items as string[];
+}

--- a/src/commands/suppressions/delete.ts
+++ b/src/commands/suppressions/delete.ts
@@ -1,0 +1,44 @@
+import { Command } from '@commander-js/extra-typings';
+import { runDelete } from '../../lib/actions';
+import type { GlobalOpts } from '../../lib/client';
+import { buildHelpText } from '../../lib/help-text';
+import { pickItem } from '../../lib/prompts';
+import { suppressionPickerConfig } from './utils';
+
+export const deleteSuppressionCommand = new Command('delete')
+  .alias('rm')
+  .description(
+    'Remove a suppression so the address can receive your emails again',
+  )
+  .argument('[id-or-email]', 'Suppression ID or the suppressed email address')
+  .option('--yes', 'Skip confirmation prompt')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      context: `Non-interactive: --yes is required to confirm removal when stdin/stdout is not a TTY.
+
+Removing a suppression means future sends to this address are no longer skipped.`,
+      output: `  {"object":"suppression","id":"<id>","deleted":true}`,
+      errorCodes: ['auth_error', 'confirmation_required', 'delete_error'],
+      examples: [
+        'resend suppressions delete spam@example.com --yes',
+        'resend suppressions rm 78261eea-8f8b-4381-83c6-79fa7120f1cf --yes --json',
+      ],
+    }),
+  )
+  .action(async (idArg, opts, cmd) => {
+    const globalOpts = cmd.optsWithGlobals() as GlobalOpts;
+    const picked = await pickItem(idArg, suppressionPickerConfig, globalOpts);
+    await runDelete(
+      picked.id,
+      !!opts.yes,
+      {
+        confirmMessage: `Remove suppression "${picked.label}"?\nID: ${picked.id}\nResend will be able to send to this address again.`,
+        loading: 'Removing suppression...',
+        object: 'suppression',
+        successMsg: 'Suppression removed',
+        sdkCall: (resend) => resend.suppressions.remove(picked.id),
+      },
+      globalOpts,
+    );
+  });

--- a/src/commands/suppressions/get.ts
+++ b/src/commands/suppressions/get.ts
@@ -1,0 +1,41 @@
+import { Command } from '@commander-js/extra-typings';
+import { runGet } from '../../lib/actions';
+import type { GlobalOpts } from '../../lib/client';
+import { buildHelpText } from '../../lib/help-text';
+import { pickId } from '../../lib/prompts';
+import { suppressionPickerConfig } from './utils';
+
+export const getSuppressionCommand = new Command('get')
+  .description('Retrieve a suppression by ID or email address')
+  .argument('[id-or-email]', 'Suppression ID or the suppressed email address')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      output: `  {"object":"suppression","id":"<id>","email":"<email>","origin":"bounce|complaint|manual","source_id":"<id>|null","created_at":"<date>"}`,
+      errorCodes: ['auth_error', 'fetch_error'],
+      examples: [
+        'resend suppressions get spam@example.com',
+        'resend suppressions get 78261eea-8f8b-4381-83c6-79fa7120f1cf --json',
+      ],
+    }),
+  )
+  .action(async (idArg, _opts, cmd) => {
+    const globalOpts = cmd.optsWithGlobals() as GlobalOpts;
+    const idOrEmail = await pickId(idArg, suppressionPickerConfig, globalOpts);
+    await runGet(
+      {
+        loading: 'Fetching suppression...',
+        sdkCall: (resend) => resend.suppressions.get(idOrEmail),
+        onInteractive: (data) => {
+          console.log(`${data.email}`);
+          console.log(`ID: ${data.id}`);
+          console.log(`Origin: ${data.origin}`);
+          if (data.source_id) {
+            console.log(`Source: ${data.source_id}`);
+          }
+          console.log(`Created: ${data.created_at}`);
+        },
+      },
+      globalOpts,
+    );
+  });

--- a/src/commands/suppressions/index.ts
+++ b/src/commands/suppressions/index.ts
@@ -1,0 +1,39 @@
+import { Command } from '@commander-js/extra-typings';
+import pc from 'picocolors';
+import { buildHelpText } from '../../lib/help-text';
+import { addSuppressionCommand } from './add';
+import { batchSuppressionsCommand } from './batch/index';
+import { deleteSuppressionCommand } from './delete';
+import { getSuppressionCommand } from './get';
+import { listSuppressionsCommand } from './list';
+
+export const suppressionsCommand = new Command('suppressions')
+  .description(
+    `${pc.cyan('● beta')} · Manage the suppression list — addresses that won't receive your emails (request access to enable)`,
+  )
+  .addHelpText(
+    'after',
+    buildHelpText({
+      context: `Beta: this command requires the suppression list to be enabled on your account.
+Not enabled yet? Reach out to Resend to join the beta. Calls return an API error until then.
+
+Suppressions block future sends to an address. Entries have an origin:
+  bounce     added automatically after a hard bounce
+  complaint  added automatically after a spam complaint
+  manual     added by you via "suppressions add"
+
+get/delete accept either a suppression ID or the email address.`,
+      examples: [
+        'resend suppressions list',
+        'resend suppressions add spam@example.com',
+        'resend suppressions get spam@example.com',
+        'resend suppressions delete spam@example.com --yes',
+        'resend suppressions batch add --file ./emails.json',
+      ],
+    }),
+  )
+  .addCommand(listSuppressionsCommand, { isDefault: true })
+  .addCommand(addSuppressionCommand)
+  .addCommand(getSuppressionCommand)
+  .addCommand(deleteSuppressionCommand)
+  .addCommand(batchSuppressionsCommand);

--- a/src/commands/suppressions/list.ts
+++ b/src/commands/suppressions/list.ts
@@ -67,6 +67,7 @@ export const listSuppressionsCommand = new Command('list')
             before: opts.before,
             apiKey: globalOpts.apiKey,
             profile: globalOpts.profile,
+            ...(opts.origin && { extraFlags: `--origin ${opts.origin}` }),
           });
         },
       },

--- a/src/commands/suppressions/list.ts
+++ b/src/commands/suppressions/list.ts
@@ -1,0 +1,75 @@
+import { Command, Option } from '@commander-js/extra-typings';
+import { runList } from '../../lib/actions';
+import type { GlobalOpts } from '../../lib/client';
+import { buildHelpText } from '../../lib/help-text';
+import {
+  buildPaginationOpts,
+  parseLimitOpt,
+  printPaginationHint,
+} from '../../lib/pagination';
+import { renderSuppressionsTable } from './utils';
+
+export const listSuppressionsCommand = new Command('list')
+  .alias('ls')
+  .description('List suppressed email addresses')
+  .option(
+    '--limit <n>',
+    'Maximum number of suppressions to return (1-100)',
+    '10',
+  )
+  .option(
+    '--after <cursor>',
+    'Cursor for forward pagination — list items after this ID',
+  )
+  .option(
+    '--before <cursor>',
+    'Cursor for backward pagination — list items before this ID',
+  )
+  .addOption(
+    new Option(
+      '--origin <origin>',
+      'Filter by how the address was suppressed',
+    ).choices(['bounce', 'complaint', 'manual'] as const),
+  )
+  .addHelpText(
+    'after',
+    buildHelpText({
+      output: `  {"object":"list","has_more":false,"data":[{"object":"suppression","id":"<id>","email":"<email>","origin":"bounce|complaint|manual","source_id":"<id>|null","created_at":"<date>"}]}`,
+      errorCodes: ['auth_error', 'invalid_limit', 'list_error'],
+      examples: [
+        'resend suppressions list',
+        'resend suppressions list --origin bounce --json',
+        'resend suppressions list --limit 25 --after <cursor> --json',
+      ],
+    }),
+  )
+  .action(async (opts, cmd) => {
+    const globalOpts = cmd.optsWithGlobals() as GlobalOpts;
+    const limit = parseLimitOpt(opts.limit, globalOpts);
+    const paginationOpts = buildPaginationOpts(
+      limit,
+      opts.after,
+      opts.before,
+      globalOpts,
+    );
+    await runList(
+      {
+        loading: 'Fetching suppressions...',
+        sdkCall: (resend) =>
+          resend.suppressions.list({
+            ...paginationOpts,
+            ...(opts.origin && { origin: opts.origin }),
+          }),
+        onInteractive: (list) => {
+          console.log(renderSuppressionsTable(list.data));
+          printPaginationHint(list, 'suppressions list', {
+            limit,
+            before: opts.before,
+            apiKey: globalOpts.apiKey,
+            profile: globalOpts.profile,
+          });
+        },
+      },
+      globalOpts,
+    );
+  });

--- a/src/commands/suppressions/utils.ts
+++ b/src/commands/suppressions/utils.ts
@@ -1,0 +1,29 @@
+import type { PickerConfig } from '../../lib/prompts';
+import { renderTable } from '../../lib/table';
+
+type SuppressionEntry = {
+  id: string;
+  email: string;
+  origin: 'bounce' | 'complaint' | 'manual';
+  source_id: string | null;
+  created_at: string;
+};
+
+export const suppressionPickerConfig: PickerConfig<SuppressionEntry> = {
+  resource: 'suppression',
+  resourcePlural: 'suppressions',
+  fetchItems: (resend, { limit, after }) =>
+    resend.suppressions.list({ limit, ...(after && { after }) }),
+  display: (s) => ({ label: s.email, hint: s.id }),
+};
+
+export function renderSuppressionsTable(
+  entries: Array<SuppressionEntry>,
+): string {
+  const rows = entries.map((s) => [s.email, s.id, s.origin, s.created_at]);
+  return renderTable(
+    ['Email', 'ID', 'Origin', 'Created'],
+    rows,
+    '(no suppressions)',
+  );
+}

--- a/src/lib/pagination.ts
+++ b/src/lib/pagination.ts
@@ -45,7 +45,13 @@ export function printPaginationHint(
     data: Array<{ id: string }>;
   },
   command: string,
-  opts: { limit?: number; before?: string; apiKey?: string; profile?: string },
+  opts: {
+    limit?: number;
+    before?: string;
+    apiKey?: string;
+    profile?: string;
+    extraFlags?: string;
+  },
 ): void {
   if (!list.has_more || list.data.length === 0) {
     return;
@@ -61,8 +67,9 @@ export function printPaginationHint(
   const limitFlag = opts.limit ? ` --limit ${opts.limit}` : '';
   const apiKeyFlag = opts.apiKey ? ` --api-key ${maskKey(opts.apiKey)}` : '';
   const profileFlag = opts.profile ? ` --profile ${opts.profile}` : '';
+  const extraFlags = opts.extraFlags ? ` ${opts.extraFlags}` : '';
 
   console.log(
-    `\nFetch the next page:\n$ resend ${command} ${flag} ${cursor}${limitFlag}${apiKeyFlag}${profileFlag}`,
+    `\nFetch the next page:\n$ resend ${command} ${flag} ${cursor}${limitFlag}${extraFlags}${apiKeyFlag}${profileFlag}`,
   );
 }

--- a/tests/commands/suppressions/add.test.ts
+++ b/tests/commands/suppressions/add.test.ts
@@ -1,0 +1,117 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from 'vitest';
+import {
+  captureTestEnv,
+  expectExit1,
+  mockExitThrow,
+  mockSdkError,
+  setNonInteractive,
+  setupOutputSpies,
+} from '../../helpers';
+
+const mockAdd = vi.fn(async () => ({
+  data: { object: 'suppression', id: 'sup-1' },
+  error: null,
+}));
+
+vi.mock('resend', () => ({
+  Resend: class MockResend {
+    constructor(public key: string) {}
+    suppressions = { add: mockAdd };
+  },
+}));
+
+describe('suppressions add command', () => {
+  const restoreEnv = captureTestEnv();
+  let spies: ReturnType<typeof setupOutputSpies> | undefined;
+  let errorSpy: MockInstance | undefined;
+  let stderrSpy: MockInstance | undefined;
+  let exitSpy: MockInstance | undefined;
+
+  beforeEach(() => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    mockAdd.mockClear();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    errorSpy?.mockRestore();
+    stderrSpy?.mockRestore();
+    exitSpy?.mockRestore();
+    spies = undefined;
+    errorSpy = undefined;
+    stderrSpy = undefined;
+    exitSpy = undefined;
+  });
+
+  it('suppresses the email passed as an argument', async () => {
+    spies = setupOutputSpies();
+    const { addSuppressionCommand } = await import(
+      '../../../src/commands/suppressions/add'
+    );
+    await addSuppressionCommand.parseAsync(['spam@example.com'], {
+      from: 'user',
+    });
+
+    expect(mockAdd).toHaveBeenCalledWith({ email: 'spam@example.com' });
+  });
+
+  it('outputs the created suppression JSON when non-interactive', async () => {
+    spies = setupOutputSpies();
+    const { addSuppressionCommand } = await import(
+      '../../../src/commands/suppressions/add'
+    );
+    await addSuppressionCommand.parseAsync(['spam@example.com'], {
+      from: 'user',
+    });
+
+    const output = spies.logSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output);
+    expect(parsed.object).toBe('suppression');
+    expect(parsed.id).toBe('sup-1');
+  });
+
+  it('errors with missing_email when no email in non-interactive mode', async () => {
+    setNonInteractive();
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = mockExitThrow();
+
+    const { addSuppressionCommand } = await import(
+      '../../../src/commands/suppressions/add'
+    );
+    await expectExit1(() =>
+      addSuppressionCommand.parseAsync([], { from: 'user' }),
+    );
+
+    expect(mockAdd).not.toHaveBeenCalled();
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('missing_email');
+  });
+
+  it('errors with create_error when SDK returns an error', async () => {
+    setNonInteractive();
+    mockAdd.mockResolvedValueOnce(mockSdkError('Boom', 'server_error'));
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    exitSpy = mockExitThrow();
+
+    const { addSuppressionCommand } = await import(
+      '../../../src/commands/suppressions/add'
+    );
+    await expectExit1(() =>
+      addSuppressionCommand.parseAsync(['spam@example.com'], { from: 'user' }),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('create_error');
+  });
+});

--- a/tests/commands/suppressions/batch.test.ts
+++ b/tests/commands/suppressions/batch.test.ts
@@ -1,0 +1,147 @@
+import { unlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from 'vitest';
+import {
+  captureTestEnv,
+  expectExit1,
+  mockExitThrow,
+  setNonInteractive,
+  setupOutputSpies,
+} from '../../helpers';
+
+const mockBatchAdd = vi.fn(async () => ({
+  data: { data: [{ object: 'suppression', id: 'sup-1' }] },
+  error: null,
+}));
+const mockBatchRemove = vi.fn(async () => ({
+  data: { data: [{ object: 'suppression', id: 'sup-1', deleted: true }] },
+  error: null,
+}));
+
+vi.mock('resend', () => ({
+  Resend: class MockResend {
+    constructor(public key: string) {}
+    suppressions = { batch: { add: mockBatchAdd, remove: mockBatchRemove } };
+  },
+}));
+
+describe('suppressions batch commands', () => {
+  const restoreEnv = captureTestEnv();
+  let _spies: ReturnType<typeof setupOutputSpies> | undefined;
+  let errorSpy: MockInstance | undefined;
+  let stderrSpy: MockInstance | undefined;
+  let exitSpy: MockInstance | undefined;
+  let tmpFile: string;
+
+  beforeEach(() => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    mockBatchAdd.mockClear();
+    mockBatchRemove.mockClear();
+    tmpFile = join(tmpdir(), `resend-sup-batch-${process.pid}.json`);
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    errorSpy?.mockRestore();
+    stderrSpy?.mockRestore();
+    exitSpy?.mockRestore();
+    _spies = undefined;
+    errorSpy = undefined;
+    stderrSpy = undefined;
+    exitSpy = undefined;
+    try {
+      unlinkSync(tmpFile);
+    } catch {}
+  });
+
+  it('batch add sends the email list from the file', async () => {
+    writeFileSync(tmpFile, JSON.stringify(['a@example.com', 'b@example.com']));
+    _spies = setupOutputSpies();
+
+    const { batchAddSuppressionsCommand } = await import(
+      '../../../src/commands/suppressions/batch/add'
+    );
+    await batchAddSuppressionsCommand.parseAsync(['--file', tmpFile], {
+      from: 'user',
+    });
+
+    expect(mockBatchAdd).toHaveBeenCalledWith({
+      emails: ['a@example.com', 'b@example.com'],
+    });
+  });
+
+  it('batch remove defaults to emails', async () => {
+    writeFileSync(tmpFile, JSON.stringify(['a@example.com']));
+    _spies = setupOutputSpies();
+
+    const { batchRemoveSuppressionsCommand } = await import(
+      '../../../src/commands/suppressions/batch/remove'
+    );
+    await batchRemoveSuppressionsCommand.parseAsync(['--file', tmpFile], {
+      from: 'user',
+    });
+
+    expect(mockBatchRemove).toHaveBeenCalledWith({ emails: ['a@example.com'] });
+  });
+
+  it('batch remove --ids treats entries as ids', async () => {
+    writeFileSync(tmpFile, JSON.stringify(['sup-1', 'sup-2']));
+    _spies = setupOutputSpies();
+
+    const { batchRemoveSuppressionsCommand } = await import(
+      '../../../src/commands/suppressions/batch/remove'
+    );
+    await batchRemoveSuppressionsCommand.parseAsync(
+      ['--file', tmpFile, '--ids'],
+      { from: 'user' },
+    );
+
+    expect(mockBatchRemove).toHaveBeenCalledWith({ ids: ['sup-1', 'sup-2'] });
+  });
+
+  it('errors with invalid_format when the file is not an array of strings', async () => {
+    writeFileSync(tmpFile, JSON.stringify([{ email: 'a@example.com' }]));
+    setNonInteractive();
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = mockExitThrow();
+
+    const { batchAddSuppressionsCommand } = await import(
+      '../../../src/commands/suppressions/batch/add'
+    );
+    await expectExit1(() =>
+      batchAddSuppressionsCommand.parseAsync(['--file', tmpFile], {
+        from: 'user',
+      }),
+    );
+
+    expect(mockBatchAdd).not.toHaveBeenCalled();
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('invalid_format');
+  });
+
+  it('errors with missing_file when no --file in non-interactive mode', async () => {
+    setNonInteractive();
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = mockExitThrow();
+
+    const { batchAddSuppressionsCommand } = await import(
+      '../../../src/commands/suppressions/batch/add'
+    );
+    await expectExit1(() =>
+      batchAddSuppressionsCommand.parseAsync([], { from: 'user' }),
+    );
+
+    expect(mockBatchAdd).not.toHaveBeenCalled();
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('missing_file');
+  });
+});

--- a/tests/commands/suppressions/delete.test.ts
+++ b/tests/commands/suppressions/delete.test.ts
@@ -1,0 +1,118 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from 'vitest';
+import {
+  captureTestEnv,
+  expectExit1,
+  mockExitThrow,
+  mockSdkError,
+  setNonInteractive,
+  setupOutputSpies,
+} from '../../helpers';
+
+const mockRemove = vi.fn(async () => ({
+  data: { object: 'suppression', id: 'sup-1', deleted: true },
+  error: null,
+}));
+
+vi.mock('resend', () => ({
+  Resend: class MockResend {
+    constructor(public key: string) {}
+    suppressions = { remove: mockRemove };
+  },
+}));
+
+describe('suppressions delete command', () => {
+  const restoreEnv = captureTestEnv();
+  let spies: ReturnType<typeof setupOutputSpies> | undefined;
+  let errorSpy: MockInstance | undefined;
+  let stderrSpy: MockInstance | undefined;
+  let exitSpy: MockInstance | undefined;
+
+  beforeEach(() => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    mockRemove.mockClear();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    errorSpy?.mockRestore();
+    stderrSpy?.mockRestore();
+    exitSpy?.mockRestore();
+    spies = undefined;
+    errorSpy = undefined;
+    stderrSpy = undefined;
+    exitSpy = undefined;
+  });
+
+  it('removes a suppression by email with --yes', async () => {
+    spies = setupOutputSpies();
+    const { deleteSuppressionCommand } = await import(
+      '../../../src/commands/suppressions/delete'
+    );
+    await deleteSuppressionCommand.parseAsync(['spam@example.com', '--yes'], {
+      from: 'user',
+    });
+
+    expect(mockRemove).toHaveBeenCalledWith('spam@example.com');
+  });
+
+  it('outputs synthesized deleted JSON on success', async () => {
+    spies = setupOutputSpies();
+    const { deleteSuppressionCommand } = await import(
+      '../../../src/commands/suppressions/delete'
+    );
+    await deleteSuppressionCommand.parseAsync(['sup-1', '--yes'], {
+      from: 'user',
+    });
+
+    const output = spies.logSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output);
+    expect(parsed.deleted).toBe(true);
+    expect(parsed.id).toBe('sup-1');
+    expect(parsed.object).toBe('suppression');
+  });
+
+  it('errors with confirmation_required when --yes absent in non-interactive mode', async () => {
+    setNonInteractive();
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = mockExitThrow();
+
+    const { deleteSuppressionCommand } = await import(
+      '../../../src/commands/suppressions/delete'
+    );
+    await expectExit1(() =>
+      deleteSuppressionCommand.parseAsync(['sup-1'], { from: 'user' }),
+    );
+
+    expect(mockRemove).not.toHaveBeenCalled();
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('confirmation_required');
+  });
+
+  it('errors with delete_error when SDK returns an error', async () => {
+    setNonInteractive();
+    mockRemove.mockResolvedValueOnce(mockSdkError('Not found', 'not_found'));
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    exitSpy = mockExitThrow();
+
+    const { deleteSuppressionCommand } = await import(
+      '../../../src/commands/suppressions/delete'
+    );
+    await expectExit1(() =>
+      deleteSuppressionCommand.parseAsync(['sup-1', '--yes'], { from: 'user' }),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('delete_error');
+  });
+});

--- a/tests/commands/suppressions/get.test.ts
+++ b/tests/commands/suppressions/get.test.ts
@@ -1,0 +1,117 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from 'vitest';
+import {
+  captureTestEnv,
+  expectExit1,
+  mockExitThrow,
+  mockSdkError,
+  setNonInteractive,
+  setupOutputSpies,
+} from '../../helpers';
+
+const mockGet = vi.fn(async () => ({
+  data: {
+    object: 'suppression',
+    id: 'sup-1',
+    email: 'spam@example.com',
+    origin: 'bounce',
+    source_id: 'evt-1',
+    created_at: '2026-01-01T00:00:00.000Z',
+  },
+  error: null,
+}));
+
+vi.mock('resend', () => ({
+  Resend: class MockResend {
+    constructor(public key: string) {}
+    suppressions = { get: mockGet };
+  },
+}));
+
+describe('suppressions get command', () => {
+  const restoreEnv = captureTestEnv();
+  let spies: ReturnType<typeof setupOutputSpies> | undefined;
+  let errorSpy: MockInstance | undefined;
+  let stderrSpy: MockInstance | undefined;
+  let exitSpy: MockInstance | undefined;
+
+  beforeEach(() => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    mockGet.mockClear();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    errorSpy?.mockRestore();
+    stderrSpy?.mockRestore();
+    exitSpy?.mockRestore();
+    spies = undefined;
+    errorSpy = undefined;
+    stderrSpy = undefined;
+    exitSpy = undefined;
+  });
+
+  it('fetches by email argument', async () => {
+    spies = setupOutputSpies();
+    const { getSuppressionCommand } = await import(
+      '../../../src/commands/suppressions/get'
+    );
+    await getSuppressionCommand.parseAsync(['spam@example.com'], {
+      from: 'user',
+    });
+
+    expect(mockGet).toHaveBeenCalledWith('spam@example.com');
+  });
+
+  it('fetches by id argument', async () => {
+    spies = setupOutputSpies();
+    const { getSuppressionCommand } = await import(
+      '../../../src/commands/suppressions/get'
+    );
+    await getSuppressionCommand.parseAsync(['sup-1'], { from: 'user' });
+
+    expect(mockGet).toHaveBeenCalledWith('sup-1');
+  });
+
+  it('outputs the suppression JSON when non-interactive', async () => {
+    spies = setupOutputSpies();
+    const { getSuppressionCommand } = await import(
+      '../../../src/commands/suppressions/get'
+    );
+    await getSuppressionCommand.parseAsync(['spam@example.com'], {
+      from: 'user',
+    });
+
+    const output = spies.logSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output);
+    expect(parsed.email).toBe('spam@example.com');
+    expect(parsed.origin).toBe('bounce');
+  });
+
+  it('errors with fetch_error when SDK returns an error', async () => {
+    setNonInteractive();
+    mockGet.mockResolvedValueOnce(mockSdkError('Not found', 'not_found'));
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    exitSpy = mockExitThrow();
+
+    const { getSuppressionCommand } = await import(
+      '../../../src/commands/suppressions/get'
+    );
+    await expectExit1(() =>
+      getSuppressionCommand.parseAsync(['sup-1'], { from: 'user' }),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('fetch_error');
+  });
+});

--- a/tests/commands/suppressions/list.test.ts
+++ b/tests/commands/suppressions/list.test.ts
@@ -1,0 +1,173 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from 'vitest';
+import {
+  captureTestEnv,
+  expectExit1,
+  mockExitThrow,
+  mockSdkError,
+  setNonInteractive,
+  setupOutputSpies,
+} from '../../helpers';
+
+const mockList = vi.fn(async () => ({
+  data: {
+    object: 'list',
+    data: [
+      {
+        object: 'suppression',
+        id: 'sup-1',
+        email: 'spam@example.com',
+        origin: 'bounce',
+        source_id: 'evt-1',
+        created_at: '2026-01-01T00:00:00.000Z',
+      },
+      {
+        object: 'suppression',
+        id: 'sup-2',
+        email: 'complaint@example.com',
+        origin: 'manual',
+        source_id: null,
+        created_at: '2026-01-02T00:00:00.000Z',
+      },
+    ],
+    has_more: false,
+  },
+  error: null,
+}));
+
+vi.mock('resend', () => ({
+  Resend: class MockResend {
+    constructor(public key: string) {}
+    suppressions = { list: mockList };
+  },
+}));
+
+describe('suppressions list command', () => {
+  const restoreEnv = captureTestEnv();
+  let spies: ReturnType<typeof setupOutputSpies> | undefined;
+  let errorSpy: MockInstance | undefined;
+  let stderrSpy: MockInstance | undefined;
+  let exitSpy: MockInstance | undefined;
+
+  beforeEach(() => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    mockList.mockClear();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    errorSpy?.mockRestore();
+    stderrSpy?.mockRestore();
+    exitSpy?.mockRestore();
+    spies = undefined;
+    errorSpy = undefined;
+    stderrSpy = undefined;
+    exitSpy = undefined;
+  });
+
+  function getFirstCallArgs(): unknown {
+    const firstCall = mockList.mock.calls.at(0);
+    if (!firstCall) {
+      throw new Error('Expected mockList to be called at least once');
+    }
+    return firstCall[0];
+  }
+
+  it('uses default limit of 10 when not specified', async () => {
+    spies = setupOutputSpies();
+    const { listSuppressionsCommand } = await import(
+      '../../../src/commands/suppressions/list'
+    );
+    await listSuppressionsCommand.parseAsync([], { from: 'user' });
+
+    expect(mockList).toHaveBeenCalledTimes(1);
+    expect(getFirstCallArgs()).toMatchObject({ limit: 10 });
+  });
+
+  it('outputs JSON list when non-interactive', async () => {
+    spies = setupOutputSpies();
+    const { listSuppressionsCommand } = await import(
+      '../../../src/commands/suppressions/list'
+    );
+    await listSuppressionsCommand.parseAsync([], { from: 'user' });
+
+    const output = spies.logSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output);
+    expect(parsed.object).toBe('list');
+    expect(parsed.data).toHaveLength(2);
+    expect(parsed.data[0].email).toBe('spam@example.com');
+  });
+
+  it('passes origin filter to SDK', async () => {
+    spies = setupOutputSpies();
+    const { listSuppressionsCommand } = await import(
+      '../../../src/commands/suppressions/list'
+    );
+    await listSuppressionsCommand.parseAsync(['--origin', 'bounce'], {
+      from: 'user',
+    });
+
+    expect(getFirstCallArgs()).toMatchObject({ origin: 'bounce' });
+  });
+
+  it('rejects an invalid origin value', async () => {
+    setNonInteractive();
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    exitSpy = mockExitThrow();
+
+    const { listSuppressionsCommand } = await import(
+      '../../../src/commands/suppressions/list'
+    );
+    await expect(
+      listSuppressionsCommand.parseAsync(['--origin', 'nope'], {
+        from: 'user',
+      }),
+    ).rejects.toThrow();
+
+    expect(mockList).not.toHaveBeenCalled();
+  });
+
+  it('passes after cursor to SDK', async () => {
+    spies = setupOutputSpies();
+    const { listSuppressionsCommand } = await import(
+      '../../../src/commands/suppressions/list'
+    );
+    await listSuppressionsCommand.parseAsync(['--after', 'cur'], {
+      from: 'user',
+    });
+
+    expect(getFirstCallArgs()).toMatchObject({ after: 'cur' });
+  });
+
+  it('errors with list_error when SDK returns an error', async () => {
+    setNonInteractive();
+    mockList.mockResolvedValueOnce(
+      mockSdkError('Unauthorized', 'unauthorized'),
+    );
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    exitSpy = mockExitThrow();
+
+    const { listSuppressionsCommand } = await import(
+      '../../../src/commands/suppressions/list'
+    );
+    await expectExit1(() =>
+      listSuppressionsCommand.parseAsync([], { from: 'user' }),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('list_error');
+  });
+});

--- a/tests/commands/suppressions/list.test.ts
+++ b/tests/commands/suppressions/list.test.ts
@@ -149,6 +149,41 @@ describe('suppressions list command', () => {
     expect(getFirstCallArgs()).toMatchObject({ after: 'cur' });
   });
 
+  it('preserves --origin in the next-page hint', async () => {
+    mockList.mockResolvedValueOnce({
+      data: {
+        object: 'list',
+        data: [
+          {
+            object: 'suppression',
+            id: 'sup-1',
+            email: 'spam@example.com',
+            origin: 'bounce',
+            source_id: 'evt-1',
+            created_at: '2026-01-01T00:00:00.000Z',
+          },
+        ],
+        has_more: true,
+      },
+      error: null,
+    });
+    // Interactive mode: the pagination hint only prints when stdout is a TTY.
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, writable: true });
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, writable: true });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const { listSuppressionsCommand } = await import(
+      '../../../src/commands/suppressions/list'
+    );
+    await listSuppressionsCommand.parseAsync(['--origin', 'bounce'], {
+      from: 'user',
+    });
+
+    const output = logSpy.mock.calls.map((c) => c[0]).join('\n');
+    logSpy.mockRestore();
+    expect(output).toContain('--origin bounce');
+  });
+
   it('errors with list_error when SDK returns an error', async () => {
     setNonInteractive();
     mockList.mockResolvedValueOnce(

--- a/tests/commands/suppressions/list.test.ts
+++ b/tests/commands/suppressions/list.test.ts
@@ -168,8 +168,14 @@ describe('suppressions list command', () => {
       error: null,
     });
     // Interactive mode: the pagination hint only prints when stdout is a TTY.
-    Object.defineProperty(process.stdin, 'isTTY', { value: true, writable: true });
-    Object.defineProperty(process.stdout, 'isTTY', { value: true, writable: true });
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: true,
+      writable: true,
+    });
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: true,
+      writable: true,
+    });
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
     const { listSuppressionsCommand } = await import(

--- a/tests/commands/suppressions/list.test.ts
+++ b/tests/commands/suppressions/list.test.ts
@@ -167,7 +167,7 @@ describe('suppressions list command', () => {
       },
       error: null,
     });
-    // Interactive mode: the pagination hint only prints when stdout is a TTY.
+    // Interactive mode: the hint only prints when TTY and not a CI env.
     Object.defineProperty(process.stdin, 'isTTY', {
       value: true,
       writable: true,
@@ -176,6 +176,9 @@ describe('suppressions list command', () => {
       value: true,
       writable: true,
     });
+    delete process.env.CI;
+    delete process.env.GITHUB_ACTIONS;
+    delete process.env.TERM;
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
     const { listSuppressionsCommand } = await import(

--- a/tests/commands/suppressions/utils.test.ts
+++ b/tests/commands/suppressions/utils.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  renderSuppressionsTable,
+  suppressionPickerConfig,
+} from '../../../src/commands/suppressions/utils';
+
+describe('suppressionPickerConfig', () => {
+  it('forwards limit and after to resend.suppressions.list', async () => {
+    const mockList = vi.fn(async () => ({
+      data: { data: [{ id: 'sup-1' }], has_more: true },
+      error: null,
+    }));
+    const resend = { suppressions: { list: mockList } } as never;
+
+    await suppressionPickerConfig.fetchItems(resend, {
+      limit: 20,
+      after: 'cursor-abc',
+    });
+
+    expect(mockList).toHaveBeenCalledWith({ limit: 20, after: 'cursor-abc' });
+  });
+
+  it('omits after when not provided', async () => {
+    const mockList = vi.fn(async () => ({
+      data: { data: [{ id: 'sup-1' }], has_more: false },
+      error: null,
+    }));
+    const resend = { suppressions: { list: mockList } } as never;
+
+    await suppressionPickerConfig.fetchItems(resend, { limit: 20 });
+
+    expect(mockList).toHaveBeenCalledWith({ limit: 20 });
+  });
+
+  it('displays email as label and id as hint', () => {
+    const display = suppressionPickerConfig.display({
+      id: 'sup-123',
+      email: 'spam@example.com',
+      origin: 'manual',
+      source_id: null,
+      created_at: '2026-01-01T00:00:00.000Z',
+    });
+
+    expect(display).toEqual({ label: 'spam@example.com', hint: 'sup-123' });
+  });
+});
+
+describe('renderSuppressionsTable', () => {
+  it('renders a header row and the entries', () => {
+    const table = renderSuppressionsTable([
+      {
+        id: 'sup-1',
+        email: 'spam@example.com',
+        origin: 'bounce',
+        source_id: 'evt-1',
+        created_at: '2026-01-01T00:00:00.000Z',
+      },
+    ]);
+
+    expect(table).toContain('Email');
+    expect(table).toContain('Origin');
+    expect(table).toContain('spam@example.com');
+    expect(table).toContain('bounce');
+  });
+
+  it('shows an empty-state message when there are no entries', () => {
+    expect(renderSuppressionsTable([])).toContain('(no suppressions)');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new `resend suppressions` command group, the CLI's downstream slice of the public-API suppressions work. Suppressions are still pre-GA and gated per account, so the command ships **visible with a** `● beta` **marker** — the API enforces access, and non-enrolled users get a clear API error rather than a hidden feature.

Downstream of the Node SDK per the [Shipping Public API changes checklist](<https://app.notion.com/p/resend/Shipping-Public-API-changes-downstream-checklist-35ac40d6c4ef80c3b372e631ba7c652a>). Unblocked by the canary SDK, which already exposes `resend.suppressions` + `.batch`(`resend` bumped `6.17.1 → 6.18.0-canary.0`).

## What's included

Commands (mirroring the existing resource-command pattern — `runCreate/runList/runGet/runDelete`, picker configs, `buildHelpText`):

<!-- linear:table-colwidths:400,400 -->
| Command | Description |
| -- | -- |
| `suppressions list` (`ls`, default) | List suppressed addresses; `--origin bounce\|complaint\|manual` filter + pagination |
| `suppressions add <email>` | Suppress a single address (origin `manual`) |
| `suppressions get <id-or-email>` | Fetch one suppression by ID or email |
| `suppressions delete <id-or-email>` (`rm`) | Remove a suppression; `--yes` required non-interactive |
| `suppressions batch add --file` | Suppress up to 100 addresses from a JSON file |
| `suppressions batch remove --file [--ids]` (`rm`) | Remove up to 100 by email (or ID with `--ids`) |

* Registered in `src/cli.ts` (visible, `● beta` marker in the description).
* Skill updates: new `references/suppressions.md`, `SKILL.md` command table + references list + when-to-load, skill version `2.3.1 → 2.4.0`.

## Notes

* **Beta visibility:** intentional. The command appears in `--help` with a marker; usage is gated by the account flag on the API side.

https://github.com/user-attachments/assets/c5c75b43-0dec-457b-b50d-7829c071baf4

---

## Summary by cubic

Adds a new beta `resend suppressions` command group to manage the suppression list (list, add, get, delete, batch), visible in help with a beta badge and gated by the API for non-enrolled accounts. Aligns with [WORKSPA-2482](https://linear.app/resend/issue/WORKSPA-2482/add-new-routes-to-the-cli).

* **New Features**
  * Command group: `list` (`ls`, default) with `--origin` filter and pagination; `add <email>`; `get <id-or-email>`; `delete <id-or-email>` (`rm`, requires `--yes` non-interactive).
  * Batch ops: `batch add --file` and `batch remove --file [--ids]` (up to 100 entries; supports `--file -` for stdin).
  * Docs and UX: new `references/suppressions.md`, skill bumped to `2.4.0`, beta marker in `--help`, JSON output supported, tests covering all paths.
* **Dependencies**
  * Bumped `resend` to `6.18.0-canary.0` to use suppressions APIs; package version to `2.9.0` (lockfile updated).

Written for commit b6d394c924632bffb40cf47bfe89af6d6c54d472. Summary will update on new commits.

[![Review in cubic](https://uploads.linear.app/cb0ab4b6-77ee-42b8-a07e-7ddb22cfd0d1/eedab2c7-eb4b-4919-9664-fa08fceecefe/86ef8694-0fff-457d-91ea-9c08f7940773?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2NiMGFiNGI2LTc3ZWUtNDJiOC1hMDdlLTdkZGIyMmNmZDBkMS9lZWRhYjJjNy1lYjRiLTQ5MTktOTY2NC1mYTA4ZmNlZWNlZmUvODZlZjg2OTQtMGZmZi00NTdkLTkxZWEtOWMwOGY3OTQwNzczIiwiaWF0IjoxNzg0MTM1MjEyLCJleHAiOjE4MTU3MDU3NzJ9.OU4_fJzG-pw7pTDqDhP56rW6Pr11d9cP1_gAKEPzPhQ)](<https://cubic.dev/pr/resend/resend-cli/pull/347?utm_source=github>)