### PR TITLE
chore(skill): complete the broadcasts command table

### DIFF
--- a/skills/resend-cli/SKILL.md
+++ b/skills/resend-cli/SKILL.md
@@ -150,7 +150,7 @@ Auth resolves: `--api-key` flag > `RESEND_API_KEY` env > config file (`resend lo
 | `api-keys` | create, list, update, delete |
 | `automations` | create, get, list, update, delete, duplicate, stop, open, runs |
 | `events` | create, get, list, update, delete, send, open |
-| `broadcasts` | create, send, update, delete, list, clicked-links |
+| `broadcasts` | create, send, get, update, delete, list, cancel, open, clicked-links, recipients |
 | `contacts` | create, update, delete, segments, topics, imports |
 | `contact-properties` | create, update, delete, list |
 | `segments` | create, get, list, delete, contacts |


### PR DESCRIPTION
## What

Update the `broadcasts` row in `skills/resend-cli/SKILL.md` to list every command the group has: add `recipients`, `get`, `cancel`, and `open`.

## Why

#369 added the `recipients` command and updated `references/broadcasts.md`, but missed the SKILL.md command table. The table syncs to resend/resend-skills on merge, so agents that read the skill do not see the command. `get`, `cancel`, and `open` are pre-existing gaps in the same row; the row is one line, so this PR completes it in one pass. Follow-up from the recipients rollout review.

Doc-only change; no code touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes the `broadcasts` command table in `skills/resend-cli/SKILL.md` so the skill lists all supported commands. Previously the row listed: create, send, update, delete, list, clicked-links; now it lists: create, send, get, update, delete, list, cancel, open, clicked-links, recipients—ensuring parity with `references/broadcasts.md` and preventing missed capabilities.

Docs-only update that syncs to `resend/resend-skills` on merge; no CLI behavior changes and no migration.

<sup>Written for commit 496f0a8454b0f676a30c55602b07e1ed1b0c6756. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-cli/pull/371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

