### PR TITLE
chore: bump to 2.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-cli",
-  "version": "2.8.1",
+  "version": "2.9.0",
   "description": "The official CLI for Resend",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumped `resend-cli` to 2.9.0 to publish the next minor release. New version will include the suppression commands
<sup>Written for commit c87d2394f7e5ba1a9a1f89625e38832eee558740. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-cli/pull/348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

