### PR TITLE
feat: fail closed when checksum verification cannot run

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -19,7 +19,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install via install.sh
-        run: curl -fsSL https://raw.githubusercontent.com/resend/resend-cli/${{ github.event.workflow_run.head_sha }}/install.sh | bash
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/resend/resend-cli/${{ github.event.workflow_run.head_sha }}/install.sh | bash 2>&1 | tee install.log
+          grep -q "Checksum verified" install.log || {
+            echo "The released archive was not verified against checksums.txt"
+            exit 1
+          }
       - name: Verify binary
         run: |
           "$HOME/.resend/bin/resend" --version
@@ -31,7 +36,12 @@ jobs:
     steps:
       - name: Install via install.ps1
         shell: pwsh
-        run: irm https://raw.githubusercontent.com/resend/resend-cli/${{ github.event.workflow_run.head_sha }}/install.ps1 | iex
+        run: |
+          irm https://raw.githubusercontent.com/resend/resend-cli/${{ github.event.workflow_run.head_sha }}/install.ps1 | iex *>&1 | Tee-Object install.log
+          if (-not (Select-String -Path install.log -Pattern 'Checksum verified' -Quiet)) {
+            Write-Error "The released archive was not verified against checksums.txt"
+            exit 1
+          }
       - name: Verify binary
         shell: pwsh
         run: |

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -20,8 +20,9 @@ jobs:
     steps:
       - name: Install via install.sh
         run: |
+          set -o pipefail
           curl -fsSL https://raw.githubusercontent.com/resend/resend-cli/${{ github.event.workflow_run.head_sha }}/install.sh | bash 2>&1 | tee install.log
-          grep -q "Checksum verified" install.log || {
+          grep -qF "Checksum verified" install.log || {
             echo "The released archive was not verified against checksums.txt"
             exit 1
           }

--- a/.github/workflows/test-install-unix.yml
+++ b/.github/workflows/test-install-unix.yml
@@ -29,11 +29,29 @@ jobs:
       - name: Run install.sh pinned to a pre-checksum release (warn path)
         run: |
           RESEND_INSTALL="$HOME/.resend-pinned" bash install.sh 2.10.0 2>&1 | tee install-pinned.log
-          grep -q "no published checksums" install-pinned.log || {
+          grep -q "predates published checksums" install-pinned.log || {
             echo "Expected a warning about missing checksums for v2.10.0"
             exit 1
           }
           "$HOME/.resend-pinned/bin/resend" --version
+      - name: Run install.sh with a missing manifest for a new release (fail path)
+        run: |
+          sed 's|^checksums_url=.*|checksums_url="https://github.com/resend/resend-cli/releases/download/v2.11.0/nonexistent.txt"|' install.sh > install-missing.sh
+          status=0
+          RESEND_INSTALL="$HOME/.resend-missing" bash install-missing.sh 2.11.0 > install-missing.log 2>&1 || status=$?
+          cat install-missing.log
+          if [ "$status" -eq 0 ]; then
+            echo "Expected installer to fail when checksums are missing for a post-v2.10.0 release"
+            exit 1
+          fi
+          grep -q "checksums.txt not found" install-missing.log || {
+            echo "Expected a missing-checksums error"
+            exit 1
+          }
+          if [ -e "$HOME/.resend-missing/bin/resend" ]; then
+            echo "Binary must not be installed when checksums are missing"
+            exit 1
+          fi
       - name: Run install.sh with a mismatched manifest (fail path)
         run: |
           sed 's|^checksums_url=.*|checksums_url="https://github.com/resend/resend-cli/releases/download/v2.11.0/checksums.txt"|' install.sh > install-mismatch.sh

--- a/.github/workflows/test-install-unix.yml
+++ b/.github/workflows/test-install-unix.yml
@@ -21,15 +21,17 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Run install.sh from repo
         run: |
+          set -o pipefail
           bash install.sh 2>&1 | tee install.log
-          grep -q "Checksum verified" install.log || {
+          grep -qF "Checksum verified" install.log || {
             echo "Expected checksum verification for the latest release"
             exit 1
           }
       - name: Run install.sh pinned to a pre-checksum release (warn path)
         run: |
+          set -o pipefail
           RESEND_INSTALL="$HOME/.resend-pinned" bash install.sh 2.10.0 2>&1 | tee install-pinned.log
-          grep -q "predates published checksums" install-pinned.log || {
+          grep -qF "predates published checksums" install-pinned.log || {
             echo "Expected a warning about missing checksums for v2.10.0"
             exit 1
           }
@@ -44,7 +46,7 @@ jobs:
             echo "Expected installer to fail when checksums are missing for a post-v2.10.0 release"
             exit 1
           fi
-          grep -q "checksums.txt not found" install-missing.log || {
+          grep -qF "checksums.txt not found" install-missing.log || {
             echo "Expected a missing-checksums error"
             exit 1
           }
@@ -62,7 +64,7 @@ jobs:
             echo "Expected installer to fail on checksum mismatch"
             exit 1
           fi
-          grep -q "Checksum verification failed" install-mismatch.log || {
+          grep -qF "Checksum verification failed" install-mismatch.log || {
             echo "Expected a checksum mismatch error"
             exit 1
           }

--- a/.github/workflows/test-install-windows.yml
+++ b/.github/workflows/test-install-windows.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Run installer via Invoke-Expression (simulates irm | iex)
         run: |
           Invoke-Expression (Get-Content -Raw .\install.ps1) *>&1 | Tee-Object install.log
-          if (-not (Select-String -Path install.log -Pattern 'Checksum verified' -Quiet)) {
+          if (-not (Select-String -Path install.log -Pattern 'Checksum verified' -SimpleMatch -Quiet)) {
             Write-Error "Expected checksum verification for the latest release"
             exit 1
           }
@@ -34,7 +34,7 @@ jobs:
           $env:RESEND_VERSION = '2.10.0'
           $env:RESEND_INSTALL = "$env:USERPROFILE\.resend-pinned"
           Invoke-Expression (Get-Content -Raw .\install.ps1) *>&1 | Tee-Object install-pinned.log
-          if (-not (Select-String -Path install-pinned.log -Pattern 'predates published checksums' -Quiet)) {
+          if (-not (Select-String -Path install-pinned.log -Pattern 'predates published checksums' -SimpleMatch -Quiet)) {
             Write-Error "Expected a warning about missing checksums for v2.10.0"
             exit 1
           }
@@ -60,7 +60,7 @@ jobs:
             Write-Error "Expected installer to fail when checksums are missing for a post-v2.10.0 release"
             exit 1
           }
-          if (-not (Select-String -Path install-missing.log -Pattern 'checksums.txt not found' -Quiet)) {
+          if (-not (Select-String -Path install-missing.log -Pattern 'checksums.txt not found' -SimpleMatch -Quiet)) {
             Write-Error "Expected a missing-checksums error"
             exit 1
           }
@@ -89,7 +89,7 @@ jobs:
             Write-Error "Expected installer to fail on checksum mismatch"
             exit 1
           }
-          if (-not (Select-String -Path install-mismatch.log -Pattern 'Checksum verification failed' -Quiet)) {
+          if (-not (Select-String -Path install-mismatch.log -Pattern 'Checksum verification failed' -SimpleMatch -Quiet)) {
             Write-Error "Expected a checksum mismatch error"
             exit 1
           }

--- a/.github/workflows/test-install-windows.yml
+++ b/.github/workflows/test-install-windows.yml
@@ -34,11 +34,40 @@ jobs:
           $env:RESEND_VERSION = '2.10.0'
           $env:RESEND_INSTALL = "$env:USERPROFILE\.resend-pinned"
           Invoke-Expression (Get-Content -Raw .\install.ps1) *>&1 | Tee-Object install-pinned.log
-          if (-not (Select-String -Path install-pinned.log -Pattern 'no published checksums' -Quiet)) {
+          if (-not (Select-String -Path install-pinned.log -Pattern 'predates published checksums' -Quiet)) {
             Write-Error "Expected a warning about missing checksums for v2.10.0"
             exit 1
           }
           & "$env:USERPROFILE\.resend-pinned\bin\resend.exe" --version
+      - name: Run installer with a missing manifest for a new release (fail path)
+        run: |
+          $original = '($url.Substring(0, $url.LastIndexOf(''/''))) + ''/checksums.txt'''
+          $override = '''https://github.com/resend/resend-cli/releases/download/v2.11.0/nonexistent.txt'''
+          $script = (Get-Content -Raw .\install.ps1).Replace($original, $override)
+          if ($script -notlike '*releases/download/v2.11.0/nonexistent.txt*') {
+            Write-Error "Failed to inject the missing manifest URL -- did install.ps1 change?"
+            exit 1
+          }
+          $env:RESEND_VERSION = '2.11.0'
+          $env:RESEND_INSTALL = "$env:USERPROFILE\.resend-missing"
+          $failed = $false
+          try {
+            Invoke-Expression $script *>&1 | Tee-Object install-missing.log
+          } catch {
+            $failed = $true
+          }
+          if (-not $failed) {
+            Write-Error "Expected installer to fail when checksums are missing for a post-v2.10.0 release"
+            exit 1
+          }
+          if (-not (Select-String -Path install-missing.log -Pattern 'checksums.txt not found' -Quiet)) {
+            Write-Error "Expected a missing-checksums error"
+            exit 1
+          }
+          if (Test-Path "$env:USERPROFILE\.resend-missing\bin\resend.exe") {
+            Write-Error "Binary must not be installed when checksums are missing"
+            exit 1
+          }
       - name: Run installer with a mismatched manifest (fail path)
         run: |
           $original = '($url.Substring(0, $url.LastIndexOf(''/''))) + ''/checksums.txt'''

--- a/install.ps1
+++ b/install.ps1
@@ -111,19 +111,23 @@ try {
   $expected     = $null
   $checksumsAvailable = $true
 
+  # Releases up to v2.10.0 predate checksums.txt.
+  $versionHasChecksums = [version](($Version -split '-')[0]) -gt [version]'2.10.0'
+
   try {
     Invoke-WebRequest -Uri $checksumsUrl -OutFile $tmpChecksums -UseBasicParsing
   } catch {
-    # Releases up to v2.10.0 predate checksums.txt (404) -- warn and continue
-    # so pinned old versions stay installable. Any other failure refuses to
-    # install: a fetch error must not silently disable verification.
     $status = $null
     if ($_.Exception.PSObject.Properties['Response'] -and $_.Exception.Response) {
       $status = [int]$_.Exception.Response.StatusCode
     }
-    if ($status -eq 404) {
-      Write-Info "This release has no published checksums -- skipping verification"
+    if ($status -eq 404 -and -not $versionHasChecksums) {
+      # Old versions stay installable, but only they may skip verification.
+      Write-Info "This release predates published checksums -- skipping verification"
       $checksumsAvailable = $false
+    } elseif ($status -eq 404) {
+      Write-Fail "checksums.txt not found for v$Version (HTTP 404).`n`n  Every release after v2.10.0 publishes checksums. The release may be incomplete or tampered with.`n  Report it: https://github.com/resend/resend-cli/issues"
+      throw "Installation failed."
     } else {
       if (-not $status) { $status = '000' }
       Write-Fail "Failed to download checksums.txt (HTTP $status).`n`n  Refusing to install without verification -- try again.`n`n  URL: $checksumsUrl"

--- a/install.sh
+++ b/install.sh
@@ -64,6 +64,8 @@ tildify() {
 
 command -v curl >/dev/null 2>&1 || error "curl is required but not found. Install it and try again."
 command -v tar  >/dev/null 2>&1 || error "tar is required but not found. Install it and try again."
+command -v sha256sum >/dev/null 2>&1 || command -v shasum >/dev/null 2>&1 ||
+  error "sha256sum or shasum is required to verify the download but neither was found. Install coreutils and try again."
 
 # ─── OS / Architecture detection ────────────────────────────────────────────
 
@@ -191,18 +193,33 @@ checksums_file="${tmpdir}/checksums.txt"
 sha256() {
   if command -v sha256sum >/dev/null 2>&1; then
     sha256sum "$1" | awk '{print $1}'
-  elif command -v shasum >/dev/null 2>&1; then
+  else
     shasum -a 256 "$1" | awk '{print $1}'
   fi
 }
 
+# Releases up to v2.10.0 predate checksums.txt.
+version_has_checksums() {
+  local base="${VERSION%%-*}" major minor patch
+  IFS=. read -r major minor patch <<< "$base"
+  if (( major > 2 )); then return 0; fi
+  if (( major < 2 )); then return 1; fi
+  if (( minor > 10 )); then return 0; fi
+  if (( minor < 10 )); then return 1; fi
+  (( patch > 0 ))
+}
+
 http_code=$(curl --location --silent --output "$checksums_file" --write-out '%{http_code}' "$checksums_url" || true)
 
-if [[ $http_code == "404" ]]; then
-  # Releases up to v2.10.0 predate checksums.txt — warn and continue so
-  # pinned old versions stay installable. Any other failure refuses to
-  # install: a fetch error must not silently disable verification.
-  warn "this release has no published checksums — skipping verification"
+if [[ $http_code == "404" ]] && ! version_has_checksums; then
+  # Old versions stay installable, but only they may skip verification.
+  warn "this release predates published checksums — skipping verification"
+elif [[ $http_code == "404" ]]; then
+  error "checksums.txt not found for v${VERSION} (HTTP 404).
+
+  Every release after v2.10.0 publishes checksums. The release may be
+  incomplete or tampered with.
+  Report it: https://github.com/resend/resend-cli/issues"
 elif [[ $http_code != "200" ]]; then
   error "Failed to download checksums.txt (HTTP ${http_code:-000}).
 
@@ -217,8 +234,6 @@ else
 
   The release may be incomplete or tampered with. Please, try again.
   Report it: https://github.com/resend/resend-cli/issues"
-  elif [[ -z $actual ]]; then
-    warn "sha256sum/shasum not found — skipping checksum verification"
   elif [[ $actual != "$expected" ]]; then
     error "Checksum verification failed for ${archive_name}.
 


### PR DESCRIPTION
## Summary

Tightens the checksum verification from #358. Both installers now fail closed in every case where verification cannot run, except the one legitimate legacy case.

Prompted by review findings on the resend.com sync PR: the previous behavior left two fail-open paths.

## Changes

- **Hash tooling is now a hard dependency** in `install.sh`, checked up front next to curl and tar. The warn-and-skip branch for missing tools is gone. Cost is near zero: `sha256sum` ships in coreutils (Essential on every glibc distro; Alpine/musl is already rejected) and macOS always has `shasum`.
- **The missing-manifest bypass is version-gated.** Only releases up to v2.10.0 — which predate `checksums.txt` — may skip verification, with a warning. A 404 for any newer version now fails the install. This turns "all future releases publish checksums" from a convention into an enforced invariant: a release that ships without a manifest breaks loudly instead of silently downgrading every install to unverified.
- **Post-release verification asserts "Checksum verified"** on Unix and Windows, so a checksum publication regression in the release pipeline is caught minutes after tagging, not months later.
- **New CI fail-path coverage** on all platforms: a post-v2.10.0 install with a 404 manifest must exit non-zero and install nothing.

## Testing

Local (macOS), all paths of `install.sh`:
- latest (v2.12.0): "Checksum verified", installs.
- pinned 2.10.0: legacy warning, installs.
- pinned 2.11.0 with a 404 manifest URL: exits 1, nothing installed.
- Version gate unit-tested at the edges: 2.9.9/2.10.0/1.x and 2.10.0-beta.1 warn; 2.10.1/2.11.0/3.0.0 and 2.11.0-rc.1 require checksums.

PowerShell paths ride on the installer CI (pwsh + PowerShell 5.1).

## Follow-up

Sync both scripts to the monorepo's `apps/dashboard/public/` (resend/resend-monorepo#8224).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened installer verification to fail closed whenever checksum verification can’t run. Only legacy versions <= v2.10.0 may skip checks; CI now enforces “Checksum verified” and is hardened to catch failures.

- **Bug Fixes**
  - Require `sha256sum` or `shasum` in `install.sh`; removed the warn-and-skip path for missing hash tools.
  - Allow missing-manifest bypass only for releases <= v2.10.0; a 404 for newer versions aborts install with no files written (Unix and Windows).
  - Print “Checksum verified” in both installers and enforce it in post-release CI; hardened CI with `pipefail` and fixed-string log matching; added fail-path tests on Unix and Windows.

<sup>Written for commit 3e48ceebf557be5ffa125cf212375409e76d1d2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-cli/pull/362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

