### PR TITLE
fix: use resend.dev addresses in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,7 +627,7 @@ steps:
   - run: |
       resend emails send \
         --from "deploy@example.com" \
-        --to "delivered@resend.com" \
+        --to "delivered@resend.dev" \
         --subject "Deploy complete" \
         --text "Version ${{ github.sha }} deployed."
 ```

--- a/src/commands/broadcasts/create.ts
+++ b/src/commands/broadcasts/create.ts
@@ -86,9 +86,9 @@ Scheduling:
         'create_error',
       ],
       examples: [
-        'resend broadcasts create --from onboarding@resend.com --subject "Weekly Update" --segment-id 7b1e0a3d-4c5f-4e8a-9b2d-1a3c5e7f9b2d --html "<p>Hello {{{FIRST_NAME|there}}}</p>"',
-        'resend broadcasts create --from onboarding@resend.com --subject "Launch" --segment-id 7b1e0a3d-4c5f-4e8a-9b2d-1a3c5e7f9b2d --html-file ./email.html --send',
-        'resend broadcasts create --from onboarding@resend.com --subject "Launch" --segment-id 7b1e0a3d-4c5f-4e8a-9b2d-1a3c5e7f9b2d --text "Hello!" --send --scheduled-at "tomorrow at 9am ET"',
+        'resend broadcasts create --from onboarding@resend.dev --subject "Weekly Update" --segment-id 7b1e0a3d-4c5f-4e8a-9b2d-1a3c5e7f9b2d --html "<p>Hello {{{FIRST_NAME|there}}}</p>"',
+        'resend broadcasts create --from onboarding@resend.dev --subject "Launch" --segment-id 7b1e0a3d-4c5f-4e8a-9b2d-1a3c5e7f9b2d --html-file ./email.html --send',
+        'resend broadcasts create --from onboarding@resend.dev --subject "Launch" --segment-id 7b1e0a3d-4c5f-4e8a-9b2d-1a3c5e7f9b2d --text "Hello!" --send --scheduled-at "tomorrow at 9am ET"',
       ],
     }),
   )
@@ -157,7 +157,7 @@ Scheduling:
       }
       const result = await p.text({
         message: 'From address',
-        placeholder: 'e.g. onboarding@resend.com',
+        placeholder: 'e.g. onboarding@resend.dev',
         validate: (v) => (!v ? 'Required' : undefined),
       });
       if (p.isCancel(result)) {

--- a/src/commands/broadcasts/index.ts
+++ b/src/commands/broadcasts/index.ts
@@ -27,7 +27,7 @@ Scheduling:
   --scheduled-at accepts ISO 8601 or natural language e.g. "in 1 hour", "tomorrow at 9am ET".`,
       examples: [
         'resend broadcasts list',
-        'resend broadcasts create --from onboarding@resend.com --subject "Launch" --segment-id 7b1e0a3d-4c5f-4e8a-9b2d-1a3c5e7f9b2d --html "<p>Hi {{{FIRST_NAME|there}}}</p>"',
+        'resend broadcasts create --from onboarding@resend.dev --subject "Launch" --segment-id 7b1e0a3d-4c5f-4e8a-9b2d-1a3c5e7f9b2d --html "<p>Hi {{{FIRST_NAME|there}}}</p>"',
         'resend broadcasts send d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6',
         'resend broadcasts send d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6 --scheduled-at "in 1 hour"',
         'resend broadcasts get d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6',

--- a/src/commands/broadcasts/update.ts
+++ b/src/commands/broadcasts/update.ts
@@ -56,7 +56,7 @@ Variable interpolation:
       examples: [
         'resend broadcasts update d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6 --subject "Updated Subject"',
         'resend broadcasts update d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6 --html-file ./new-email.html',
-        'resend broadcasts update d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6 --name "Q1 Newsletter" --from "onboarding@resend.com" --json',
+        'resend broadcasts update d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6 --name "Q1 Newsletter" --from "onboarding@resend.dev" --json',
         'echo "<p>New content</p>" | resend broadcasts update d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6 --html-file -',
       ],
     }),

--- a/src/commands/emails/batch.ts
+++ b/src/commands/emails/batch.ts
@@ -34,7 +34,7 @@ export const batchCommand = new Command('batch')
     'after',
     buildHelpText({
       context:
-        'Non-interactive: --file\nLimit: 100 emails per request (API hard limit — warned if exceeded)\nUnsupported per-email fields: attachments\n\nFile format (--file path):\n  [\n    {"from":"onboarding@resend.com","to":["delivered@resend.com"],"subject":"Hello","text":"Hi"},\n    {"from":"onboarding@resend.com","to":["delivered@resend.com"],"subject":"Hello","html":"<b>Hi</b>","scheduled_at":"in 1 hour","tags":[{"name":"campaign","value":"welcome"}]}\n  ]',
+        'Non-interactive: --file\nLimit: 100 emails per request (API hard limit — warned if exceeded)\nUnsupported per-email fields: attachments\n\nFile format (--file path):\n  [\n    {"from":"onboarding@resend.dev","to":["delivered@resend.dev"],"subject":"Hello","text":"Hi"},\n    {"from":"onboarding@resend.dev","to":["delivered@resend.dev"],"subject":"Hello","html":"<b>Hi</b>","scheduled_at":"in 1 hour","tags":[{"name":"campaign","value":"welcome"}]}\n  ]',
       output: '  [{"id":"<email-id>"},{"id":"<email-id>"}]',
       errorCodes: [
         'auth_error',
@@ -50,7 +50,7 @@ export const batchCommand = new Command('batch')
       examples: [
         'resend emails batch --file ./emails.json',
         'resend emails batch --file ./emails.json --batch-validation permissive',
-        'echo \'[{"from":"onboarding@resend.com","to":["delivered@resend.com"],"subject":"Hi","text":"Hello"}]\' | resend emails batch --file -',
+        'echo \'[{"from":"onboarding@resend.dev","to":["delivered@resend.dev"],"subject":"Hi","text":"Hello"}]\' | resend emails batch --file -',
       ],
     }),
   )

--- a/src/commands/emails/get.ts
+++ b/src/commands/emails/get.ts
@@ -12,7 +12,7 @@ export const getEmailCommand = new Command('get')
     'after',
     buildHelpText({
       output:
-        '  {"object":"email","id":"<uuid>","message_id":"<111-222-333@email.example.com>","from":"onboarding@resend.com","to":["delivered@resend.com"],"subject":"Hello","html":"<p>Hi</p>","text":"Hi","last_event":"delivered","created_at":"<iso-date>","scheduled_at":null,"bcc":null,"cc":null,"reply_to":null}',
+        '  {"object":"email","id":"<uuid>","message_id":"<111-222-333@email.example.com>","from":"onboarding@resend.dev","to":["delivered@resend.dev"],"subject":"Hello","html":"<p>Hi</p>","text":"Hi","last_event":"delivered","created_at":"<iso-date>","scheduled_at":null,"bcc":null,"cc":null,"reply_to":null}',
       errorCodes: ['auth_error', 'fetch_error'],
       examples: [
         'resend emails get <email-id>',

--- a/src/commands/emails/index.ts
+++ b/src/commands/emails/index.ts
@@ -16,14 +16,14 @@ export const emailsCommand = new Command('emails')
     'after',
     buildHelpText({
       examples: [
-        'resend emails send --from onboarding@resend.com --to delivered@resend.com --subject "Hello" --text "Hi"',
+        'resend emails send --from onboarding@resend.dev --to delivered@resend.dev --subject "Hello" --text "Hi"',
         'resend emails get <email-id>',
         'resend emails batch --file ./emails.json',
         'resend emails cancel <email-id>',
         'resend emails attachments <email-id>',
         'resend emails attachment <email-id> <attachment-id>',
         'resend emails receiving list',
-        'resend emails receiving forward <email-id> --to delivered@resend.com --from onboarding@resend.com',
+        'resend emails receiving forward <email-id> --to delivered@resend.dev --from onboarding@resend.dev',
       ],
     }),
   )

--- a/src/commands/emails/receiving/forward.ts
+++ b/src/commands/emails/receiving/forward.ts
@@ -18,8 +18,8 @@ export const forwardCommand = new Command('forward')
       output: '  {"id":"<email-id>"}',
       errorCodes: ['auth_error', 'create_error'],
       examples: [
-        'resend emails receiving forward <email-id> --to delivered@resend.com --from onboarding@resend.com',
-        'resend emails receiving forward <email-id> --to delivered@resend.com --from onboarding@resend.com --json',
+        'resend emails receiving forward <email-id> --to delivered@resend.dev --from onboarding@resend.dev',
+        'resend emails receiving forward <email-id> --to delivered@resend.dev --from onboarding@resend.dev --json',
       ],
     }),
   )

--- a/src/commands/emails/receiving/index.ts
+++ b/src/commands/emails/receiving/index.ts
@@ -22,7 +22,7 @@ export const receivingCommand = new Command('receiving')
         'resend emails receiving get <email-id>',
         'resend emails receiving attachments <email-id>',
         'resend emails receiving attachment <email-id> <attachment-id>',
-        'resend emails receiving forward <email-id> --to delivered@resend.com --from onboarding@resend.com',
+        'resend emails receiving forward <email-id> --to delivered@resend.dev --from onboarding@resend.dev',
       ],
     }),
   )

--- a/src/commands/emails/send.ts
+++ b/src/commands/emails/send.ts
@@ -105,10 +105,10 @@ export const sendCommand = new Command('send')
         'send_error',
       ],
       examples: [
-        'resend emails send --from onboarding@resend.com --to delivered@resend.com --subject "Hello" --text "Hi"',
-        'resend emails send --from onboarding@resend.com --to delivered@resend.com --subject "Hello" --html "<b>Hi</b>"',
-        'resend emails send --from onboarding@resend.com --to delivered@resend.com --subject "Hello" --text "Hi" --attachment ./report.pdf',
-        'resend emails send --template tmpl_123 --to delivered@resend.com',
+        'resend emails send --from onboarding@resend.dev --to delivered@resend.dev --subject "Hello" --text "Hi"',
+        'resend emails send --from onboarding@resend.dev --to delivered@resend.dev --subject "Hello" --html "<b>Hi</b>"',
+        'resend emails send --from onboarding@resend.dev --to delivered@resend.dev --subject "Hello" --text "Hi" --attachment ./report.pdf',
+        'resend emails send --template tmpl_123 --to delivered@resend.dev',
       ],
     }),
   )


### PR DESCRIPTION
## Summary

Example addresses in CLI help text and the README used `@resend.com`, which doesn't work against the real API:

- `delivered@resend.com` as a recipient is rejected with a 422 validation error ("Invalid to field. Please use our testing email address") — the testing recipient is `delivered@resend.dev`.
- `onboarding@resend.com` as a sender isn't a domain users can send from — the shared example sender is `onboarding@resend.dev`.

This replaces both with their `resend.dev` equivalents everywhere they appear in examples: command `examples` arrays, help/details text, sample JSON payloads, the interactive `--from` placeholder in `broadcasts create`, and the README (32 replacements across 10 files).

## Testing

- `pnpm lint` passes (2 pre-existing warnings in untouched files)
- `pnpm test`: 1046 passed, 1 skipped

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced all example email addresses from @resend.com to @resend.dev across CLI help, examples, and the README to match the real API and avoid 422 validation errors.

- **Bug Fixes**
  - Switched to `delivered@resend.dev` and `onboarding@resend.dev` in broadcasts and emails commands (send, batch, get, receiving forward), including the interactive `--from` placeholder.
  - Updated README and sample payloads (32 replacements across 10 files).

<sup>Written for commit 15cd4e17eddb821d52351dd357bac5bb1cd55159. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-cli/pull/350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

