### PR TITLE
feat(emails): add share command

### DIFF
--- a/src/commands/emails/index.ts
+++ b/src/commands/emails/index.ts
@@ -8,6 +8,7 @@ import { getEmailCommand } from './get';
 import { listEmailsCommand } from './list';
 import { receivingCommand } from './receiving/index';
 import { sendCommand } from './send';
+import { shareCommand } from './share';
 import { updateCommand } from './update';
 
 export const emailsCommand = new Command('emails')
@@ -20,6 +21,7 @@ export const emailsCommand = new Command('emails')
         'resend emails get <email-id>',
         'resend emails batch --file ./emails.json',
         'resend emails cancel <email-id>',
+        'resend emails share <email-id>',
         'resend emails attachments <email-id>',
         'resend emails attachment <email-id> <attachment-id>',
         'resend emails receiving list',
@@ -33,6 +35,7 @@ export const emailsCommand = new Command('emails')
   .addCommand(batchCommand)
   .addCommand(cancelCommand)
   .addCommand(updateCommand)
+  .addCommand(shareCommand)
   .addCommand(listAttachmentsCommand)
   .addCommand(getAttachmentCommand)
   .addCommand(receivingCommand);

--- a/src/commands/emails/share.ts
+++ b/src/commands/emails/share.ts
@@ -34,7 +34,9 @@ export const shareCommand = new Command('share')
         sdkCall: (resend) =>
           resend.emails.share(
             id,
-            opts.expiresIn ? { expiresIn: opts.expiresIn } : undefined,
+            opts.expiresIn !== undefined
+              ? { expiresIn: opts.expiresIn }
+              : undefined,
           ),
         onInteractive: (d) => {
           console.log(`  ${pc.gray('ID:')}   ${d.id}`);

--- a/src/commands/emails/share.ts
+++ b/src/commands/emails/share.ts
@@ -1,0 +1,46 @@
+import { Command } from '@commander-js/extra-typings';
+import pc from 'picocolors';
+import { runCreate } from '../../lib/actions';
+import type { GlobalOpts } from '../../lib/client';
+import { buildHelpText } from '../../lib/help-text';
+import { pickId } from '../../lib/prompts';
+import { emailPickerConfig } from './utils';
+
+export const shareCommand = new Command('share')
+  .description('Create a shareable link for a sent or received email')
+  .argument('[id]', 'Email ID')
+  .option(
+    '--expires-in <duration>',
+    'Link expiration, e.g. "10m", "2 hours", "1 day" (max 48h, default 48h)',
+  )
+  .addHelpText(
+    'after',
+    buildHelpText({
+      output: '  {"object":"email","id":"<email-id>","url":"<share-link-url>"}',
+      errorCodes: ['auth_error', 'create_error'],
+      examples: [
+        'resend emails share <email-id>',
+        'resend emails share <email-id> --expires-in "1 day"',
+        'resend emails share <email-id> --json',
+      ],
+    }),
+  )
+  .action(async (idArg, opts, cmd) => {
+    const globalOpts = cmd.optsWithGlobals() as GlobalOpts;
+    const id = await pickId(idArg, emailPickerConfig, globalOpts);
+    await runCreate(
+      {
+        loading: 'Creating share link...',
+        sdkCall: (resend) =>
+          resend.emails.share(
+            id,
+            opts.expiresIn ? { expiresIn: opts.expiresIn } : undefined,
+          ),
+        onInteractive: (d) => {
+          console.log(`  ${pc.gray('ID:')}   ${d.id}`);
+          console.log(`  ${pc.gray('URL:')}  ${d.url}`);
+        },
+      },
+      globalOpts,
+    );
+  });

--- a/tests/commands/emails/share.test.ts
+++ b/tests/commands/emails/share.test.ts
@@ -79,6 +79,17 @@ describe('emails share command', () => {
     });
   });
 
+  it('passes an empty --expires-in through to the SDK instead of dropping it', async () => {
+    spies = setupOutputSpies();
+
+    const { shareCommand } = await import('../../../src/commands/emails/share');
+    await shareCommand.parseAsync(['test-email-id', '--expires-in', ''], {
+      from: 'user',
+    });
+
+    expect(mockShare).toHaveBeenCalledWith('test-email-id', { expiresIn: '' });
+  });
+
   it('outputs JSON object in non-interactive mode', async () => {
     spies = setupOutputSpies();
 

--- a/tests/commands/emails/share.test.ts
+++ b/tests/commands/emails/share.test.ts
@@ -1,0 +1,133 @@
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from 'vitest';
+import {
+  captureTestEnv,
+  expectExit1,
+  mockExitThrow,
+  mockSdkError,
+  setNonInteractive,
+  setupOutputSpies,
+} from '../../helpers';
+
+const mockShare = vi.fn(async () => ({
+  data: {
+    object: 'email',
+    id: 'test-email-id',
+    url: 'https://resend.com/share/test-token',
+  },
+  error: null,
+}));
+
+vi.mock('resend', () => ({
+  Resend: class MockResend {
+    constructor(public key: string) {}
+    emails = { share: mockShare };
+  },
+}));
+
+describe('emails share command', () => {
+  const restoreEnv = captureTestEnv();
+  let spies: ReturnType<typeof setupOutputSpies> | undefined;
+  let errorSpy: MockInstance | undefined;
+  let stderrSpy: MockInstance | undefined;
+  let exitSpy: MockInstance | undefined;
+
+  beforeEach(() => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    mockShare.mockClear();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    errorSpy?.mockRestore();
+    stderrSpy?.mockRestore();
+    exitSpy?.mockRestore();
+    spies = undefined;
+    errorSpy = undefined;
+    stderrSpy = undefined;
+    exitSpy = undefined;
+  });
+
+  it('calls SDK share with correct id and no options', async () => {
+    spies = setupOutputSpies();
+
+    const { shareCommand } = await import('../../../src/commands/emails/share');
+    await shareCommand.parseAsync(['test-email-id'], { from: 'user' });
+
+    expect(mockShare).toHaveBeenCalledWith('test-email-id', undefined);
+  });
+
+  it('calls SDK share with expiresIn when --expires-in is passed', async () => {
+    spies = setupOutputSpies();
+
+    const { shareCommand } = await import('../../../src/commands/emails/share');
+    await shareCommand.parseAsync(['test-email-id', '--expires-in', '1 day'], {
+      from: 'user',
+    });
+
+    expect(mockShare).toHaveBeenCalledWith('test-email-id', {
+      expiresIn: '1 day',
+    });
+  });
+
+  it('outputs JSON object in non-interactive mode', async () => {
+    spies = setupOutputSpies();
+
+    const { shareCommand } = await import('../../../src/commands/emails/share');
+    await shareCommand.parseAsync(['test-email-id'], { from: 'user' });
+
+    const output = spies.logSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output);
+    expect(parsed.id).toBe('test-email-id');
+    expect(parsed.object).toBe('email');
+    expect(parsed.url).toBe('https://resend.com/share/test-token');
+  });
+
+  it('errors with auth_error when no API key', async () => {
+    setNonInteractive();
+    delete process.env.RESEND_API_KEY;
+    process.env.XDG_CONFIG_HOME = join(
+      tmpdir(),
+      `resend-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = mockExitThrow();
+
+    const { shareCommand } = await import('../../../src/commands/emails/share');
+    await expectExit1(() =>
+      shareCommand.parseAsync(['test-email-id'], { from: 'user' }),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('auth_error');
+  });
+
+  it('errors with create_error when SDK returns an error', async () => {
+    setNonInteractive();
+    mockShare.mockResolvedValueOnce(
+      mockSdkError('Email not found', 'not_found'),
+    );
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    exitSpy = mockExitThrow();
+
+    const { shareCommand } = await import('../../../src/commands/emails/share');
+    await expectExit1(() =>
+      shareCommand.parseAsync(['test-email-id'], { from: 'user' }),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('create_error');
+  });
+});


### PR DESCRIPTION
Adds `resend emails share <id> [--expires-in <duration>]`, calling the new `emails.share()` SDK method (published in `resend@6.21.0`) which hits `POST /emails/{id}/share` and creates a shareable link for a sent or received email.

Prints the returned URL directly in interactive mode (via `runCreate`), same as `api-keys create`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CLI subcommand to create a share link for an email, enabling time-limited external access. Previously there was no way to generate share links; now `resend emails share <email-id> [--expires-in <duration>]` creates one.

- Calls `resend.emails.share()` (requires `resend@6.21.0+`) to POST /emails/{id}/share.
- Accepts `--expires-in` (e.g., "10m", "2 hours", "1 day"); default and max are 48h. Preserves an explicitly empty value to surface API validation errors.
- Interactive mode prints ID and URL; non-interactive prints the JSON object.
- Surfaces `auth_error` when no API key and `create_error` when the SDK returns an error.
- Registered under `emails`, uses `runCreate`, and prompts for the ID when omitted.
- Tests cover flag mapping (including empty `--expires-in`), output modes, and error paths. No breaking changes.

<sup>Written for commit 67b50c1fbe6b8c5ffc12544641ac8502e15dbdca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-cli/pull/366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

