### PR TITLE
chore: publish sha256 checksums with release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,6 +197,13 @@ jobs:
                     dist/resend-windows-x64.zip; do
             [ -s "$f" ] || { echo "Missing or empty: $f"; exit 1; }
           done
+      - name: Generate checksums
+        run: |
+          cd dist
+          sha256sum resend-darwin-arm64.tar.gz resend-darwin-x64.tar.gz \
+                    resend-linux-x64.tar.gz resend-linux-arm64.tar.gz \
+                    resend-windows-x64.zip > checksums.txt
+          cat checksums.txt
       - name: Detect pre-release
         id: meta
         run: |
@@ -241,6 +248,7 @@ jobs:
             dist/resend-linux-x64.tar.gz
             dist/resend-linux-arm64.tar.gz
             dist/resend-windows-x64.zip
+            dist/checksums.txt
   publish-npm:
     if: github.event_name != 'workflow_dispatch'
     needs: release


### PR DESCRIPTION
## Summary

An external security report flagged that the install scripts download and run the CLI binary without integrity verification.

This PR adds the first half of the fix. The release workflow now generates a `checksums.txt` file and attaches it as a release asset.

## Changes

- Add a "Generate checksums" step to the `release` job. It runs `sha256sum` over the five archives and writes `checksums.txt`. The step also prints the file, so the workflow log keeps an immutable record of the published hashes.
- Attach `dist/checksums.txt` to the GitHub Release.

## What this enables

- The install scripts can verify the archive before extraction (follow-up PR).
- Users and tooling can verify downloads manually.

## Notes

- Releases up to and including v2.10.0 have no `checksums.txt`. The installer follow-up must warn and skip when the file is absent, and fail hard on a mismatch.
- The file uses standard `sha256sum` format. The filenames match the release asset names.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes SHA-256 checksums with each release to enable archive integrity verification and address the installer security gap. The release workflow now generates `dist/checksums.txt` and uploads it alongside all five archives.

- New Features
  - Add "Generate checksums" step in the `release` job to create and log `checksums.txt` for all archives.
  - Upload `dist/checksums.txt` as a GitHub Release asset.

- Migration
  - Releases up to v2.10.0 don’t include `checksums.txt`; the installer follow-up will warn when absent and fail on mismatches.

<sup>Written for commit 915501e6779842f86422a158a1e9ba89fe2dfd73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-cli/pull/356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

