### PR TITLE
chore: bump to v2.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-cli",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "description": "The official CLI for Resend",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Bump version to 2.15.0. Minor release covering #365 (api-keys update) and #366 (emails share command).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release `resend-cli` v2.15.0 to ship the api-keys update and the emails share command. v2.14.0 did not include these features; v2.15.0 includes them with no breaking changes.

- Publish `resend-cli@2.15.0` to npm; this PR only bumps the version.
- After publish, smoke-test `resend api-keys update` and `resend emails share`.
- No migrations or config changes required.

<sup>Written for commit 39df1cc9441cb85a3edf346513da7c3c60fe0ce7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-cli/pull/367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

