### PR TITLE
feat: verify sha256 checksums in install scripts

### DIFF
--- a/.github/workflows/test-install-unix.yml
+++ b/.github/workflows/test-install-unix.yml
@@ -20,7 +20,20 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Run install.sh from repo
-        run: bash install.sh
+        run: |
+          bash install.sh 2>&1 | tee install.log
+          grep -q "Checksum verified" install.log || {
+            echo "Expected checksum verification for the latest release"
+            exit 1
+          }
+      - name: Run install.sh pinned to a pre-checksum release (warn path)
+        run: |
+          RESEND_INSTALL="$HOME/.resend-pinned" bash install.sh 2.10.0 2>&1 | tee install-pinned.log
+          grep -q "no published checksums" install-pinned.log || {
+            echo "Expected a warning about missing checksums for v2.10.0"
+            exit 1
+          }
+          "$HOME/.resend-pinned/bin/resend" --version
       - name: Verify binary exists
         run: |
           exe="$HOME/.resend/bin/resend"

--- a/.github/workflows/test-install-unix.yml
+++ b/.github/workflows/test-install-unix.yml
@@ -34,6 +34,24 @@ jobs:
             exit 1
           }
           "$HOME/.resend-pinned/bin/resend" --version
+      - name: Run install.sh with a mismatched manifest (fail path)
+        run: |
+          sed 's|^checksums_url=.*|checksums_url="https://github.com/resend/resend-cli/releases/latest/download/checksums.txt"|' install.sh > install-mismatch.sh
+          status=0
+          RESEND_INSTALL="$HOME/.resend-mismatch" bash install-mismatch.sh 2.10.0 > install-mismatch.log 2>&1 || status=$?
+          cat install-mismatch.log
+          if [ "$status" -eq 0 ]; then
+            echo "Expected installer to fail on checksum mismatch"
+            exit 1
+          fi
+          grep -q "Checksum verification failed" install-mismatch.log || {
+            echo "Expected a checksum mismatch error"
+            exit 1
+          }
+          if [ -e "$HOME/.resend-mismatch/bin/resend" ]; then
+            echo "Binary must not be installed on mismatch"
+            exit 1
+          fi
       - name: Verify binary exists
         run: |
           exe="$HOME/.resend/bin/resend"

--- a/.github/workflows/test-install-unix.yml
+++ b/.github/workflows/test-install-unix.yml
@@ -36,7 +36,7 @@ jobs:
           "$HOME/.resend-pinned/bin/resend" --version
       - name: Run install.sh with a mismatched manifest (fail path)
         run: |
-          sed 's|^checksums_url=.*|checksums_url="https://github.com/resend/resend-cli/releases/latest/download/checksums.txt"|' install.sh > install-mismatch.sh
+          sed 's|^checksums_url=.*|checksums_url="https://github.com/resend/resend-cli/releases/download/v2.11.0/checksums.txt"|' install.sh > install-mismatch.sh
           status=0
           RESEND_INSTALL="$HOME/.resend-mismatch" bash install-mismatch.sh 2.10.0 > install-mismatch.log 2>&1 || status=$?
           cat install-mismatch.log

--- a/.github/workflows/test-install-windows.yml
+++ b/.github/workflows/test-install-windows.yml
@@ -39,6 +39,35 @@ jobs:
             exit 1
           }
           & "$env:USERPROFILE\.resend-pinned\bin\resend.exe" --version
+      - name: Run installer with a mismatched manifest (fail path)
+        run: |
+          $original = '($url.Substring(0, $url.LastIndexOf(''/''))) + ''/checksums.txt'''
+          $override = '''https://github.com/resend/resend-cli/releases/latest/download/checksums.txt'''
+          $script = (Get-Content -Raw .\install.ps1).Replace($original, $override)
+          if ($script -notlike '*releases/latest/download/checksums.txt*') {
+            Write-Error "Failed to inject the mismatched manifest URL -- did install.ps1 change?"
+            exit 1
+          }
+          $env:RESEND_VERSION = '2.10.0'
+          $env:RESEND_INSTALL = "$env:USERPROFILE\.resend-mismatch"
+          $failed = $false
+          try {
+            Invoke-Expression $script *>&1 | Tee-Object install-mismatch.log
+          } catch {
+            $failed = $true
+          }
+          if (-not $failed) {
+            Write-Error "Expected installer to fail on checksum mismatch"
+            exit 1
+          }
+          if (-not (Select-String -Path install-mismatch.log -Pattern 'Checksum verification failed' -Quiet)) {
+            Write-Error "Expected a checksum mismatch error"
+            exit 1
+          }
+          if (Test-Path "$env:USERPROFILE\.resend-mismatch\bin\resend.exe") {
+            Write-Error "Binary must not be installed on mismatch"
+            exit 1
+          }
       - name: Verify binary exists
         run: |
           $exe = "$env:USERPROFILE\.resend\bin\resend.exe"

--- a/.github/workflows/test-install-windows.yml
+++ b/.github/workflows/test-install-windows.yml
@@ -24,7 +24,21 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Run installer via Invoke-Expression (simulates irm | iex)
         run: |
-          Invoke-Expression (Get-Content -Raw .\install.ps1)
+          Invoke-Expression (Get-Content -Raw .\install.ps1) *>&1 | Tee-Object install.log
+          if (-not (Select-String -Path install.log -Pattern 'Checksum verified' -Quiet)) {
+            Write-Error "Expected checksum verification for the latest release"
+            exit 1
+          }
+      - name: Run installer pinned to a pre-checksum release (warn path)
+        run: |
+          $env:RESEND_VERSION = '2.10.0'
+          $env:RESEND_INSTALL = "$env:USERPROFILE\.resend-pinned"
+          Invoke-Expression (Get-Content -Raw .\install.ps1) *>&1 | Tee-Object install-pinned.log
+          if (-not (Select-String -Path install-pinned.log -Pattern 'no published checksums' -Quiet)) {
+            Write-Error "Expected a warning about missing checksums for v2.10.0"
+            exit 1
+          }
+          & "$env:USERPROFILE\.resend-pinned\bin\resend.exe" --version
       - name: Verify binary exists
         run: |
           $exe = "$env:USERPROFILE\.resend\bin\resend.exe"

--- a/.github/workflows/test-install-windows.yml
+++ b/.github/workflows/test-install-windows.yml
@@ -42,9 +42,9 @@ jobs:
       - name: Run installer with a mismatched manifest (fail path)
         run: |
           $original = '($url.Substring(0, $url.LastIndexOf(''/''))) + ''/checksums.txt'''
-          $override = '''https://github.com/resend/resend-cli/releases/latest/download/checksums.txt'''
+          $override = '''https://github.com/resend/resend-cli/releases/download/v2.11.0/checksums.txt'''
           $script = (Get-Content -Raw .\install.ps1).Replace($original, $override)
-          if ($script -notlike '*releases/latest/download/checksums.txt*') {
+          if ($script -notlike '*releases/download/v2.11.0/checksums.txt*') {
             Write-Error "Failed to inject the mismatched manifest URL -- did install.ps1 change?"
             exit 1
           }

--- a/install.ps1
+++ b/install.ps1
@@ -125,6 +125,7 @@ try {
       Write-Info "This release has no published checksums -- skipping verification"
       $checksumsAvailable = $false
     } else {
+      if (-not $status) { $status = '000' }
       Write-Fail "Failed to download checksums.txt (HTTP $status).`n`n  Refusing to install without verification -- try again.`n`n  URL: $checksumsUrl"
       throw "Installation failed."
     }

--- a/install.ps1
+++ b/install.ps1
@@ -85,6 +85,40 @@ try {
     throw "Installation failed."
   }
 
+  # --- Checksum verification ---------------------------------------------
+  # Releases up to v2.10.0 have no checksums.txt -- warn and continue so
+  # pinned old versions stay installable. A hash mismatch always fails.
+  $archiveName  = "resend-$target.zip"
+  $checksumsUrl = ($url.Substring(0, $url.LastIndexOf('/'))) + '/checksums.txt'
+  $tmpChecksums = Join-Path $tmpDir 'checksums.txt'
+  $expected     = $null
+
+  try {
+    Invoke-WebRequest -Uri $checksumsUrl -OutFile $tmpChecksums -UseBasicParsing
+  } catch {
+    Write-Info "This release has no published checksums -- skipping verification"
+  }
+
+  if (Test-Path $tmpChecksums) {
+    foreach ($line in Get-Content $tmpChecksums) {
+      $parts = $line.Trim() -split '\s+'
+      if ($parts.Length -eq 2 -and $parts[1] -eq $archiveName) {
+        $expected = $parts[0].ToLower()
+        break
+      }
+    }
+    if (-not $expected) {
+      Write-Fail "checksums.txt does not list $archiveName.`n`n  The release may be incomplete or tampered with.`n  Report it: https://github.com/resend/resend-cli/issues"
+      throw "Installation failed."
+    }
+    $actual = (Get-FileHash -Path $tmpZip -Algorithm SHA256).Hash.ToLower()
+    if ($actual -ne $expected) {
+      Write-Fail "Checksum verification failed for $archiveName.`n`n  Expected: $expected`n  Actual:   $actual`n`n  The download may be corrupted or tampered with -- try again.`n  If the problem persists, report it: https://github.com/resend/resend-cli/issues"
+      throw "Installation failed."
+    }
+    Write-Info "Checksum verified"
+  }
+
   try {
     Expand-Archive -Path $tmpZip -DestinationPath $binDir -Force
   } catch {

--- a/install.ps1
+++ b/install.ps1
@@ -46,10 +46,30 @@ if ($Version) {
     Write-Fail "Invalid version format: $Version`n`n  Expected: semantic version like 0.1.0 or 1.2.3-beta.1`n  Usage:    `$env:RESEND_VERSION = 'v0.1.0'; irm https://resend.com/install.ps1 | iex"
     throw "Installation failed."
   }
-  $url = "$repo/releases/download/v$Version/resend-$target.zip"
 } else {
-  $url = "$repo/releases/latest/download/resend-$target.zip"
+  # Resolve "latest" to a concrete tag so the archive and its checksums come
+  # from the same release even while a new one is being published.
+  try {
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    $latestResponse = Invoke-WebRequest -Uri "$repo/releases/latest" -Method Head -UseBasicParsing
+  } catch {
+    Write-Fail "Failed to resolve the latest release.`n`n  Possible causes:`n    - No internet connection`n    - GitHub is unreachable`n`n  URL: $repo/releases/latest"
+    throw "Installation failed."
+  }
+  $base = $latestResponse.BaseResponse
+  if ($base -is [System.Net.HttpWebResponse]) {
+    $finalUrl = $base.ResponseUri.AbsoluteUri          # Windows PowerShell 5.1
+  } else {
+    $finalUrl = $base.RequestMessage.RequestUri.AbsoluteUri  # PowerShell 7+
+  }
+  if ($finalUrl -notmatch '/releases/tag/v(.+)$') {
+    Write-Fail "Could not determine the latest version from: $finalUrl"
+    throw "Installation failed."
+  }
+  $Version = $Matches[1]
 }
+
+$url = "$repo/releases/download/v$Version/resend-$target.zip"
 
 # --- Install directory -------------------------------------------------------
 
@@ -80,26 +100,37 @@ try {
     $ProgressPreference = 'SilentlyContinue'  # Invoke-WebRequest is ~10x faster without progress bar
     Invoke-WebRequest -Uri $url -OutFile $tmpZip -UseBasicParsing
   } catch {
-    if ($Version) { $ver = $Version } else { $ver = 'latest' }
-    Write-Fail "Download failed.`n`n  Possible causes:`n    - No internet connection`n    - The version does not exist: $ver`n    - GitHub is unreachable`n`n  URL: $url"
+    Write-Fail "Download failed.`n`n  Possible causes:`n    - No internet connection`n    - The version does not exist: $Version`n    - GitHub is unreachable`n`n  URL: $url"
     throw "Installation failed."
   }
 
   # --- Checksum verification ---------------------------------------------
-  # Releases up to v2.10.0 have no checksums.txt -- warn and continue so
-  # pinned old versions stay installable. A hash mismatch always fails.
   $archiveName  = "resend-$target.zip"
   $checksumsUrl = ($url.Substring(0, $url.LastIndexOf('/'))) + '/checksums.txt'
   $tmpChecksums = Join-Path $tmpDir 'checksums.txt'
   $expected     = $null
+  $checksumsAvailable = $true
 
   try {
     Invoke-WebRequest -Uri $checksumsUrl -OutFile $tmpChecksums -UseBasicParsing
   } catch {
-    Write-Info "This release has no published checksums -- skipping verification"
+    # Releases up to v2.10.0 predate checksums.txt (404) -- warn and continue
+    # so pinned old versions stay installable. Any other failure refuses to
+    # install: a fetch error must not silently disable verification.
+    $status = $null
+    if ($_.Exception.PSObject.Properties['Response'] -and $_.Exception.Response) {
+      $status = [int]$_.Exception.Response.StatusCode
+    }
+    if ($status -eq 404) {
+      Write-Info "This release has no published checksums -- skipping verification"
+      $checksumsAvailable = $false
+    } else {
+      Write-Fail "Failed to download checksums.txt (HTTP $status).`n`n  Refusing to install without verification -- try again.`n`n  URL: $checksumsUrl"
+      throw "Installation failed."
+    }
   }
 
-  if (Test-Path $tmpChecksums) {
+  if ($checksumsAvailable) {
     foreach ($line in Get-Content $tmpChecksums) {
       $parts = $line.Trim() -split '\s+'
       if ($parts.Length -eq 2 -and $parts[1] -eq $archiveName) {

--- a/install.ps1
+++ b/install.ps1
@@ -139,12 +139,12 @@ try {
       }
     }
     if (-not $expected) {
-      Write-Fail "checksums.txt does not list $archiveName.`n`n  The release may be incomplete or tampered with.`n  Report it: https://github.com/resend/resend-cli/issues"
+      Write-Fail "checksums.txt does not list $archiveName.`n`n  The release may be incomplete or tampered with. Please, try again.`n  Report it: https://github.com/resend/resend-cli/issues"
       throw "Installation failed."
     }
     $actual = (Get-FileHash -Path $tmpZip -Algorithm SHA256).Hash.ToLower()
     if ($actual -ne $expected) {
-      Write-Fail "Checksum verification failed for $archiveName.`n`n  Expected: $expected`n  Actual:   $actual`n`n  The download may be corrupted or tampered with -- try again.`n  If the problem persists, report it: https://github.com/resend/resend-cli/issues"
+      Write-Fail "Checksum verification failed for $archiveName.`n`n  Expected: $expected`n  Actual:   $actual`n`n  If the problem persists, report it: https://github.com/resend/resend-cli/issues"
       throw "Installation failed."
     }
     Write-Info "Checksum verified"

--- a/install.sh
+++ b/install.sh
@@ -215,7 +215,7 @@ else
   if [[ -z $expected ]]; then
     error "checksums.txt does not list ${archive_name}.
 
-  The release may be incomplete or tampered with.
+  The release may be incomplete or tampered with. Please, try again.
   Report it: https://github.com/resend/resend-cli/issues"
   elif [[ -z $actual ]]; then
     warn "sha256sum/shasum not found — skipping checksum verification"
@@ -225,7 +225,6 @@ else
   Expected: ${expected}
   Actual:   ${actual}
 
-  The download may be corrupted or tampered with — try again.
   If the problem persists, report it: https://github.com/resend/resend-cli/issues"
   else
     info "  Checksum verified"

--- a/install.sh
+++ b/install.sh
@@ -130,10 +130,25 @@ if [[ -n $VERSION ]]; then
   Expected: semantic version like 0.1.0 or 1.2.3-beta.1
   Usage:    curl -fsSL https://resend.com/install.sh | bash -s v0.1.0"
   fi
-  url="${REPO}/releases/download/v${VERSION}/resend-${target}.tar.gz"
 else
-  url="${REPO}/releases/latest/download/resend-${target}.tar.gz"
+  # Resolve "latest" to a concrete tag so the archive and its checksums come
+  # from the same release even while a new one is being published.
+  release_url=$(curl --head --fail --location --silent --output /dev/null --write-out '%{url_effective}' "${REPO}/releases/latest") ||
+    error "Failed to resolve the latest release.
+
+  Possible causes:
+    - No internet connection
+    - GitHub is unreachable
+
+  URL: ${REPO}/releases/latest"
+
+  case "$release_url" in
+    */releases/tag/v*) VERSION="${release_url##*/tag/v}" ;;
+    *) error "Could not determine the latest version from: ${release_url}" ;;
+  esac
 fi
+
+url="${REPO}/releases/download/v${VERSION}/resend-${target}.tar.gz"
 
 # ─── Install directory ──────────────────────────────────────────────────────
 
@@ -162,15 +177,13 @@ curl --fail --location --progress-bar --output "$tmpfile" "$url" ||
 
   Possible causes:
     - No internet connection
-    - The version does not exist: ${VERSION:-latest}
+    - The version does not exist: ${VERSION}
     - GitHub is unreachable
 
   URL: ${url}"
 
 # ─── Checksum verification ──────────────────────────────────────────────────
 
-# Releases up to v2.10.0 have no checksums.txt — warn and continue so pinned
-# old versions stay installable. A hash mismatch always fails.
 archive_name="resend-${target}.tar.gz"
 checksums_url="${url%/*}/checksums.txt"
 checksums_file="${tmpdir}/checksums.txt"
@@ -183,8 +196,19 @@ sha256() {
   fi
 }
 
-if ! curl --fail --location --silent --output "$checksums_file" "$checksums_url"; then
+http_code=$(curl --location --silent --output "$checksums_file" --write-out '%{http_code}' "$checksums_url" || true)
+
+if [[ $http_code == "404" ]]; then
+  # Releases up to v2.10.0 predate checksums.txt — warn and continue so
+  # pinned old versions stay installable. Any other failure refuses to
+  # install: a fetch error must not silently disable verification.
   warn "this release has no published checksums — skipping verification"
+elif [[ $http_code != "200" ]]; then
+  error "Failed to download checksums.txt (HTTP ${http_code:-000}).
+
+  Refusing to install without verification — try again.
+
+  URL: ${checksums_url}"
 else
   expected=$(awk -v name="$archive_name" '$2 == name { print $1 }' "$checksums_file")
   actual=$(sha256 "$tmpfile")

--- a/install.sh
+++ b/install.sh
@@ -167,6 +167,47 @@ curl --fail --location --progress-bar --output "$tmpfile" "$url" ||
 
   URL: ${url}"
 
+# ─── Checksum verification ──────────────────────────────────────────────────
+
+# Releases up to v2.10.0 have no checksums.txt — warn and continue so pinned
+# old versions stay installable. A hash mismatch always fails.
+archive_name="resend-${target}.tar.gz"
+checksums_url="${url%/*}/checksums.txt"
+checksums_file="${tmpdir}/checksums.txt"
+
+sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+if ! curl --fail --location --silent --output "$checksums_file" "$checksums_url"; then
+  warn "this release has no published checksums — skipping verification"
+else
+  expected=$(awk -v name="$archive_name" '$2 == name { print $1 }' "$checksums_file")
+  actual=$(sha256 "$tmpfile")
+  if [[ -z $expected ]]; then
+    error "checksums.txt does not list ${archive_name}.
+
+  The release may be incomplete or tampered with.
+  Report it: https://github.com/resend/resend-cli/issues"
+  elif [[ -z $actual ]]; then
+    warn "sha256sum/shasum not found — skipping checksum verification"
+  elif [[ $actual != "$expected" ]]; then
+    error "Checksum verification failed for ${archive_name}.
+
+  Expected: ${expected}
+  Actual:   ${actual}
+
+  The download may be corrupted or tampered with — try again.
+  If the problem persists, report it: https://github.com/resend/resend-cli/issues"
+  else
+    info "  Checksum verified"
+  fi
+fi
+
 tar -xzf "$tmpfile" -C "$bin_dir" ||
   error "Failed to extract archive. The download may be corrupted — try again."
 


### PR DESCRIPTION
## Summary

Second half of the installer integrity fix (first half: #356, shipped in v2.11.0). Both install scripts now verify the downloaded archive against the release's `checksums.txt` before extraction.

## Behavior

- Download `checksums.txt` from the same release as the archive.
- Compare the archive's SHA-256 hash against the manifest entry.
- **Mismatch:** fail hard, before extraction. Nothing is installed.
- **Manifest present but missing the archive's entry:** fail hard.
- **Manifest absent** (all releases ≤ v2.10.0): warn and continue, so pinned old versions stay installable.
- **No hash tool on the system** (`sha256sum`/`shasum`): warn and continue.

Hashing uses `sha256sum` (Linux), `shasum -a 256` (macOS), and `Get-FileHash` (Windows). No new dependencies. The raw hex strings are compared directly, which avoids `sha256sum -c` temp-filename issues.

## Tests

CI now asserts both paths on all platforms:
- Latest release (v2.11.0+): output must contain "Checksum verified".
- Pinned v2.10.0: output must contain the missing-checksums warning, and the binary must still run.

Verified locally on macOS: verify path (v2.11.0), warn path (v2.10.0), and the mismatch path (v2.10.0 archive against the v2.11.0 manifest fails with exit 1 and installs nothing).

## Follow-up

The scripts served at resend.com are hand-maintained copies in the monorepo (`apps/dashboard/public/`). They need a separate PR there after this merges — users get the verification only once that copy updates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SHA-256 checksum verification to Unix and Windows installers and resolves "latest" to a concrete tag so archives and checksums always come from the same release. Installs fail on mismatches or missing entries; we only warn when `checksums.txt` is absent (≤ v2.10.0) or no hash tool is found.

- **New Features**
  - Verify archive SHA-256 against release `checksums.txt` before extraction; mismatch or missing entry fails.
  - Resolve "latest" to a specific version before download to bind archive and manifest to the same release.
  - Checksums fetch: warn only on 404; any other fetch error aborts install. Missing `sha256sum`/`shasum` warns and continues.
  - CI asserts verify (latest), warn (v2.10.0), and fail (mismatched manifest) paths on Linux, macOS, and Windows; mismatch test pinned to the v2.11.0 manifest for stability.

- **Refactors**
  - Improved error/warning messages; include HTTP 000 when the checksums fetch has no response.

<sup>Written for commit 1d76099609c2219087b2adf2be9db261df77c15e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-cli/pull/358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

