### PR TITLE
feat(automations): add duplicate command

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "esbuild": "0.28.1",
     "esbuild-wasm": "0.28.0",
     "picocolors": "1.1.1",
-    "resend": "6.19.0"
+    "resend": "6.21.0"
   },
   "pkg": {
     "scripts": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-cli",
-  "version": "2.13.0",
+  "version": "2.14.0",
   "description": "The official CLI for Resend",
   "license": "MIT",
   "repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: 1.1.1
         version: 1.1.1
       resend:
-        specifier: 6.19.0
-        version: 6.19.0
+        specifier: 6.21.0
+        version: 6.21.0
     devDependencies:
       '@biomejs/biome':
         specifier: 2.4.11
@@ -1226,8 +1226,8 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
-  resend@6.19.0:
-    resolution: {integrity: sha512-JnEdYnd9WyBDIzunsEZtUF8n3cBKM9SlmySaos/7wwi4sEXKG1Zz4M64VFAyk+278erX01Fq2wHQ3p7OIdPriA==}
+  resend@6.21.0:
+    resolution: {integrity: sha512-XT1eP2iA8rZ51NSO2CJlL1ZE2baBoPpOGMgz2p0o2uluz/YU3XfItpGymXDlL0Sp2Mc+y9+Xxsfdccfi4f2FzQ==}
     engines: {node: '>=20'}
     peerDependencies:
       '@react-email/render': '*'
@@ -2431,7 +2431,7 @@ snapshots:
 
   require-directory@2.1.1: {}
 
-  resend@6.19.0:
+  resend@6.21.0:
     dependencies:
       postal-mime: 2.7.5
       standardwebhooks: 1.0.0

--- a/skills/resend-cli/SKILL.md
+++ b/skills/resend-cli/SKILL.md
@@ -13,7 +13,7 @@ metadata:
   author: resend
   # Skill version is independent from the CLI/package.json version —
   # bump it on skill content changes, not CLI releases.
-  version: "2.7.0"
+  version: "2.8.0"
   homepage: https://resend.com/docs/cli-agents
   source: https://github.com/resend/resend-cli
   openclaw:

--- a/skills/resend-cli/SKILL.md
+++ b/skills/resend-cli/SKILL.md
@@ -148,7 +148,7 @@ Auth resolves: `--api-key` flag > `RESEND_API_KEY` env > config file (`resend lo
 | `careers` | list, apply — browse open positions at Resend and apply |
 | `suppressions` _(beta)_ | list, add, get, delete, batch — requires account enrollment |
 | `api-keys` | create, list, delete |
-| `automations` | create, get, list, update, delete, stop, open, runs |
+| `automations` | create, get, list, update, delete, duplicate, stop, open, runs |
 | `events` | create, get, list, update, delete, send, open |
 | `broadcasts` | create, send, update, delete, list |
 | `contacts` | create, update, delete, segments, topics, imports |

--- a/skills/resend-cli/references/automations.md
+++ b/skills/resend-cli/references/automations.md
@@ -54,6 +54,18 @@ resend automations update <id> --status enabled
 
 ---
 
+## automations duplicate
+
+```
+resend automations duplicate <id>
+```
+
+Creates a copy of an existing automation, including its steps and connections.
+
+Returns `{"object":"automation","id":"<new-automation-id>"}`.
+
+---
+
 ## automations stop
 
 ```

--- a/src/commands/automations/duplicate.ts
+++ b/src/commands/automations/duplicate.ts
@@ -1,0 +1,37 @@
+import { Command } from '@commander-js/extra-typings';
+import { runCreate } from '../../lib/actions';
+import type { GlobalOpts } from '../../lib/client';
+import { buildHelpText } from '../../lib/help-text';
+import { pickId } from '../../lib/prompts';
+import { automationPickerConfig } from './utils';
+
+export const duplicateAutomationCommand = new Command('duplicate')
+  .description('Duplicate an automation')
+  .argument('[id]', 'Automation ID to duplicate')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      context: `Creates a copy of an existing automation and returns the new automation ID.
+The steps and connections are copied from the original.`,
+      output: '  {"object":"automation","id":"<new-automation-id>"}',
+      errorCodes: ['auth_error', 'create_error'],
+      examples: [
+        'resend automations duplicate <id>',
+        'resend automations duplicate <id> --json',
+      ],
+    }),
+  )
+  .action(async (idArg, _opts, cmd) => {
+    const globalOpts = cmd.optsWithGlobals() as GlobalOpts;
+    const id = await pickId(idArg, automationPickerConfig, globalOpts);
+    await runCreate(
+      {
+        loading: 'Duplicating automation...',
+        sdkCall: (resend) => resend.automations.duplicate(id),
+        onInteractive: (d) => {
+          console.log(`Automation duplicated: ${d.id}`);
+        },
+      },
+      globalOpts,
+    );
+  });

--- a/src/commands/automations/index.ts
+++ b/src/commands/automations/index.ts
@@ -2,6 +2,7 @@ import { Command } from '@commander-js/extra-typings';
 import { buildHelpText } from '../../lib/help-text';
 import { createAutomationCommand } from './create';
 import { deleteAutomationCommand } from './delete';
+import { duplicateAutomationCommand } from './duplicate';
 import { getAutomationCommand } from './get';
 import { listAutomationsCommand } from './list';
 import { openAutomationCommand } from './open';
@@ -22,14 +23,16 @@ Connections define the flow between steps (default, condition_met, condition_not
 Lifecycle:
   1. resend automations create --name "Welcome" --file workflow.json
   2. resend automations update <id> --status enabled
-  3. resend automations stop <id>                        (stop automation)
-  4. resend automations runs <id>                        (inspect runs)
-  5. resend automations open <id>                        (view in dashboard)`,
+  3. resend automations duplicate <id>                   (copy an automation)
+  4. resend automations stop <id>                        (stop automation)
+  5. resend automations runs <id>                        (inspect runs)
+  6. resend automations open <id>                        (view in dashboard)`,
       examples: [
         'resend automations list',
         'resend automations create --name "Welcome Flow" --file workflow.json',
         'resend automations get <id>',
         'resend automations update <id> --status enabled',
+        'resend automations duplicate <id>',
         'resend automations stop <id>',
         'resend automations delete <id> --yes',
         'resend automations runs <automation-id>',
@@ -43,6 +46,7 @@ Lifecycle:
   .addCommand(listAutomationsCommand, { isDefault: true })
   .addCommand(updateAutomationCommand)
   .addCommand(deleteAutomationCommand)
+  .addCommand(duplicateAutomationCommand)
   .addCommand(stopAutomationCommand)
   .addCommand(openAutomationCommand)
   .addCommand(automationRunsCommand);


### PR DESCRIPTION
Adds `resend automations duplicate <id>` for the new `POST /automations/:id/duplicate` endpoint.

Modeled directly on `templates duplicate`: same `runCreate` action, same `pickId` interactive picker when the ID is omitted, same `create_error` code.

```
$ resend automations duplicate --help
Usage: resend automations duplicate [options] [id]

Duplicate an automation
```

Also updates the `automations` help lifecycle and examples, the `automations` row in `skills/resend-cli/SKILL.md`, and `references/automations.md`.

### The SDK bump

`resend` was pinned at 6.19.0, which does not have `automations.duplicate` — it shipped in 6.20.0. Bumped to 6.21.0, the current latest. Without this the command does not compile.

### Verification

- `pnpm typecheck` and `pnpm lint` clean
- `pnpm test` — 1091 passed, 1 skipped
- `resend automations duplicate` shows in `automations --help`

Docs side: resend/resend-docs#1757.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `resend automations duplicate [id]` to duplicate an automation from the CLI. Previously there was no duplicate flow; now the command copies steps and connections and returns the new automation ID.

- Mirrors `templates duplicate`: uses `runCreate`, prompts for ID via `pickId` when omitted, and surfaces `auth_error` and `create_error`.
- Registers the subcommand and lifecycle help; updates `skills/resend-cli/SKILL.md` (skill version `2.8.0`) and `references/automations.md` with usage and JSON output.
- Bumps `resend` to `6.21.0` and `resend-cli` to `2.14.0` so `automations.duplicate` compiles.
- Review focus: `src/commands/automations/duplicate.ts` and `src/commands/automations/index.ts`; verify help text, interactive log, and JSON output.

<sup>Written for commit f5c28bf3670d2d003d577666b644fc7972a5b307. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-cli/pull/364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

