### PR TITLE
chore: bump to v2.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-cli",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "description": "The official CLI for Resend",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Bumps the version for the release that ships:
- feat: add broadcasts clicked-links command (#368)
- feat: add emails metrics command (#370)
- feat(broadcasts): add recipients command (#369)
- chore(skill): complete the broadcasts command table (#371)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `resend-cli` from 2.15.0 to 2.16.0 to ship new CLI commands: broadcasts clicked-links, broadcasts recipients, and emails metrics, plus a completed broadcasts command table. No other code changes; this is a release-only update.

- Rollout
  - After merge, tag v2.16.0 and publish `resend-cli` to npm.
  - No breaking changes; no user migration required.

<sup>Written for commit 2c64ed99bb2ca9eb622e6ce9441920b39630c37f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-cli/pull/372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

