### PR TITLE
feat: support scheduling and tags in batch email sends

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "esbuild": "0.28.1",
     "esbuild-wasm": "0.28.0",
     "picocolors": "1.1.1",
-    "resend": "6.18.0-canary.0"
+    "resend": "6.18.0"
   },
   "pkg": {
     "scripts": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: 1.1.1
         version: 1.1.1
       resend:
-        specifier: 6.18.0-canary.0
-        version: 6.18.0-canary.0
+        specifier: 6.18.0
+        version: 6.18.0
     devDependencies:
       '@biomejs/biome':
         specifier: 2.4.11
@@ -1226,8 +1226,8 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
-  resend@6.18.0-canary.0:
-    resolution: {integrity: sha512-XDP/rAa5phbGlmb/Hy+uqVlKKwNPBSUXFdwQVVdCi46brbBim/E0JsBkvvZ6UJdz7YePNOw8PSu4fqK5hPH80Q==}
+  resend@6.18.0:
+    resolution: {integrity: sha512-EjxZ9AVzywJgOlUoIJe9ytBWVrfbUtJbjeoLnRSvpU1sv97Hh9DSwhw+k8kiujrG4Rg4bzTBsjlmwWWuoOxSug==}
     engines: {node: '>=20'}
     peerDependencies:
       '@react-email/render': '*'
@@ -2431,7 +2431,7 @@ snapshots:
 
   require-directory@2.1.1: {}
 
-  resend@6.18.0-canary.0:
+  resend@6.18.0:
     dependencies:
       postal-mime: 2.7.5
       standardwebhooks: 1.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,4 +2,4 @@ allowBuilds:
   esbuild: true
   '@biomejs/biome': true
 minimumReleaseAgeExclude:
-  - resend@6.17.1
+  - resend@6.18.0

--- a/skills/resend-cli/SKILL.md
+++ b/skills/resend-cli/SKILL.md
@@ -13,7 +13,7 @@ metadata:
   author: resend
   # Skill version is independent from the CLI/package.json version —
   # bump it on skill content changes, not CLI releases.
-  version: "2.4.0"
+  version: "2.5.0"
   homepage: https://resend.com/docs/cli-agents
   source: https://github.com/resend/resend-cli
   openclaw:
@@ -169,7 +169,7 @@ Read the matching reference file for detailed flags and output shapes.
 | 1 | **Forgetting `--yes` on delete commands** | All `delete`/`rm` subcommands require `--yes` in non-interactive mode — otherwise the CLI exits with an error |
 | 2 | **Not saving webhook `signing_secret`** | `webhooks create` shows the secret once only — it cannot be retrieved later. Capture it from command output immediately |
 | 3 | **Omitting `--quiet` in CI** | Without `-q`, spinners and status text still go to stderr (not stdout). Use `-q` for JSON on stdout with no spinner noise on stderr |
-| 4 | **Using `--scheduled-at` with batch** | Batch sending does not support `scheduled_at` — use single `emails send` instead |
+| 4 | **Passing `--scheduled-at` as a flag to batch** | There is no `--scheduled-at` flag on `emails batch` — set `scheduled_at` per-email in the JSON file instead |
 | 5 | **Expecting `domains list` to include DNS records** | List returns summaries only — use `domains get <id>` for the full `records[]` array |
 | 6 | **Sending a dashboard-created broadcast via CLI** | Only API-created broadcasts can be sent with `broadcasts send` — dashboard broadcasts must be sent from the dashboard |
 | 7 | **Passing `--events` to `webhooks update` expecting additive behavior** | `--events` replaces the entire subscription list — always pass the complete set |

--- a/skills/resend-cli/references/emails.md
+++ b/skills/resend-cli/references/emails.md
@@ -85,14 +85,16 @@ Send up to 100 emails in a single request.
 ```json
 [
   {"from":"a@domain.com","to":["b@example.com"],"subject":"Hi","text":"Body"},
-  {"from":"a@domain.com","to":["c@example.com"],"subject":"Hi","html":"<b>Body</b>"}
+  {"from":"a@domain.com","to":["c@example.com"],"subject":"Hi","html":"<b>Body</b>","scheduled_at":"in 1 hour","tags":[{"name":"campaign","value":"welcome"}]}
 ]
 ```
+
+Per-email `scheduled_at` (ISO 8601 or natural language) and `tags` are supported.
 
 **Output (success):** `[{"id":"..."},{"id":"..."}]`
 **Output (permissive with errors):** `{"data":[{"id":"..."}],"errors":[{"index":1,"message":"..."}]}`
 
-**Constraints:** Max 100 emails. Attachments and `scheduled_at` not supported per-email.
+**Constraints:** Max 100 emails. Attachments not supported per-email.
 
 ---
 

--- a/src/commands/emails/batch.ts
+++ b/src/commands/emails/batch.ts
@@ -34,7 +34,7 @@ export const batchCommand = new Command('batch')
     'after',
     buildHelpText({
       context:
-        'Non-interactive: --file\nLimit: 100 emails per request (API hard limit — warned if exceeded)\nUnsupported per-email fields: attachments, scheduled_at\n\nFile format (--file path):\n  [\n    {"from":"onboarding@resend.com","to":["delivered@resend.com"],"subject":"Hello","text":"Hi"},\n    {"from":"onboarding@resend.com","to":["delivered@resend.com"],"subject":"Hello","html":"<b>Hi</b>"}\n  ]',
+        'Non-interactive: --file\nLimit: 100 emails per request (API hard limit — warned if exceeded)\nUnsupported per-email fields: attachments\n\nFile format (--file path):\n  [\n    {"from":"onboarding@resend.com","to":["delivered@resend.com"],"subject":"Hello","text":"Hi"},\n    {"from":"onboarding@resend.com","to":["delivered@resend.com"],"subject":"Hello","html":"<b>Hi</b>","scheduled_at":"in 1 hour","tags":[{"name":"campaign","value":"welcome"}]}\n  ]',
       output: '  [{"id":"<email-id>"},{"id":"<email-id>"}]',
       errorCodes: [
         'auth_error',
@@ -109,6 +109,14 @@ export const batchCommand = new Command('batch')
       }
     }
 
+    // The SDK re-serializes each email and only reads camelCase field names —
+    // snake_case variants would be silently dropped.
+    const snakeCaseAliases: Record<string, string> = {
+      reply_to: 'replyTo',
+      scheduled_at: 'scheduledAt',
+      topic_id: 'topicId',
+    };
+
     for (let i = 0; i < emails.length; i++) {
       const email = emails[i];
       if (email === null || typeof email !== 'object' || Array.isArray(email)) {
@@ -130,14 +138,13 @@ export const batchCommand = new Command('batch')
           { json: globalOpts.json },
         );
       }
-      if ('scheduled_at' in email) {
-        outputError(
-          {
-            message: `Email at index ${i} contains "scheduled_at", which is not supported in batch sends.`,
-            code: 'batch_error',
-          },
-          { json: globalOpts.json },
-        );
+
+      const record = email as Record<string, unknown>;
+      for (const [snake, camel] of Object.entries(snakeCaseAliases)) {
+        if (snake in record) {
+          record[camel] ??= record[snake];
+          delete record[snake];
+        }
       }
     }
 

--- a/tests/commands/emails/batch.test.ts
+++ b/tests/commands/emails/batch.test.ts
@@ -233,22 +233,48 @@ describe('batch command', () => {
     expect(output).toContain('attachments');
   });
 
-  it('rejects entries with scheduled_at', async () => {
-    setNonInteractive();
-    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    exitSpy = mockExitThrow();
+  it('passes scheduling and tags through to the API', async () => {
+    spies = setupOutputSpies();
 
     const emails = [
-      { ...VALID_EMAILS[0], scheduled_at: '2026-01-01T00:00:00Z' },
+      {
+        ...VALID_EMAILS[0],
+        scheduledAt: '2026-01-01T00:00:00Z',
+        tags: [{ name: 'campaign', value: 'welcome' }],
+      },
     ];
     const file = await writeTmpJson(emails);
     const { batchCommand } = await import('../../../src/commands/emails/batch');
-    await expectExit1(() =>
-      batchCommand.parseAsync(['--file', file], { from: 'user' }),
-    );
+    await batchCommand.parseAsync(['--file', file], { from: 'user' });
 
-    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
-    expect(output).toContain('scheduled_at');
+    expect(mockBatchSend).toHaveBeenCalledTimes(1);
+    const sent = mockBatchSend.mock.calls[0][0] as Record<string, unknown>[];
+    expect(sent[0].scheduledAt).toBe('2026-01-01T00:00:00Z');
+    expect(sent[0].tags).toEqual([{ name: 'campaign', value: 'welcome' }]);
+  });
+
+  it('normalizes snake_case fields to the camelCase names the SDK serializes', async () => {
+    spies = setupOutputSpies();
+
+    const emails = [
+      {
+        ...VALID_EMAILS[0],
+        scheduled_at: '2026-01-01T00:00:00Z',
+        reply_to: 'reply@example.com',
+        topic_id: 'topic-1',
+      },
+    ];
+    const file = await writeTmpJson(emails);
+    const { batchCommand } = await import('../../../src/commands/emails/batch');
+    await batchCommand.parseAsync(['--file', file], { from: 'user' });
+
+    const sent = mockBatchSend.mock.calls[0][0] as Record<string, unknown>[];
+    expect(sent[0].scheduledAt).toBe('2026-01-01T00:00:00Z');
+    expect(sent[0].replyTo).toBe('reply@example.com');
+    expect(sent[0].topicId).toBe('topic-1');
+    expect(sent[0]).not.toHaveProperty('scheduled_at');
+    expect(sent[0]).not.toHaveProperty('reply_to');
+    expect(sent[0]).not.toHaveProperty('topic_id');
   });
 
   it('warns but continues when array length exceeds 100', async () => {


### PR DESCRIPTION
## Summary

The batch API now supports per-email `scheduled_at` and `tags` (see resend/resend-node#1022 for the SDK-side change). This PR unblocks them in the CLI:

- Remove the CLI-side validation that rejected `scheduled_at` in batch email JSON (attachments remain blocked, matching the API)
- Normalize snake_case fields (`reply_to`, `scheduled_at`, `topic_id`) to the camelCase names the Node SDK serializes — the SDK rebuilds each email via `parseEmailToApiOptions` and only reads camelCase, so snake_case values were silently dropped (a `scheduled_at` email would send immediately instead of being scheduled)
- Bump `resend` to 6.18.0 (adds `scheduledAt` to batch types; the suppressions API was already in the canary we built against)
- Update `--help` text and skill docs; file-format examples now show `scheduled_at` and `tags`; skill version bumped to 2.5.0

## Testing

- Unit tests: passthrough test for `scheduledAt`/`tags`, normalization test asserting snake_case keys are mapped and don't leak through (1047 passing)
- Verified live against the API: a batch with one `scheduled_at` (snake_case) and one `scheduledAt` (camelCase) email, both with tags — both came back `last_event: scheduled` with correct timestamp and tags; test emails canceled afterwards

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable per-email scheduling and tags in `emails batch`, and map snake_case fields to camelCase so the Node SDK sends them correctly. Help text and docs updated; `resend` upgraded to 6.18.0.

- **New Features**
  - Allow per-email `scheduled_at` (ISO 8601 or natural language) and `tags` in batch; remove CLI rejection.
  - Normalize `reply_to`, `scheduled_at`, `topic_id` to `replyTo`, `scheduledAt`, `topicId`; attachments remain blocked per email.
  - Update `emails batch --help`, examples, and skill docs; bump skill to 2.5.0.

- **Dependencies**
  - Upgrade `resend` to `6.18.0`.

<sup>Written for commit 4ad5fd6cb9fe011a458c1bdc162aadd8c2dae16f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-cli/pull/349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

