### PR TITLE
feat(broadcasts): add recipients command

### DIFF
--- a/skills/resend-cli/references/broadcasts.md
+++ b/skills/resend-cli/references/broadcasts.md
@@ -43,6 +43,25 @@ Returns full object with html/text, from, subject, status (`draft`|`queued`|`sen
 
 ---
 
+## broadcasts recipients
+
+**Argument:** `[id]` — Broadcast ID
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--type <type>` | string | Yes | Event to filter by: `sent`, `delivered`, `opened`, `clicked`, `bounced`, `complained`, `unsubscribed`, `suppressed` |
+| `--email <email>` | string | No | Substring filter on recipient email |
+| `--bounce-type <type>` | string | No | Bounce classification: `permanent`, `transient`, `undetermined` — only meaningful when `--type bounced` |
+| `--limit <n>` | number | No | Max results (1-100, default 20) |
+| `--after <cursor>` | string | No | Forward pagination |
+| `--before <cursor>` | string | No | Backward pagination |
+
+Returns `id` (opaque pagination cursor), `contact_id` (nullable), `email`, and, depending on `--type`: `count` (`opened`/`clicked`), `bounce_type` (`bounced`), `clicked_links` (`clicked`).
+
+**Note:** Responses are cached for up to 15 minutes, so requesting the same page again may return slightly stale data within that window.
+
+---
+
 ## broadcasts send
 
 Send a draft broadcast.

--- a/skills/resend-cli/references/broadcasts.md
+++ b/skills/resend-cli/references/broadcasts.md
@@ -49,7 +49,7 @@ Returns full object with html/text, from, subject, status (`draft`|`queued`|`sen
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
-| `--type <type>` | string | Yes | Event to filter by: `sent`, `delivered`, `opened`, `clicked`, `bounced`, `complained`, `unsubscribed`, `suppressed` |
+| `--type <type>` | string | Yes (non-interactive) | Event to filter by: `sent`, `delivered`, `opened`, `clicked`, `bounced`, `complained`, `unsubscribed`, `suppressed` |
 | `--email <email>` | string | No | Substring filter on recipient email |
 | `--bounce-type <type>` | string | No | Bounce classification: `permanent`, `transient`, `undetermined` — only meaningful when `--type bounced` |
 | `--limit <n>` | number | No | Max results (1-100, default 20) |

--- a/src/commands/broadcasts/index.ts
+++ b/src/commands/broadcasts/index.ts
@@ -7,6 +7,7 @@ import { deleteBroadcastCommand } from './delete';
 import { getBroadcastCommand } from './get';
 import { listBroadcastsCommand } from './list';
 import { openBroadcastCommand } from './open';
+import { recipientsBroadcastCommand } from './recipients';
 import { sendBroadcastCommand } from './send';
 import { updateBroadcastCommand } from './update';
 
@@ -36,6 +37,7 @@ Scheduling:
         'resend broadcasts send d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6',
         'resend broadcasts send d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6 --scheduled-at "in 1 hour"',
         'resend broadcasts get d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6',
+        'resend broadcasts recipients d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6 --type opened',
         'resend broadcasts update d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6 --subject "Updated Subject"',
         'resend broadcasts cancel d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6',
         'resend broadcasts delete d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6 --yes',
@@ -50,6 +52,7 @@ Scheduling:
   .addCommand(sendBroadcastCommand)
   .addCommand(getBroadcastCommand)
   .addCommand(listBroadcastsCommand, { isDefault: true })
+  .addCommand(recipientsBroadcastCommand)
   .addCommand(updateBroadcastCommand)
   .addCommand(cancelBroadcastCommand)
   .addCommand(deleteBroadcastCommand)

--- a/src/commands/broadcasts/recipients.ts
+++ b/src/commands/broadcasts/recipients.ts
@@ -10,6 +10,10 @@ import {
 import { pickId, requireSelect } from '../../lib/prompts';
 import { broadcastPickerConfig, renderBroadcastRecipientsTable } from './utils';
 
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
 const EVENT_TYPES = [
   'sent',
   'delivered',
@@ -110,7 +114,7 @@ again may return slightly stale data within that window.
             profile: globalOpts.profile,
             extraFlags: [
               `--type ${type}`,
-              opts.email && `--email ${opts.email}`,
+              opts.email && `--email ${shellQuote(opts.email)}`,
               opts.bounceType && `--bounce-type ${opts.bounceType}`,
             ]
               .filter(Boolean)

--- a/src/commands/broadcasts/recipients.ts
+++ b/src/commands/broadcasts/recipients.ts
@@ -10,10 +10,6 @@ import {
 import { pickId, requireSelect } from '../../lib/prompts';
 import { broadcastPickerConfig, renderBroadcastRecipientsTable } from './utils';
 
-function shellQuote(value: string): string {
-  return `'${value.replace(/'/g, `'\\''`)}'`;
-}
-
 const EVENT_TYPES = [
   'sent',
   'delivered',
@@ -114,7 +110,7 @@ again may return slightly stale data within that window.
             profile: globalOpts.profile,
             extraFlags: [
               `--type ${type}`,
-              opts.email && `--email ${shellQuote(opts.email)}`,
+              opts.email && `--email ${opts.email}`,
               opts.bounceType && `--bounce-type ${opts.bounceType}`,
             ]
               .filter(Boolean)

--- a/src/commands/broadcasts/recipients.ts
+++ b/src/commands/broadcasts/recipients.ts
@@ -1,0 +1,123 @@
+import { Command, Option } from '@commander-js/extra-typings';
+import { runList } from '../../lib/actions';
+import type { GlobalOpts } from '../../lib/client';
+import { buildHelpText } from '../../lib/help-text';
+import {
+  buildPaginationOpts,
+  parseLimitOpt,
+  printPaginationHint,
+} from '../../lib/pagination';
+import { pickId, requireSelect } from '../../lib/prompts';
+import { broadcastPickerConfig, renderBroadcastRecipientsTable } from './utils';
+
+const EVENT_TYPES = [
+  'sent',
+  'delivered',
+  'opened',
+  'clicked',
+  'bounced',
+  'complained',
+  'unsubscribed',
+  'suppressed',
+] as const;
+
+export const recipientsBroadcastCommand = new Command('recipients')
+  .description("List a broadcast's recipients for a given event type")
+  .argument('[id]', 'Broadcast ID')
+  .addOption(
+    new Option('--type <type>', 'Event type to filter recipients by').choices(
+      EVENT_TYPES,
+    ),
+  )
+  .option(
+    '--email <email>',
+    'Filter recipients whose email contains this value',
+  )
+  .addOption(
+    new Option(
+      '--bounce-type <type>',
+      'Filter by bounce classification — only meaningful when --type is bounced',
+    ).choices(['permanent', 'transient', 'undetermined'] as const),
+  )
+  .option('--limit <n>', 'Maximum number of recipients to return (1-100)', '20')
+  .option(
+    '--after <cursor>',
+    'Cursor for forward pagination — list items after this ID',
+  )
+  .option(
+    '--before <cursor>',
+    'Cursor for backward pagination — list items before this ID',
+  )
+  .addHelpText(
+    'after',
+    buildHelpText({
+      context: `Non-interactive: --type is required.
+Note: responses are cached for up to 15 minutes, so requesting the same page
+again may return slightly stale data within that window.
+--bounce-type only has an effect when --type is bounced.`,
+      output: `  {"object":"list","has_more":false,"data":[{"id":"<cursor>","contact_id":"<id>|null","email":"...","count":3,"clicked_links":[{"url":"...","clicks":2}]}]}`,
+      errorCodes: [
+        'auth_error',
+        'missing_type',
+        'invalid_limit',
+        'invalid_pagination',
+        'list_error',
+      ],
+      examples: [
+        'resend broadcasts recipients d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6 --type opened',
+        'resend broadcasts recipients d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6 --type clicked --limit 50',
+        'resend broadcasts recipients d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6 --type bounced --bounce-type permanent',
+        'resend broadcasts recipients d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6 --type sent --email @example.com --json',
+      ],
+    }),
+  )
+  .action(async (idArg, opts, cmd) => {
+    const globalOpts = cmd.optsWithGlobals() as GlobalOpts;
+    const id = await pickId(idArg, broadcastPickerConfig, globalOpts);
+    const type = await requireSelect(
+      opts.type,
+      {
+        message: 'Event type',
+        options: EVENT_TYPES.map((t) => ({ value: t, label: t })),
+      },
+      { message: 'Missing --type flag.', code: 'missing_type' },
+      globalOpts,
+    );
+    const limit = parseLimitOpt(opts.limit, globalOpts);
+    const paginationOpts = buildPaginationOpts(
+      limit,
+      opts.after,
+      opts.before,
+      globalOpts,
+    );
+
+    await runList(
+      {
+        loading: 'Fetching recipients...',
+        sdkCall: (resend) =>
+          resend.broadcasts.recipients(id, {
+            type,
+            ...paginationOpts,
+            ...(opts.email && { email: opts.email }),
+            ...(opts.bounceType && { bounceType: opts.bounceType }),
+          }),
+        onInteractive: (list) => {
+          console.log(renderBroadcastRecipientsTable(list.data));
+          printPaginationHint(list, `broadcasts recipients ${id}`, {
+            limit,
+            before: opts.before,
+            apiKey: globalOpts.apiKey,
+            profile: globalOpts.profile,
+            extraFlags: [
+              `--type ${type}`,
+              opts.email && `--email ${opts.email}`,
+              opts.bounceType && `--bounce-type ${opts.bounceType}`,
+            ]
+              .filter(Boolean)
+              .join(' '),
+          });
+        },
+      },
+      globalOpts,
+    );
+  });

--- a/src/commands/broadcasts/utils.ts
+++ b/src/commands/broadcasts/utils.ts
@@ -91,7 +91,7 @@ export function renderBroadcastRecipientsTable(
   const rows = recipients.map((r) => [
     r.email,
     r.contact_id ?? '-',
-    r.count !== undefined ? String(r.count) : '-',
+    r.count !== undefined && r.count !== null ? String(r.count) : '-',
     r.bounce_type ?? '-',
     r.clicked_links && r.clicked_links.length > 0
       ? r.clicked_links.map((l) => `${l.url} (${l.clicks})`).join(', ')

--- a/src/commands/broadcasts/utils.ts
+++ b/src/commands/broadcasts/utils.ts
@@ -78,6 +78,33 @@ export function renderBroadcastsTable(
   );
 }
 
+export function renderBroadcastRecipientsTable(
+  recipients: Array<{
+    id: string;
+    contact_id: string | null;
+    email: string;
+    count?: number;
+    bounce_type?: string;
+    clicked_links?: Array<{ url: string; clicks: number }>;
+  }>,
+): string {
+  const rows = recipients.map((r) => [
+    r.email,
+    r.contact_id ?? '-',
+    r.count !== undefined ? String(r.count) : '-',
+    r.bounce_type ?? '-',
+    r.clicked_links && r.clicked_links.length > 0
+      ? r.clicked_links.map((l) => `${l.url} (${l.clicks})`).join(', ')
+      : '-',
+    r.id,
+  ]);
+  return renderTable(
+    ['Email', 'Contact ID', 'Count', 'Bounce Type', 'Clicked Links', 'ID'],
+    rows,
+    '(no recipients)',
+  );
+}
+
 export function renderBroadcastClickedLinksTable(
   links: Array<{
     url: string;

--- a/tests/commands/broadcasts/recipients.test.ts
+++ b/tests/commands/broadcasts/recipients.test.ts
@@ -1,0 +1,279 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from 'vitest';
+import {
+  captureTestEnv,
+  expectExit1,
+  mockExitThrow,
+  mockSdkError,
+  setNonInteractive,
+  setupOutputSpies,
+} from '../../helpers';
+
+const mockRecipients = vi.fn(async () => ({
+  data: {
+    object: 'list' as const,
+    has_more: false,
+    data: [
+      {
+        id: 'b2Zmc2V0OjA',
+        contact_id: 'e169aa45-1ecf-4183-9955-b1499d5701d3',
+        email: 'carter@example.com',
+        count: 3,
+        clicked_links: [
+          { url: 'https://resend.com/pricing', clicks: 2 },
+          { url: 'https://resend.com/docs', clicks: 1 },
+        ],
+      },
+    ],
+  },
+  error: null,
+}));
+
+vi.mock('resend', () => ({
+  Resend: class MockResend {
+    constructor(public key: string) {}
+    broadcasts = { recipients: mockRecipients };
+  },
+}));
+
+describe('broadcasts recipients command', () => {
+  const restoreEnv = captureTestEnv();
+  let spies: ReturnType<typeof setupOutputSpies> | undefined;
+  let errorSpy: MockInstance | undefined;
+  let stderrSpy: MockInstance | undefined;
+  let exitSpy: MockInstance | undefined;
+
+  beforeEach(() => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    mockRecipients.mockClear();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    errorSpy?.mockRestore();
+    stderrSpy?.mockRestore();
+    exitSpy?.mockRestore();
+    spies = undefined;
+    errorSpy = undefined;
+    stderrSpy = undefined;
+    exitSpy = undefined;
+  });
+
+  it('fetches recipients by id and type', async () => {
+    spies = setupOutputSpies();
+
+    const { recipientsBroadcastCommand } = await import(
+      '../../../src/commands/broadcasts/recipients'
+    );
+    await recipientsBroadcastCommand.parseAsync(
+      ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6', '--type', 'clicked'],
+      { from: 'user' },
+    );
+
+    expect(mockRecipients).toHaveBeenCalledTimes(1);
+    expect(mockRecipients.mock.calls[0][0]).toBe(
+      'd1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6',
+    );
+    const opts = mockRecipients.mock.calls[0][1] as Record<string, unknown>;
+    expect(opts.type).toBe('clicked');
+    expect(opts.limit).toBe(20);
+  });
+
+  it('passes --email and --bounce-type to SDK', async () => {
+    spies = setupOutputSpies();
+
+    const { recipientsBroadcastCommand } = await import(
+      '../../../src/commands/broadcasts/recipients'
+    );
+    await recipientsBroadcastCommand.parseAsync(
+      [
+        'd1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6',
+        '--type',
+        'bounced',
+        '--email',
+        '@example.com',
+        '--bounce-type',
+        'permanent',
+      ],
+      { from: 'user' },
+    );
+
+    const opts = mockRecipients.mock.calls[0][1] as Record<string, unknown>;
+    expect(opts.type).toBe('bounced');
+    expect(opts.email).toBe('@example.com');
+    expect(opts.bounceType).toBe('permanent');
+  });
+
+  it('passes --limit, --after, and --before to SDK', async () => {
+    spies = setupOutputSpies();
+
+    const { recipientsBroadcastCommand } = await import(
+      '../../../src/commands/broadcasts/recipients'
+    );
+    await recipientsBroadcastCommand.parseAsync(
+      [
+        'd1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6',
+        '--type',
+        'sent',
+        '--limit',
+        '5',
+        '--after',
+        'c0c0c0c0-d1d1-e2e2-f3f3-a4a4a4a4a4a4',
+      ],
+      { from: 'user' },
+    );
+
+    const opts = mockRecipients.mock.calls[0][1] as Record<string, unknown>;
+    expect(opts.limit).toBe(5);
+    expect(opts.after).toBe('c0c0c0c0-d1d1-e2e2-f3f3-a4a4a4a4a4a4');
+  });
+
+  it('outputs JSON list when non-interactive', async () => {
+    spies = setupOutputSpies();
+
+    const { recipientsBroadcastCommand } = await import(
+      '../../../src/commands/broadcasts/recipients'
+    );
+    await recipientsBroadcastCommand.parseAsync(
+      ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6', '--type', 'clicked'],
+      { from: 'user' },
+    );
+
+    const output = spies.logSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output);
+    expect(parsed.object).toBe('list');
+    expect(parsed.data).toHaveLength(1);
+    expect(parsed.data[0].email).toBe('carter@example.com');
+    expect(parsed.data[0].clicked_links).toHaveLength(2);
+  });
+
+  it('errors with missing_type in non-interactive mode', async () => {
+    setNonInteractive();
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = mockExitThrow();
+
+    const { recipientsBroadcastCommand } = await import(
+      '../../../src/commands/broadcasts/recipients'
+    );
+    await expectExit1(() =>
+      recipientsBroadcastCommand.parseAsync(
+        ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'],
+        { from: 'user' },
+      ),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('missing_type');
+  });
+
+  it('errors with invalid_limit when --limit is out of range', async () => {
+    setNonInteractive();
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    exitSpy = mockExitThrow();
+
+    const { recipientsBroadcastCommand } = await import(
+      '../../../src/commands/broadcasts/recipients'
+    );
+    await expectExit1(() =>
+      recipientsBroadcastCommand.parseAsync(
+        [
+          'd1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6',
+          '--type',
+          'sent',
+          '--limit',
+          '999',
+        ],
+        { from: 'user' },
+      ),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('invalid_limit');
+  });
+
+  it('errors with invalid_pagination when --after and --before are both set', async () => {
+    setNonInteractive();
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    exitSpy = mockExitThrow();
+
+    const { recipientsBroadcastCommand } = await import(
+      '../../../src/commands/broadcasts/recipients'
+    );
+    await expectExit1(() =>
+      recipientsBroadcastCommand.parseAsync(
+        [
+          'd1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6',
+          '--type',
+          'sent',
+          '--after',
+          'cursor-a',
+          '--before',
+          'cursor-b',
+        ],
+        { from: 'user' },
+      ),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('invalid_pagination');
+  });
+
+  it('errors with auth_error when no API key', async () => {
+    setNonInteractive();
+    delete process.env.RESEND_API_KEY;
+    process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = mockExitThrow();
+
+    const { recipientsBroadcastCommand } = await import(
+      '../../../src/commands/broadcasts/recipients'
+    );
+    await expectExit1(() =>
+      recipientsBroadcastCommand.parseAsync(
+        ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6', '--type', 'sent'],
+        { from: 'user' },
+      ),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('auth_error');
+  });
+
+  it('errors with list_error when SDK returns an error', async () => {
+    setNonInteractive();
+    mockRecipients.mockResolvedValueOnce(
+      mockSdkError('Broadcast not found', 'not_found'),
+    );
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    exitSpy = mockExitThrow();
+
+    const { recipientsBroadcastCommand } = await import(
+      '../../../src/commands/broadcasts/recipients'
+    );
+    await expectExit1(() =>
+      recipientsBroadcastCommand.parseAsync(
+        ['00000000-0000-0000-0000-00000000bad0', '--type', 'sent'],
+        { from: 'user' },
+      ),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('list_error');
+  });
+});


### PR DESCRIPTION
Adds \`resend broadcasts recipients <id>\` for GET /broadcasts/{id}/recipients.

Tests: 1114 passed. Lint/typecheck clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `resend broadcasts recipients <id>` to list a broadcast’s recipients by event type, enabling recipient inspection that was previously not possible. Uses `resend` 6.22.0 to call `broadcasts.recipients()`.

- Flags: `--type` is required (non-interactive) with `sent|delivered|opened|clicked|bounced|complained|unsubscribed|suppressed`. Optional `--email` (substring filter) and `--bounce-type` (`permanent|transient|undetermined`, only meaningful with `--type bounced`).
- Pagination and UX: supports `--limit` (1–100, default 20), `--after`, `--before`. Interactive mode prints a table and pagination hints; hints do not shell-quote `--email`. Table renders missing counts as `-`.
- Output and docs/tests: non-interactive returns the JSON list (type-specific fields like `count`, `bounce_type`, `clicked_links`). Adds docs and tests for validation, pagination, and SDK errors. Note: responses may be cached for up to 15 minutes.

<sup>Written for commit 3e425384ac0de44f347e8dcbbb736d4d3915a22a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-cli/pull/369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

