### PR TITLE
fix: remove beta mention for supressions

### DIFF
--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -391,7 +391,7 @@ export const loginCommand = new Command('login')
       apiKey = result.trim();
     }
 
-    if (!apiKey || !apiKey.startsWith('re_')) {
+    if (!apiKey?.startsWith('re_')) {
       outputError(
         {
           message: 'Invalid API key format. Key must start with re_',

--- a/src/commands/suppressions/index.ts
+++ b/src/commands/suppressions/index.ts
@@ -1,5 +1,4 @@
 import { Command } from '@commander-js/extra-typings';
-import pc from 'picocolors';
 import { buildHelpText } from '../../lib/help-text';
 import { addSuppressionCommand } from './add';
 import { batchSuppressionsCommand } from './batch/index';

--- a/src/commands/suppressions/index.ts
+++ b/src/commands/suppressions/index.ts
@@ -9,15 +9,12 @@ import { listSuppressionsCommand } from './list';
 
 export const suppressionsCommand = new Command('suppressions')
   .description(
-    `${pc.cyan('● beta')} · Manage the suppression list — addresses that won't receive your emails (request access to enable)`,
+    "Manage the suppression list — addresses that won't receive your emails",
   )
   .addHelpText(
     'after',
     buildHelpText({
-      context: `Beta: this command requires the suppression list to be enabled on your account.
-Not enabled yet? Reach out to Resend to join the beta. Calls return an API error until then.
-
-Suppressions block future sends to an address. Entries have an origin:
+      context: `Suppressions block future sends to an address. Entries have an origin:
   bounce     added automatically after a hard bounce
   complaint  added automatically after a spam complaint
   manual     added by you via "suppressions add"

--- a/src/lib/domains.ts
+++ b/src/lib/domains.ts
@@ -55,7 +55,7 @@ export async function promptForFromAddress(domains: string[]): Promise<string> {
       message: 'From address',
       placeholder: `e.g. you@${domain}`,
       validate: (v) =>
-        !v || !v.includes('@') ? 'Enter a valid email address' : undefined,
+        !v?.includes('@') ? 'Enter a valid email address' : undefined,
     });
     if (p.isCancel(custom)) {
       cancelAndExit('Send cancelled.');


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed beta labeling and access-gated messaging from the `suppressions` CLI command to reflect GA availability. Help text now explains suppressions and their origins, and we simplified null checks in API key and from-address validation.

<sup>Written for commit efeae67a443d2f7a5c080ef4c24c97e5fbf6077c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-cli/pull/361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

