### PR TITLE
chore: bump to v2.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-cli",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "description": "The official CLI for Resend",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- Bumps the version for the release including #359 (`broadcasts cancel` command), following the same pattern as #357.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v2.12.0 of `resend-cli`, publishing the new broadcasts cancel command. Version bump only; no code changes.

<sup>Written for commit 4a95347d691473f9bf55fd1a1798d4c10b8f5211. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-cli/pull/360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

