### PR TITLE
feat(webhooks): add suppression webhooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "esbuild": "0.28.1",
     "esbuild-wasm": "0.28.0",
     "picocolors": "1.1.1",
-    "resend": "6.18.0"
+    "resend": "6.18.1"
   },
   "pkg": {
     "scripts": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: 1.1.1
         version: 1.1.1
       resend:
-        specifier: 6.18.0
-        version: 6.18.0
+        specifier: 6.18.1
+        version: 6.18.1
     devDependencies:
       '@biomejs/biome':
         specifier: 2.4.11
@@ -1226,8 +1226,8 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
-  resend@6.18.0:
-    resolution: {integrity: sha512-EjxZ9AVzywJgOlUoIJe9ytBWVrfbUtJbjeoLnRSvpU1sv97Hh9DSwhw+k8kiujrG4Rg4bzTBsjlmwWWuoOxSug==}
+  resend@6.18.1:
+    resolution: {integrity: sha512-XN8XIaDdKF+ziSQ3K23ndUcyhP7U3ze2gky6SPgYkuAOq54mH4Wdhwm7QylEQ3zlz0NzdX7/l1AgmJUZbdPI/Q==}
     engines: {node: '>=20'}
     peerDependencies:
       '@react-email/render': '*'
@@ -2431,7 +2431,7 @@ snapshots:
 
   require-directory@2.1.1: {}
 
-  resend@6.18.0:
+  resend@6.18.1:
     dependencies:
       postal-mime: 2.7.5
       standardwebhooks: 1.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,4 +2,4 @@ allowBuilds:
   esbuild: true
   '@biomejs/biome': true
 minimumReleaseAgeExclude:
-  - resend@6.18.0
+  - resend

--- a/src/commands/webhooks/create.ts
+++ b/src/commands/webhooks/create.ts
@@ -34,12 +34,13 @@ Events fire per-recipient: a batch email to 3 recipients generates 3 email.sent 
   resend webhooks create --endpoint https://... --events email.sent,email.delivered
   resend webhooks create --endpoint https://... --events all
 
-Available event types (17 total):
-  Email:   email.sent, email.delivered, email.delivery_delayed, email.bounced,
-           email.complained, email.opened, email.clicked, email.failed,
-           email.scheduled, email.suppressed, email.received
-  Contact: contact.created, contact.updated, contact.deleted
-  Domain:  domain.created, domain.updated, domain.deleted
+Available event types (19 total):
+  Email:       email.sent, email.delivered, email.delivery_delayed, email.bounced,
+               email.complained, email.opened, email.clicked, email.failed,
+               email.scheduled, email.suppressed, email.received
+  Contact:     contact.created, contact.updated, contact.deleted
+  Domain:      domain.created, domain.updated, domain.deleted
+  Suppression: suppression.added, suppression.removed
 
 The signing_secret in the response is shown ONCE — save it immediately to verify
 webhook payloads using Svix signature headers (svix-id, svix-timestamp, svix-signature).

--- a/src/commands/webhooks/index.ts
+++ b/src/commands/webhooks/index.ts
@@ -15,12 +15,13 @@ export const webhooksCommand = new Command('webhooks')
       context: `Webhooks let you receive real-time event notifications from Resend at an HTTPS endpoint.
 Payloads are signed with Svix headers for verification.
 
-Event categories (17 total):
-  Email:   email.sent, email.delivered, email.delivery_delayed, email.bounced,
-           email.complained, email.opened, email.clicked, email.failed,
-           email.scheduled, email.suppressed, email.received
-  Contact: contact.created, contact.updated, contact.deleted
-  Domain:  domain.created, domain.updated, domain.deleted
+Event categories (19 total):
+  Email:       email.sent, email.delivered, email.delivery_delayed, email.bounced,
+               email.complained, email.opened, email.clicked, email.failed,
+               email.scheduled, email.suppressed, email.received
+  Contact:     contact.created, contact.updated, contact.deleted
+  Domain:      domain.created, domain.updated, domain.deleted
+  Suppression: suppression.added, suppression.removed
 
 Signature verification (Svix):
   Each delivery includes headers: svix-id, svix-timestamp, svix-signature

--- a/src/commands/webhooks/listen.ts
+++ b/src/commands/webhooks/listen.ts
@@ -47,7 +47,7 @@ function summarizeEvent(body: Record<string, unknown>): {
     }
   } else if (type.startsWith('domain.')) {
     detail = safeTerminalText((data.name as string) ?? '');
-  } else if (type.startsWith('contact.')) {
+  } else if (type.startsWith('contact.') || type.startsWith('suppression.')) {
     detail = safeTerminalText((data.email as string) ?? '');
   }
 

--- a/src/commands/webhooks/utils.ts
+++ b/src/commands/webhooks/utils.ts
@@ -20,6 +20,8 @@ export const ALL_WEBHOOK_EVENTS: WebhookEvent[] = [
   'domain.created',
   'domain.updated',
   'domain.deleted',
+  'suppression.added',
+  'suppression.removed',
 ];
 
 export function normalizeEvents(raw: string[]): string[] {

--- a/tests/commands/webhooks/create.test.ts
+++ b/tests/commands/webhooks/create.test.ts
@@ -83,7 +83,7 @@ describe('webhooks create command', () => {
     expect(args.events).toEqual(['email.sent', 'email.bounced']);
   });
 
-  it('expands "all" shorthand to all 17 events', async () => {
+  it('expands "all" shorthand to all 19 events', async () => {
     spies = setupOutputSpies();
 
     const { createWebhookCommand } = await import(
@@ -95,7 +95,7 @@ describe('webhooks create command', () => {
     );
 
     const args = mockCreate.mock.calls[0][0] as Record<string, unknown>;
-    expect(args.events).toHaveLength(17);
+    expect(args.events).toHaveLength(19);
     expect(args.events).toContain('email.sent');
     expect(args.events).toContain('contact.created');
     expect(args.events).toContain('domain.deleted');

--- a/tests/commands/webhooks/update.test.ts
+++ b/tests/commands/webhooks/update.test.ts
@@ -83,7 +83,7 @@ describe('webhooks update command', () => {
     expect(payload.events).toEqual(['email.sent', 'email.bounced']);
   });
 
-  it('expands "all" shorthand in --events to 17 events', async () => {
+  it('expands "all" shorthand in --events to 19 events', async () => {
     spies = setupOutputSpies();
 
     const { updateWebhookCommand } = await import(
@@ -94,7 +94,7 @@ describe('webhooks update command', () => {
     });
 
     const payload = mockUpdate.mock.calls[0][1] as Record<string, unknown>;
-    expect(payload.events).toHaveLength(17);
+    expect(payload.events).toHaveLength(19);
   });
 
   it('updates status with --status flag', async () => {


### PR DESCRIPTION
Includes `suppression.added` and `suppression.removed` webhooks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds suppression webhooks to the CLI: `suppression.added` and `suppression.removed`. The "all" shorthand now expands to 19 events, and help/listen outputs include the Suppression category.

- New Features
  - Added `suppression.added` and `suppression.removed` to `ALL_WEBHOOK_EVENTS`.
  - `webhooks create` and `webhooks` help list the Suppression category (19 total events).
  - `webhooks listen` shows the suppressed email in event details.
  - Tests updated to expect 19 events when using `--events all`.

- Dependencies
  - Bumped `resend` to `6.18.1`.
  - Workspace config now excludes `resend` from minimum release age.

<sup>Written for commit bb3f827cfabeea60f5e01f965c2730abccbb2900. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-cli/pull/353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

