### PR TITLE
refactor: convert dynamic command imports to static imports in tests

### DIFF
--- a/tests/commands/api-keys/create.test.ts
+++ b/tests/commands/api-keys/create.test.ts
@@ -1,3 +1,4 @@
+import { Command } from '@commander-js/extra-typings';
 import {
   afterEach,
   beforeEach,
@@ -7,6 +8,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { createApiKeyCommand } from '../../../src/commands/api-keys/create';
 import {
   captureTestEnv,
   expectExit1,
@@ -59,9 +61,6 @@ describe('api-keys create command', () => {
   it('creates API key with --name flag', async () => {
     spies = setupOutputSpies();
 
-    const { createApiKeyCommand } = await import(
-      '../../../src/commands/api-keys/create'
-    );
     await createApiKeyCommand.parseAsync(['--name', 'Production'], {
       from: 'user',
     });
@@ -74,9 +73,6 @@ describe('api-keys create command', () => {
   it('passes permission flag to SDK', async () => {
     spies = setupOutputSpies();
 
-    const { createApiKeyCommand } = await import(
-      '../../../src/commands/api-keys/create'
-    );
     await createApiKeyCommand.parseAsync(
       ['--name', 'CI Token', '--permission', 'sending_access'],
       { from: 'user' },
@@ -89,9 +85,6 @@ describe('api-keys create command', () => {
   it('passes domain_id (snake_case) to SDK when --domain-id is provided', async () => {
     spies = setupOutputSpies();
 
-    const { createApiKeyCommand } = await import(
-      '../../../src/commands/api-keys/create'
-    );
     await createApiKeyCommand.parseAsync(
       [
         '--name',
@@ -111,9 +104,6 @@ describe('api-keys create command', () => {
   it('outputs JSON result when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { createApiKeyCommand } = await import(
-      '../../../src/commands/api-keys/create'
-    );
     await createApiKeyCommand.parseAsync(['--name', 'Production'], {
       from: 'user',
     });
@@ -129,9 +119,6 @@ describe('api-keys create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createApiKeyCommand } = await import(
-      '../../../src/commands/api-keys/create'
-    );
     await expectExit1(() =>
       createApiKeyCommand.parseAsync([], { from: 'user' }),
     );
@@ -152,10 +139,6 @@ describe('api-keys create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { Command } = await import('@commander-js/extra-typings');
-    const { createApiKeyCommand } = await import(
-      '../../../src/commands/api-keys/create'
-    );
     const program = new Command()
       .option('--profile <name>')
       .option('--team <name>')
@@ -178,9 +161,6 @@ describe('api-keys create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createApiKeyCommand } = await import(
-      '../../../src/commands/api-keys/create'
-    );
     await expectExit1(() =>
       createApiKeyCommand.parseAsync([], { from: 'user' }),
     );
@@ -195,9 +175,6 @@ describe('api-keys create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createApiKeyCommand } = await import(
-      '../../../src/commands/api-keys/create'
-    );
     await expectExit1(() =>
       createApiKeyCommand.parseAsync(['--name', 'Production'], {
         from: 'user',
@@ -219,9 +196,6 @@ describe('api-keys create command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { createApiKeyCommand } = await import(
-      '../../../src/commands/api-keys/create'
-    );
     await expectExit1(() =>
       createApiKeyCommand.parseAsync(['--name', 'Production'], {
         from: 'user',
@@ -237,9 +211,6 @@ describe('api-keys create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createApiKeyCommand } = await import(
-      '../../../src/commands/api-keys/create'
-    );
     await expectExit1(() =>
       createApiKeyCommand.parseAsync(
         ['--name', 'CI Token', '--domain-id', 'domain-123'],
@@ -259,9 +230,6 @@ describe('api-keys create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createApiKeyCommand } = await import(
-      '../../../src/commands/api-keys/create'
-    );
     await expectExit1(() =>
       createApiKeyCommand.parseAsync(
         [
@@ -285,9 +253,6 @@ describe('api-keys create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createApiKeyCommand } = await import(
-      '../../../src/commands/api-keys/create'
-    );
     await expectExit1(() =>
       createApiKeyCommand.parseAsync(
         ['--name', 'CI Token', '--domain-id', 'domain-123'],
@@ -301,9 +266,6 @@ describe('api-keys create command', () => {
   it('allows --domain-id with --permission sending_access', async () => {
     spies = setupOutputSpies();
 
-    const { createApiKeyCommand } = await import(
-      '../../../src/commands/api-keys/create'
-    );
     await createApiKeyCommand.parseAsync(
       [
         '--name',

--- a/tests/commands/api-keys/delete.test.ts
+++ b/tests/commands/api-keys/delete.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { deleteApiKeyCommand } from '../../../src/commands/api-keys/delete';
 import {
   captureTestEnv,
   expectExit1,
@@ -54,9 +55,6 @@ describe('api-keys delete command', () => {
   it('deletes API key with --yes flag', async () => {
     spies = setupOutputSpies();
 
-    const { deleteApiKeyCommand } = await import(
-      '../../../src/commands/api-keys/delete'
-    );
     await deleteApiKeyCommand.parseAsync(['test-key-id', '--yes'], {
       from: 'user',
     });
@@ -67,9 +65,6 @@ describe('api-keys delete command', () => {
   it('outputs synthesized deleted JSON on success', async () => {
     spies = setupOutputSpies();
 
-    const { deleteApiKeyCommand } = await import(
-      '../../../src/commands/api-keys/delete'
-    );
     await deleteApiKeyCommand.parseAsync(['test-key-id', '--yes'], {
       from: 'user',
     });
@@ -85,9 +80,6 @@ describe('api-keys delete command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { deleteApiKeyCommand } = await import(
-      '../../../src/commands/api-keys/delete'
-    );
     await expectExit1(() =>
       deleteApiKeyCommand.parseAsync(['test-key-id'], { from: 'user' }),
     );
@@ -101,9 +93,6 @@ describe('api-keys delete command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { deleteApiKeyCommand } = await import(
-      '../../../src/commands/api-keys/delete'
-    );
     await expectExit1(() =>
       deleteApiKeyCommand.parseAsync(['test-key-id'], { from: 'user' }),
     );
@@ -118,9 +107,6 @@ describe('api-keys delete command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { deleteApiKeyCommand } = await import(
-      '../../../src/commands/api-keys/delete'
-    );
     await expectExit1(() =>
       deleteApiKeyCommand.parseAsync(['test-key-id', '--yes'], {
         from: 'user',
@@ -142,9 +128,6 @@ describe('api-keys delete command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { deleteApiKeyCommand } = await import(
-      '../../../src/commands/api-keys/delete'
-    );
     await expectExit1(() =>
       deleteApiKeyCommand.parseAsync(['test-key-id', '--yes'], {
         from: 'user',

--- a/tests/commands/api-keys/list.test.ts
+++ b/tests/commands/api-keys/list.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { listApiKeysCommand } from '../../../src/commands/api-keys/list';
 import {
   captureTestEnv,
   expectExit1,
@@ -79,9 +80,6 @@ describe('api-keys list command', () => {
   it('uses default limit of 10 when not specified', async () => {
     spies = setupOutputSpies();
 
-    const { listApiKeysCommand } = await import(
-      '../../../src/commands/api-keys/list'
-    );
     await listApiKeysCommand.parseAsync([], { from: 'user' });
 
     expect(mockList).toHaveBeenCalledTimes(1);
@@ -91,9 +89,6 @@ describe('api-keys list command', () => {
   it('outputs JSON list when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { listApiKeysCommand } = await import(
-      '../../../src/commands/api-keys/list'
-    );
     await listApiKeysCommand.parseAsync([], { from: 'user' });
 
     const output = spies.logSpy.mock.calls[0][0] as string;
@@ -107,9 +102,6 @@ describe('api-keys list command', () => {
   it('passes limit to SDK', async () => {
     spies = setupOutputSpies();
 
-    const { listApiKeysCommand } = await import(
-      '../../../src/commands/api-keys/list'
-    );
     await listApiKeysCommand.parseAsync(['--limit', '25'], { from: 'user' });
 
     expect(getFirstCallArgs()).toMatchObject({ limit: 25 });
@@ -118,9 +110,6 @@ describe('api-keys list command', () => {
   it('passes after cursor to SDK', async () => {
     spies = setupOutputSpies();
 
-    const { listApiKeysCommand } = await import(
-      '../../../src/commands/api-keys/list'
-    );
     await listApiKeysCommand.parseAsync(['--after', 'some-cursor'], {
       from: 'user',
     });
@@ -133,9 +122,6 @@ describe('api-keys list command', () => {
   it('passes before cursor to SDK', async () => {
     spies = setupOutputSpies();
 
-    const { listApiKeysCommand } = await import(
-      '../../../src/commands/api-keys/list'
-    );
     await listApiKeysCommand.parseAsync(['--before', 'some-cursor'], {
       from: 'user',
     });
@@ -150,9 +136,6 @@ describe('api-keys list command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { listApiKeysCommand } = await import(
-      '../../../src/commands/api-keys/list'
-    );
     await expectExit1(() =>
       listApiKeysCommand.parseAsync(
         ['--after', 'cursor_after', '--before', 'cursor_before'],
@@ -172,9 +155,6 @@ describe('api-keys list command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { listApiKeysCommand } = await import(
-      '../../../src/commands/api-keys/list'
-    );
     await expectExit1(() =>
       listApiKeysCommand.parseAsync([], { from: 'user' }),
     );
@@ -194,9 +174,6 @@ describe('api-keys list command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { listApiKeysCommand } = await import(
-      '../../../src/commands/api-keys/list'
-    );
     await expectExit1(() =>
       listApiKeysCommand.parseAsync([], { from: 'user' }),
     );

--- a/tests/commands/api-keys/update.test.ts
+++ b/tests/commands/api-keys/update.test.ts
@@ -1,3 +1,4 @@
+import { Command } from '@commander-js/extra-typings';
 import {
   afterEach,
   beforeEach,
@@ -7,6 +8,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { updateApiKeyCommand } from '../../../src/commands/api-keys/update';
 import {
   captureTestEnv,
   expectExit1,
@@ -59,9 +61,6 @@ describe('api-keys update command', () => {
   it('updates API key with id and --name flag', async () => {
     spies = setupOutputSpies();
 
-    const { updateApiKeyCommand } = await import(
-      '../../../src/commands/api-keys/update'
-    );
     await updateApiKeyCommand.parseAsync(
       ['test-key-id', '--name', 'Production v2'],
       { from: 'user' },
@@ -76,9 +75,6 @@ describe('api-keys update command', () => {
   it('outputs JSON result when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { updateApiKeyCommand } = await import(
-      '../../../src/commands/api-keys/update'
-    );
     await updateApiKeyCommand.parseAsync(
       ['test-key-id', '--name', 'Production v2'],
       { from: 'user' },
@@ -95,9 +91,6 @@ describe('api-keys update command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { updateApiKeyCommand } = await import(
-      '../../../src/commands/api-keys/update'
-    );
     await expectExit1(() =>
       updateApiKeyCommand.parseAsync(['test-key-id'], { from: 'user' }),
     );
@@ -118,10 +111,6 @@ describe('api-keys update command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { Command } = await import('@commander-js/extra-typings');
-    const { updateApiKeyCommand } = await import(
-      '../../../src/commands/api-keys/update'
-    );
     const program = new Command()
       .option('--profile <name>')
       .option('--team <name>')
@@ -153,10 +142,6 @@ describe('api-keys update command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { Command } = await import('@commander-js/extra-typings');
-    const { updateApiKeyCommand } = await import(
-      '../../../src/commands/api-keys/update'
-    );
     const program = new Command()
       .option('--profile <name>')
       .option('--team <name>')
@@ -181,9 +166,6 @@ describe('api-keys update command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { updateApiKeyCommand } = await import(
-      '../../../src/commands/api-keys/update'
-    );
     await expectExit1(() =>
       updateApiKeyCommand.parseAsync(['test-key-id'], { from: 'user' }),
     );
@@ -198,9 +180,6 @@ describe('api-keys update command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { updateApiKeyCommand } = await import(
-      '../../../src/commands/api-keys/update'
-    );
     await expectExit1(() =>
       updateApiKeyCommand.parseAsync(
         ['test-key-id', '--name', 'Production v2'],
@@ -223,9 +202,6 @@ describe('api-keys update command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { updateApiKeyCommand } = await import(
-      '../../../src/commands/api-keys/update'
-    );
     await expectExit1(() =>
       updateApiKeyCommand.parseAsync(
         ['test-key-id', '--name', 'Production v2'],

--- a/tests/commands/auth/list.test.ts
+++ b/tests/commands/auth/list.test.ts
@@ -3,11 +3,11 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Command } from '@commander-js/extra-typings';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { listCommand } from '../../../src/commands/auth/list';
 import { storeApiKey } from '../../../src/lib/config';
 import { captureTestEnv, setupOutputSpies } from '../../helpers';
 
 async function createProgram() {
-  const { listCommand } = await import('../../../src/commands/auth/list');
   return new Command()
     .name('resend')
     .option('--json', 'Force JSON output')

--- a/tests/commands/auth/login.test.ts
+++ b/tests/commands/auth/login.test.ts
@@ -7,6 +7,7 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { Command } from '@commander-js/extra-typings';
 import {
   afterEach,
   beforeEach,
@@ -16,6 +17,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { loginCommand } from '../../../src/commands/auth/login';
 import {
   captureTestEnv,
   expectExit1,
@@ -64,7 +66,6 @@ describe('login command', () => {
     exitSpy?.mockRestore();
     exitSpy = undefined;
     try {
-      const { loginCommand } = await import('../../../src/commands/auth/login');
       (loginCommand as { parent?: unknown }).parent = null;
     } catch {
       // ignore if module not loaded
@@ -86,7 +87,6 @@ describe('login command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { loginCommand } = await import('../../../src/commands/auth/login');
     await expectExit1(() =>
       loginCommand.parseAsync(['--key', 're_fake_invalid_key'], {
         from: 'user',
@@ -106,7 +106,6 @@ describe('login command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { loginCommand } = await import('../../../src/commands/auth/login');
     await expectExit1(() =>
       loginCommand.parseAsync(['--key', 'bad_key'], { from: 'user' }),
     );
@@ -120,7 +119,6 @@ describe('login command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { loginCommand } = await import('../../../src/commands/auth/login');
     await expectExit1(() =>
       loginCommand.parseAsync(['--key', '   '], { from: 'user' }),
     );
@@ -132,7 +130,6 @@ describe('login command', () => {
   it('trims API key before storing', async () => {
     setNonInteractive();
 
-    const { loginCommand } = await import('../../../src/commands/auth/login');
     await loginCommand.parseAsync(['--key', '  re_trimmed_key_456  '], {
       from: 'user',
     });
@@ -145,7 +142,6 @@ describe('login command', () => {
   it('stores valid key to credentials.json and sets active_profile', async () => {
     setupOutputSpies();
 
-    const { loginCommand } = await import('../../../src/commands/auth/login');
     await loginCommand.parseAsync(['--key', 're_valid_test_key_123'], {
       from: 'user',
     });
@@ -161,7 +157,6 @@ describe('login command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { loginCommand } = await import('../../../src/commands/auth/login');
     await expectExit1(() => loginCommand.parseAsync([], { from: 'user' }));
 
     expect(errorSpy).toBeDefined();
@@ -181,8 +176,6 @@ describe('login command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { Command } = await import('@commander-js/extra-typings');
-    const { loginCommand } = await import('../../../src/commands/auth/login');
     const program = new Command()
       .option('--profile <name>')
       .option('--team <name>')
@@ -215,7 +208,6 @@ describe('login command', () => {
 
     setupOutputSpies();
 
-    const { loginCommand } = await import('../../../src/commands/auth/login');
     await loginCommand.parseAsync(['--key', 're_new_key_5678'], {
       from: 'user',
     });
@@ -231,8 +223,6 @@ describe('login command', () => {
   it('auto-switches to profile specified via --profile flag', async () => {
     setupOutputSpies();
 
-    const { Command } = await import('@commander-js/extra-typings');
-    const { loginCommand } = await import('../../../src/commands/auth/login');
     const program = new Command()
       .option('--profile <name>')
       .option('--team <name>')
@@ -268,8 +258,6 @@ describe('login command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { Command } = await import('@commander-js/extra-typings');
-    const { loginCommand } = await import('../../../src/commands/auth/login');
     const program = new Command()
       .option('--profile <name>')
       .option('--json')
@@ -291,8 +279,6 @@ describe('login command', () => {
   it('trims --profile before storing', async () => {
     setupOutputSpies();
 
-    const { Command } = await import('@commander-js/extra-typings');
-    const { loginCommand } = await import('../../../src/commands/auth/login');
     const program = new Command()
       .option('--profile <name>')
       .option('--team <name>')
@@ -317,8 +303,6 @@ describe('login command', () => {
     setupOutputSpies();
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
-    const { Command } = await import('@commander-js/extra-typings');
-    const { loginCommand } = await import('../../../src/commands/auth/login');
     const program = new Command()
       .option('--profile <name>')
       .option('--json')
@@ -351,7 +335,6 @@ describe('login command', () => {
 
     setupOutputSpies();
 
-    const { loginCommand } = await import('../../../src/commands/auth/login');
     await loginCommand.parseAsync(['--key', 're_sending_only_key_123'], {
       from: 'user',
     });
@@ -365,7 +348,6 @@ describe('login command', () => {
   it('stores full_access permission for valid full access key', async () => {
     setupOutputSpies();
 
-    const { loginCommand } = await import('../../../src/commands/auth/login');
     await loginCommand.parseAsync(['--key', 're_full_access_key_123'], {
       from: 'user',
     });
@@ -389,8 +371,6 @@ describe('login command', () => {
     setupOutputSpies();
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
-    const { Command } = await import('@commander-js/extra-typings');
-    const { loginCommand } = await import('../../../src/commands/auth/login');
     const program = new Command()
       .option('--profile <name>')
       .option('--json')

--- a/tests/commands/auth/logout.test.ts
+++ b/tests/commands/auth/logout.test.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { Command } from '@commander-js/extra-typings';
 import {
   afterEach,
   beforeEach,
@@ -10,6 +11,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { logoutCommand } from '../../../src/commands/auth/logout';
 import {
   captureTestEnv,
   expectExit1,
@@ -64,7 +66,6 @@ describe('logout command', () => {
     spies = setupOutputSpies();
     writeCredentials();
 
-    const { logoutCommand } = await import('../../../src/commands/auth/logout');
     await logoutCommand.parseAsync([], { from: 'user' });
 
     const configPath = join(tmpDir, 'resend', 'credentials.json');
@@ -78,7 +79,6 @@ describe('logout command', () => {
   it('exits cleanly when no credentials file exists (non-interactive)', async () => {
     spies = setupOutputSpies();
 
-    const { logoutCommand } = await import('../../../src/commands/auth/logout');
     await logoutCommand.parseAsync([], { from: 'user' });
 
     const output = JSON.parse(spies.logSpy.mock.calls[0][0] as string);
@@ -90,7 +90,6 @@ describe('logout command', () => {
     spies = setupOutputSpies();
     writeCredentials({ staging: 're_staging_key', production: 're_prod_key' });
 
-    const { logoutCommand } = await import('../../../src/commands/auth/logout');
     await logoutCommand.parseAsync([], { from: 'user' });
 
     const configPath = join(tmpDir, 'resend', 'credentials.json');
@@ -106,8 +105,6 @@ describe('logout command', () => {
     writeCredentials({ staging: 're_staging_key', production: 're_prod_key' });
 
     // Use the full CLI program so --profile global option is recognized
-    const { Command } = await import('@commander-js/extra-typings');
-    const { logoutCommand } = await import('../../../src/commands/auth/logout');
     const program = new Command()
       .option('--profile <name>')
       .option('--team <name>')
@@ -144,7 +141,6 @@ describe('logout command', () => {
     rmSync(configPath);
     mkdirSync(configPath); // replace file with a directory — unlinkSync will throw EISDIR
 
-    const { logoutCommand } = await import('../../../src/commands/auth/logout');
     await expectExit1(() => logoutCommand.parseAsync([], { from: 'user' }));
 
     expect(errorSpy).toBeDefined();
@@ -162,8 +158,6 @@ describe('logout command', () => {
     // Use a fresh Command wrapper so we don't inherit cached --profile
     // option values from earlier tests (commander caches parsed opts on
     // the parent program).
-    const { Command } = await import('@commander-js/extra-typings');
-    const { logoutCommand } = await import('../../../src/commands/auth/logout');
     const program = new Command()
       .option('--profile <name>')
       .option('--json')
@@ -186,8 +180,6 @@ describe('logout command', () => {
     const configPath = join(configDir, 'credentials.json');
     writeFileSync(configPath, '{"truncated');
 
-    const { Command } = await import('@commander-js/extra-typings');
-    const { logoutCommand } = await import('../../../src/commands/auth/logout');
     const program = new Command()
       .option('--profile <name>')
       .option('--json')

--- a/tests/commands/auth/remove.test.ts
+++ b/tests/commands/auth/remove.test.ts
@@ -11,6 +11,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { removeCommand } from '../../../src/commands/auth/remove';
 import { storeApiKey } from '../../../src/lib/config';
 import {
   captureTestEnv,
@@ -20,7 +21,6 @@ import {
 } from '../../helpers';
 
 async function createProgram() {
-  const { removeCommand } = await import('../../../src/commands/auth/remove');
   return new Command()
     .name('resend')
     .option('--json', 'Force JSON output')

--- a/tests/commands/auth/switch.test.ts
+++ b/tests/commands/auth/switch.test.ts
@@ -11,6 +11,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { switchCommand } from '../../../src/commands/auth/switch';
 import { storeApiKey } from '../../../src/lib/config';
 import {
   captureTestEnv,
@@ -20,7 +21,6 @@ import {
 } from '../../helpers';
 
 async function createProgram() {
-  const { switchCommand } = await import('../../../src/commands/auth/switch');
   return new Command()
     .name('resend')
     .option('--json', 'Force JSON output')

--- a/tests/commands/broadcasts/cancel.test.ts
+++ b/tests/commands/broadcasts/cancel.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { cancelBroadcastCommand } from '../../../src/commands/broadcasts/cancel';
 import {
   captureTestEnv,
   expectExit1,
@@ -54,9 +55,6 @@ describe('broadcasts cancel command', () => {
   it('cancels broadcast by id', async () => {
     spies = setupOutputSpies();
 
-    const { cancelBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/cancel'
-    );
     await cancelBroadcastCommand.parseAsync(
       ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'],
       { from: 'user' },
@@ -71,9 +69,6 @@ describe('broadcasts cancel command', () => {
   it('outputs JSON id when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { cancelBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/cancel'
-    );
     await cancelBroadcastCommand.parseAsync(
       ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'],
       { from: 'user' },
@@ -92,9 +87,6 @@ describe('broadcasts cancel command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { cancelBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/cancel'
-    );
     await expectExit1(() =>
       cancelBroadcastCommand.parseAsync(
         ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'],
@@ -120,9 +112,6 @@ describe('broadcasts cancel command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { cancelBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/cancel'
-    );
     await expectExit1(() =>
       cancelBroadcastCommand.parseAsync(
         ['00000000-0000-0000-0000-00000000bad0'],

--- a/tests/commands/broadcasts/clicked-links.test.ts
+++ b/tests/commands/broadcasts/clicked-links.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { clickedLinksBroadcastCommand } from '../../../src/commands/broadcasts/clicked-links';
 import {
   captureTestEnv,
   expectExit1,
@@ -65,9 +66,6 @@ describe('broadcasts clicked-links command', () => {
   it('lists clicked links for a broadcast id', async () => {
     spies = setupOutputSpies();
 
-    const { clickedLinksBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/clicked-links'
-    );
     await clickedLinksBroadcastCommand.parseAsync(
       ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'],
       { from: 'user' },
@@ -82,9 +80,6 @@ describe('broadcasts clicked-links command', () => {
   it('outputs JSON list when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { clickedLinksBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/clicked-links'
-    );
     await clickedLinksBroadcastCommand.parseAsync(
       ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'],
       { from: 'user' },
@@ -100,9 +95,6 @@ describe('broadcasts clicked-links command', () => {
   it('passes --limit to SDK', async () => {
     spies = setupOutputSpies();
 
-    const { clickedLinksBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/clicked-links'
-    );
     await clickedLinksBroadcastCommand.parseAsync(
       ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6', '--limit', '5'],
       { from: 'user' },
@@ -115,9 +107,6 @@ describe('broadcasts clicked-links command', () => {
   it('passes --after cursor to SDK', async () => {
     spies = setupOutputSpies();
 
-    const { clickedLinksBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/clicked-links'
-    );
     await clickedLinksBroadcastCommand.parseAsync(
       ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6', '--after', 'b2Zmc2V0OjA'],
       { from: 'user' },
@@ -130,9 +119,6 @@ describe('broadcasts clicked-links command', () => {
   it('passes --before cursor to SDK', async () => {
     spies = setupOutputSpies();
 
-    const { clickedLinksBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/clicked-links'
-    );
     await clickedLinksBroadcastCommand.parseAsync(
       ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6', '--before', 'b2Zmc2V0OjA'],
       { from: 'user' },
@@ -150,9 +136,6 @@ describe('broadcasts clicked-links command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { clickedLinksBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/clicked-links'
-    );
     await expectExit1(() =>
       clickedLinksBroadcastCommand.parseAsync(
         ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6', '--limit', '999'],
@@ -171,9 +154,6 @@ describe('broadcasts clicked-links command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { clickedLinksBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/clicked-links'
-    );
     await expectExit1(() =>
       clickedLinksBroadcastCommand.parseAsync(
         ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'],
@@ -196,9 +176,6 @@ describe('broadcasts clicked-links command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { clickedLinksBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/clicked-links'
-    );
     await expectExit1(() =>
       clickedLinksBroadcastCommand.parseAsync(
         ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'],

--- a/tests/commands/broadcasts/create.test.ts
+++ b/tests/commands/broadcasts/create.test.ts
@@ -1,3 +1,4 @@
+import { Command } from '@commander-js/extra-typings';
 import {
   afterEach,
   beforeEach,
@@ -7,7 +8,9 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { createBroadcastCommand } from '../../../src/commands/broadcasts/create';
 import * as files from '../../../src/lib/files';
+import { outputError } from '../../../src/lib/output';
 import {
   captureTestEnv,
   expectExit1,
@@ -72,9 +75,6 @@ describe('broadcasts create command', () => {
   it('creates broadcast with required flags', async () => {
     spies = setupOutputSpies();
 
-    const { createBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/create'
-    );
     await createBroadcastCommand.parseAsync(
       [
         '--from',
@@ -100,9 +100,6 @@ describe('broadcasts create command', () => {
   it('dry-run does not call API and prints create payload', async () => {
     spies = setupOutputSpies();
 
-    const { createBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/create'
-    );
     await createBroadcastCommand.parseAsync(
       [
         '--from',
@@ -129,9 +126,6 @@ describe('broadcasts create command', () => {
     spies = setupOutputSpies();
     delete process.env.RESEND_API_KEY;
 
-    const { createBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/create'
-    );
     await createBroadcastCommand.parseAsync(
       [
         '--from',
@@ -155,9 +149,6 @@ describe('broadcasts create command', () => {
   it('outputs JSON id when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { createBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/create'
-    );
     await createBroadcastCommand.parseAsync(
       [
         '--from',
@@ -180,9 +171,6 @@ describe('broadcasts create command', () => {
   it('passes --send flag to SDK', async () => {
     spies = setupOutputSpies();
 
-    const { createBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/create'
-    );
     await createBroadcastCommand.parseAsync(
       [
         '--from',
@@ -205,9 +193,6 @@ describe('broadcasts create command', () => {
   it('passes --scheduled-at with --send to SDK', async () => {
     spies = setupOutputSpies();
 
-    const { createBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/create'
-    );
     await createBroadcastCommand.parseAsync(
       [
         '--from',
@@ -232,9 +217,6 @@ describe('broadcasts create command', () => {
   it('passes optional flags to SDK', async () => {
     spies = setupOutputSpies();
 
-    const { createBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/create'
-    );
     await createBroadcastCommand.parseAsync(
       [
         '--from',
@@ -269,9 +251,6 @@ describe('broadcasts create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/create'
-    );
     await expectExit1(() =>
       createBroadcastCommand.parseAsync(
         [
@@ -295,9 +274,6 @@ describe('broadcasts create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/create'
-    );
     await expectExit1(() =>
       createBroadcastCommand.parseAsync(
         [
@@ -321,9 +297,6 @@ describe('broadcasts create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/create'
-    );
     await expectExit1(() =>
       createBroadcastCommand.parseAsync(
         [
@@ -347,9 +320,6 @@ describe('broadcasts create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/create'
-    );
     await expectExit1(() =>
       createBroadcastCommand.parseAsync(
         [
@@ -375,9 +345,6 @@ describe('broadcasts create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/create'
-    );
     await expectExit1(() =>
       createBroadcastCommand.parseAsync(
         [
@@ -409,9 +376,6 @@ describe('broadcasts create command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { createBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/create'
-    );
     await expectExit1(() =>
       createBroadcastCommand.parseAsync(
         [
@@ -437,9 +401,6 @@ describe('broadcasts create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/create'
-    );
     await expectExit1(() =>
       createBroadcastCommand.parseAsync([], { from: 'user' }),
     );
@@ -459,10 +420,6 @@ describe('broadcasts create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { Command } = await import('@commander-js/extra-typings');
-    const { createBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/create'
-    );
     const program = new Command()
       .option('--profile <name>')
       .option('--team <name>')
@@ -498,9 +455,6 @@ describe('broadcasts create command', () => {
       .spyOn(files, 'readFile')
       .mockReturnValue('<p>From file</p>');
 
-    const { createBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/create'
-    );
     await createBroadcastCommand.parseAsync(
       [
         '--from',
@@ -526,9 +480,6 @@ describe('broadcasts create command', () => {
       .spyOn(files, 'readFile')
       .mockReturnValue('Plain text from file');
 
-    const { createBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/create'
-    );
     await createBroadcastCommand.parseAsync(
       [
         '--from',
@@ -553,9 +504,6 @@ describe('broadcasts create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/create'
-    );
     await expectExit1(() =>
       createBroadcastCommand.parseAsync(
         [
@@ -585,9 +533,6 @@ describe('broadcasts create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/create'
-    );
     await expectExit1(() =>
       createBroadcastCommand.parseAsync(
         [
@@ -617,9 +562,6 @@ describe('broadcasts create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/create'
-    );
     await expectExit1(() =>
       createBroadcastCommand.parseAsync(
         [
@@ -648,9 +590,6 @@ describe('broadcasts create command', () => {
       .spyOn(files, 'readFile')
       .mockReturnValue('stdin text content');
 
-    const { createBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/create'
-    );
     await createBroadcastCommand.parseAsync(
       [
         '--from',
@@ -673,9 +612,6 @@ describe('broadcasts create command', () => {
   it('creates broadcast with --react-email flag', async () => {
     spies = setupOutputSpies();
 
-    const { createBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/create'
-    );
     await createBroadcastCommand.parseAsync(
       [
         '--from',
@@ -703,9 +639,6 @@ describe('broadcasts create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/create'
-    );
     await expectExit1(() =>
       createBroadcastCommand.parseAsync(
         [
@@ -736,7 +669,6 @@ describe('broadcasts create command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { outputError } = await import('../../../src/lib/output');
     readFileSpy = vi
       .spyOn(files, 'readFile')
       .mockImplementation(
@@ -751,9 +683,6 @@ describe('broadcasts create command', () => {
         },
       );
 
-    const { createBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/create'
-    );
     await expectExit1(() =>
       createBroadcastCommand.parseAsync(
         [

--- a/tests/commands/broadcasts/delete.test.ts
+++ b/tests/commands/broadcasts/delete.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { deleteBroadcastCommand } from '../../../src/commands/broadcasts/delete';
 import {
   captureTestEnv,
   expectExit1,
@@ -58,9 +59,6 @@ describe('broadcasts delete command', () => {
   it('deletes broadcast with --yes flag', async () => {
     spies = setupOutputSpies();
 
-    const { deleteBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/delete'
-    );
     await deleteBroadcastCommand.parseAsync(
       ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6', '--yes'],
       {
@@ -77,9 +75,6 @@ describe('broadcasts delete command', () => {
   it('outputs JSON result when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { deleteBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/delete'
-    );
     await deleteBroadcastCommand.parseAsync(
       ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6', '--yes'],
       {
@@ -99,9 +94,6 @@ describe('broadcasts delete command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { deleteBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/delete'
-    );
     await expectExit1(() =>
       deleteBroadcastCommand.parseAsync(
         ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'],
@@ -118,9 +110,6 @@ describe('broadcasts delete command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { deleteBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/delete'
-    );
     await expectExit1(() =>
       deleteBroadcastCommand.parseAsync(
         ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'],
@@ -138,9 +127,6 @@ describe('broadcasts delete command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { deleteBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/delete'
-    );
     await expectExit1(() =>
       deleteBroadcastCommand.parseAsync(
         ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6', '--yes'],
@@ -165,9 +151,6 @@ describe('broadcasts delete command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { deleteBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/delete'
-    );
     await expectExit1(() =>
       deleteBroadcastCommand.parseAsync(
         ['s1e2n3t4-5a6b-7c8d-9e0f-a1b2c3d4e5f6', '--yes'],

--- a/tests/commands/broadcasts/get.test.ts
+++ b/tests/commands/broadcasts/get.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { getBroadcastCommand } from '../../../src/commands/broadcasts/get';
 import {
   captureTestEnv,
   expectExit1,
@@ -71,9 +72,6 @@ describe('broadcasts get command', () => {
   it('fetches broadcast by id', async () => {
     spies = setupOutputSpies();
 
-    const { getBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/get'
-    );
     await getBroadcastCommand.parseAsync(
       ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'],
       { from: 'user' },
@@ -88,9 +86,6 @@ describe('broadcasts get command', () => {
   it('outputs full JSON when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { getBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/get'
-    );
     await getBroadcastCommand.parseAsync(
       ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'],
       { from: 'user' },
@@ -110,9 +105,6 @@ describe('broadcasts get command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { getBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/get'
-    );
     await expectExit1(() =>
       getBroadcastCommand.parseAsync(['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'], {
         from: 'user',
@@ -132,9 +124,6 @@ describe('broadcasts get command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { getBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/get'
-    );
     await expectExit1(() =>
       getBroadcastCommand.parseAsync(['00000000-0000-0000-0000-00000000bad0'], {
         from: 'user',

--- a/tests/commands/broadcasts/list.test.ts
+++ b/tests/commands/broadcasts/list.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { listBroadcastsCommand } from '../../../src/commands/broadcasts/list';
 import {
   captureTestEnv,
   expectExit1,
@@ -69,9 +70,6 @@ describe('broadcasts list command', () => {
   it('lists broadcasts', async () => {
     spies = setupOutputSpies();
 
-    const { listBroadcastsCommand } = await import(
-      '../../../src/commands/broadcasts/list'
-    );
     await listBroadcastsCommand.parseAsync([], { from: 'user' });
 
     expect(mockList).toHaveBeenCalledTimes(1);
@@ -80,9 +78,6 @@ describe('broadcasts list command', () => {
   it('outputs JSON list when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { listBroadcastsCommand } = await import(
-      '../../../src/commands/broadcasts/list'
-    );
     await listBroadcastsCommand.parseAsync([], { from: 'user' });
 
     const output = spies.logSpy.mock.calls[0][0] as string;
@@ -95,9 +90,6 @@ describe('broadcasts list command', () => {
   it('passes --limit to SDK', async () => {
     spies = setupOutputSpies();
 
-    const { listBroadcastsCommand } = await import(
-      '../../../src/commands/broadcasts/list'
-    );
     await listBroadcastsCommand.parseAsync(['--limit', '5'], { from: 'user' });
 
     const opts = mockList.mock.calls[0][0] as Record<string, unknown>;
@@ -107,9 +99,6 @@ describe('broadcasts list command', () => {
   it('passes --after cursor to SDK', async () => {
     spies = setupOutputSpies();
 
-    const { listBroadcastsCommand } = await import(
-      '../../../src/commands/broadcasts/list'
-    );
     await listBroadcastsCommand.parseAsync(
       ['--after', 'c0c0c0c0-d1d1-e2e2-f3f3-a4a4a4a4a4a4'],
       {
@@ -124,9 +113,6 @@ describe('broadcasts list command', () => {
   it('passes --before cursor to SDK', async () => {
     spies = setupOutputSpies();
 
-    const { listBroadcastsCommand } = await import(
-      '../../../src/commands/broadcasts/list'
-    );
     await listBroadcastsCommand.parseAsync(
       ['--before', 'c0c0c0c0-d1d1-e2e2-f3f3-a4a4a4a4a4a4'],
       {
@@ -146,9 +132,6 @@ describe('broadcasts list command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { listBroadcastsCommand } = await import(
-      '../../../src/commands/broadcasts/list'
-    );
     await expectExit1(() =>
       listBroadcastsCommand.parseAsync(['--limit', '999'], { from: 'user' }),
     );
@@ -164,9 +147,6 @@ describe('broadcasts list command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { listBroadcastsCommand } = await import(
-      '../../../src/commands/broadcasts/list'
-    );
     await expectExit1(() =>
       listBroadcastsCommand.parseAsync([], { from: 'user' }),
     );
@@ -186,9 +166,6 @@ describe('broadcasts list command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { listBroadcastsCommand } = await import(
-      '../../../src/commands/broadcasts/list'
-    );
     await expectExit1(() =>
       listBroadcastsCommand.parseAsync([], { from: 'user' }),
     );

--- a/tests/commands/broadcasts/open.test.ts
+++ b/tests/commands/broadcasts/open.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { openBroadcastCommand } from '../../../src/commands/broadcasts/open';
 import * as browser from '../../../src/lib/browser';
 
 describe('broadcasts open command', () => {
@@ -11,9 +12,6 @@ describe('broadcasts open command', () => {
   });
 
   it('with no args opens broadcasts list', async () => {
-    const { openBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/open'
-    );
     await openBroadcastCommand.parseAsync([], { from: 'user' });
 
     expect(browser.openInBrowserOrLog).toHaveBeenCalledTimes(1);
@@ -24,9 +22,6 @@ describe('broadcasts open command', () => {
   });
 
   it('with id opens broadcast URL', async () => {
-    const { openBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/open'
-    );
     await openBroadcastCommand.parseAsync(
       ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'],
       { from: 'user' },

--- a/tests/commands/broadcasts/recipients.test.ts
+++ b/tests/commands/broadcasts/recipients.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { recipientsBroadcastCommand } from '../../../src/commands/broadcasts/recipients';
 import {
   captureTestEnv,
   expectExit1,
@@ -69,9 +70,6 @@ describe('broadcasts recipients command', () => {
   it('fetches recipients by id and type', async () => {
     spies = setupOutputSpies();
 
-    const { recipientsBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/recipients'
-    );
     await recipientsBroadcastCommand.parseAsync(
       ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6', '--type', 'clicked'],
       { from: 'user' },
@@ -89,9 +87,6 @@ describe('broadcasts recipients command', () => {
   it('passes --email and --bounce-type to SDK', async () => {
     spies = setupOutputSpies();
 
-    const { recipientsBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/recipients'
-    );
     await recipientsBroadcastCommand.parseAsync(
       [
         'd1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6',
@@ -114,9 +109,6 @@ describe('broadcasts recipients command', () => {
   it('passes --limit, --after, and --before to SDK', async () => {
     spies = setupOutputSpies();
 
-    const { recipientsBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/recipients'
-    );
     await recipientsBroadcastCommand.parseAsync(
       [
         'd1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6',
@@ -138,9 +130,6 @@ describe('broadcasts recipients command', () => {
   it('outputs JSON list when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { recipientsBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/recipients'
-    );
     await recipientsBroadcastCommand.parseAsync(
       ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6', '--type', 'clicked'],
       { from: 'user' },
@@ -159,9 +148,6 @@ describe('broadcasts recipients command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { recipientsBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/recipients'
-    );
     await expectExit1(() =>
       recipientsBroadcastCommand.parseAsync(
         ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'],
@@ -181,9 +167,6 @@ describe('broadcasts recipients command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { recipientsBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/recipients'
-    );
     await expectExit1(() =>
       recipientsBroadcastCommand.parseAsync(
         [
@@ -209,9 +192,6 @@ describe('broadcasts recipients command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { recipientsBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/recipients'
-    );
     await expectExit1(() =>
       recipientsBroadcastCommand.parseAsync(
         [
@@ -238,9 +218,6 @@ describe('broadcasts recipients command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { recipientsBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/recipients'
-    );
     await expectExit1(() =>
       recipientsBroadcastCommand.parseAsync(
         ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6', '--type', 'sent'],
@@ -263,9 +240,6 @@ describe('broadcasts recipients command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { recipientsBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/recipients'
-    );
     await expectExit1(() =>
       recipientsBroadcastCommand.parseAsync(
         ['00000000-0000-0000-0000-00000000bad0', '--type', 'sent'],

--- a/tests/commands/broadcasts/send.test.ts
+++ b/tests/commands/broadcasts/send.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { sendBroadcastCommand } from '../../../src/commands/broadcasts/send';
 import {
   captureTestEnv,
   expectExit1,
@@ -54,9 +55,6 @@ describe('broadcasts send command', () => {
   it('sends broadcast by id', async () => {
     spies = setupOutputSpies();
 
-    const { sendBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/send'
-    );
     await sendBroadcastCommand.parseAsync(
       ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'],
       { from: 'user' },
@@ -71,9 +69,6 @@ describe('broadcasts send command', () => {
   it('outputs JSON id when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { sendBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/send'
-    );
     await sendBroadcastCommand.parseAsync(
       ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'],
       { from: 'user' },
@@ -87,9 +82,6 @@ describe('broadcasts send command', () => {
   it('passes --scheduled-at to SDK', async () => {
     spies = setupOutputSpies();
 
-    const { sendBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/send'
-    );
     await sendBroadcastCommand.parseAsync(
       ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6', '--scheduled-at', 'in 1 hour'],
       { from: 'user' },
@@ -102,9 +94,6 @@ describe('broadcasts send command', () => {
   it('does not pass scheduledAt when flag absent', async () => {
     spies = setupOutputSpies();
 
-    const { sendBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/send'
-    );
     await sendBroadcastCommand.parseAsync(
       ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'],
       { from: 'user' },
@@ -121,9 +110,6 @@ describe('broadcasts send command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { sendBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/send'
-    );
     await expectExit1(() =>
       sendBroadcastCommand.parseAsync(
         ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'],
@@ -146,9 +132,6 @@ describe('broadcasts send command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { sendBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/send'
-    );
     await expectExit1(() =>
       sendBroadcastCommand.parseAsync(
         ['00000000-0000-0000-0000-00000000bad0'],

--- a/tests/commands/broadcasts/update.test.ts
+++ b/tests/commands/broadcasts/update.test.ts
@@ -7,7 +7,9 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { updateBroadcastCommand } from '../../../src/commands/broadcasts/update';
 import * as files from '../../../src/lib/files';
+import { outputError } from '../../../src/lib/output';
 import {
   captureTestEnv,
   expectExit1,
@@ -67,9 +69,6 @@ describe('broadcasts update command', () => {
   it('updates broadcast subject', async () => {
     spies = setupOutputSpies();
 
-    const { updateBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/update'
-    );
     await updateBroadcastCommand.parseAsync(
       ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6', '--subject', 'Updated Subject'],
       { from: 'user' },
@@ -86,9 +85,6 @@ describe('broadcasts update command', () => {
   it('passes all update flags to SDK', async () => {
     spies = setupOutputSpies();
 
-    const { updateBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/update'
-    );
     await updateBroadcastCommand.parseAsync(
       [
         'd1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6',
@@ -114,9 +110,6 @@ describe('broadcasts update command', () => {
   it('passes explicit empty text to the SDK', async () => {
     spies = setupOutputSpies();
 
-    const { updateBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/update'
-    );
     await updateBroadcastCommand.parseAsync(
       ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6', '--text', ''],
       { from: 'user' },
@@ -129,9 +122,6 @@ describe('broadcasts update command', () => {
   it('passes explicit empty html to the SDK', async () => {
     spies = setupOutputSpies();
 
-    const { updateBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/update'
-    );
     await updateBroadcastCommand.parseAsync(
       ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6', '--html', ''],
       { from: 'user' },
@@ -144,9 +134,6 @@ describe('broadcasts update command', () => {
   it('outputs JSON id when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { updateBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/update'
-    );
     await updateBroadcastCommand.parseAsync(
       ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6', '--subject', 'Updated'],
       { from: 'user' },
@@ -160,9 +147,6 @@ describe('broadcasts update command', () => {
   it('omits undefined fields from SDK payload', async () => {
     spies = setupOutputSpies();
 
-    const { updateBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/update'
-    );
     await updateBroadcastCommand.parseAsync(
       ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6', '--name', 'Only Name'],
       { from: 'user' },
@@ -179,9 +163,6 @@ describe('broadcasts update command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { updateBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/update'
-    );
     await expectExit1(() =>
       updateBroadcastCommand.parseAsync(
         ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'],
@@ -198,9 +179,6 @@ describe('broadcasts update command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { updateBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/update'
-    );
     await expectExit1(() =>
       updateBroadcastCommand.parseAsync(
         ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'],
@@ -218,9 +196,6 @@ describe('broadcasts update command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { updateBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/update'
-    );
     await expectExit1(() =>
       updateBroadcastCommand.parseAsync(
         ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6', '--subject', 'X'],
@@ -245,9 +220,6 @@ describe('broadcasts update command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { updateBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/update'
-    );
     await expectExit1(() =>
       updateBroadcastCommand.parseAsync(
         ['s1e2n3t4-5a6b-7c8d-9e0f-a1b2c3d4e5f6', '--subject', 'New'],
@@ -267,9 +239,6 @@ describe('broadcasts update command', () => {
       .spyOn(files, 'readFile')
       .mockReturnValue('<p>Updated from file</p>');
 
-    const { updateBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/update'
-    );
     await updateBroadcastCommand.parseAsync(
       [
         'd1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6',
@@ -290,9 +259,6 @@ describe('broadcasts update command', () => {
       .spyOn(files, 'readFile')
       .mockReturnValue('<p>From empty path</p>');
 
-    const { updateBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/update'
-    );
     await updateBroadcastCommand.parseAsync(
       ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6', '--html-file', ''],
       { from: 'user' },
@@ -309,9 +275,6 @@ describe('broadcasts update command', () => {
       .spyOn(files, 'readFile')
       .mockReturnValue('Updated text from file');
 
-    const { updateBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/update'
-    );
     await updateBroadcastCommand.parseAsync(
       ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6', '--text-file', '/fake/body.txt'],
       { from: 'user' },
@@ -328,9 +291,6 @@ describe('broadcasts update command', () => {
       .spyOn(files, 'readFile')
       .mockReturnValue('Text from empty path');
 
-    const { updateBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/update'
-    );
     await updateBroadcastCommand.parseAsync(
       ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6', '--text-file', ''],
       { from: 'user' },
@@ -346,9 +306,6 @@ describe('broadcasts update command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { updateBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/update'
-    );
     await expectExit1(() =>
       updateBroadcastCommand.parseAsync(
         [
@@ -373,9 +330,6 @@ describe('broadcasts update command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { updateBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/update'
-    );
     await expectExit1(() =>
       updateBroadcastCommand.parseAsync(
         [
@@ -400,9 +354,6 @@ describe('broadcasts update command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { updateBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/update'
-    );
     await expectExit1(() =>
       updateBroadcastCommand.parseAsync(
         [
@@ -423,9 +374,6 @@ describe('broadcasts update command', () => {
   it('updates broadcast html with --react-email flag', async () => {
     spies = setupOutputSpies();
 
-    const { updateBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/update'
-    );
     await updateBroadcastCommand.parseAsync(
       [
         'd1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6',
@@ -449,7 +397,6 @@ describe('broadcasts update command', () => {
     exitSpy = mockExitThrow();
 
     mockBuildReactEmailHtml.mockReset();
-    const { outputError } = await import('../../../src/lib/output');
     mockBuildReactEmailHtml.mockImplementation(
       async (path: unknown, globalOpts: { json?: boolean }) => {
         if (typeof path === 'string' && path.trim() === '') {
@@ -465,9 +412,6 @@ describe('broadcasts update command', () => {
       },
     );
 
-    const { updateBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/update'
-    );
     await expectExit1(() =>
       updateBroadcastCommand.parseAsync(
         ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6', '--react-email', ''],
@@ -485,9 +429,6 @@ describe('broadcasts update command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { updateBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/update'
-    );
     await expectExit1(() =>
       updateBroadcastCommand.parseAsync(
         [
@@ -513,7 +454,6 @@ describe('broadcasts update command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { outputError } = await import('../../../src/lib/output');
     readFileSpy = vi
       .spyOn(files, 'readFile')
       .mockImplementation(
@@ -528,9 +468,6 @@ describe('broadcasts update command', () => {
         },
       );
 
-    const { updateBroadcastCommand } = await import(
-      '../../../src/commands/broadcasts/update'
-    );
     await expectExit1(() =>
       updateBroadcastCommand.parseAsync(
         [

--- a/tests/commands/careers/apply.test.ts
+++ b/tests/commands/careers/apply.test.ts
@@ -10,6 +10,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { applyCareerCommand } from '../../../src/commands/careers/apply';
 import {
   captureTestEnv,
   expectExit1,
@@ -70,9 +71,6 @@ describe('careers apply command', () => {
   it('submits a multipart application to /careers/:id', async () => {
     spies = setupOutputSpies();
 
-    const { applyCareerCommand } = await import(
-      '../../../src/commands/careers/apply'
-    );
     await applyCareerCommand.parseAsync(
       [
         'job-posting-123',
@@ -112,9 +110,6 @@ describe('careers apply command', () => {
   it('outputs the API response as JSON when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { applyCareerCommand } = await import(
-      '../../../src/commands/careers/apply'
-    );
     await applyCareerCommand.parseAsync(['job-posting-123', ...requiredFlags], {
       from: 'user',
     });
@@ -128,9 +123,6 @@ describe('careers apply command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { applyCareerCommand } = await import(
-      '../../../src/commands/careers/apply'
-    );
     await expectExit1(() =>
       applyCareerCommand.parseAsync([...requiredFlags], { from: 'user' }),
     );
@@ -151,9 +143,6 @@ describe('careers apply command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { applyCareerCommand } = await import(
-      '../../../src/commands/careers/apply'
-    );
     await expectExit1(() =>
       applyCareerCommand.parseAsync(['job-posting-123', ...flags], {
         from: 'user',
@@ -169,9 +158,6 @@ describe('careers apply command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { applyCareerCommand } = await import(
-      '../../../src/commands/careers/apply'
-    );
     await expectExit1(() =>
       applyCareerCommand.parseAsync(
         ['job-posting-123', ...requiredFlags, '--field', 'no-separator'],
@@ -188,9 +174,6 @@ describe('careers apply command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { applyCareerCommand } = await import(
-      '../../../src/commands/careers/apply'
-    );
     await expectExit1(() =>
       applyCareerCommand.parseAsync(
         [
@@ -226,9 +209,6 @@ describe('careers apply command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { applyCareerCommand } = await import(
-      '../../../src/commands/careers/apply'
-    );
     await expectExit1(() =>
       applyCareerCommand.parseAsync(['job-posting-123', ...requiredFlags], {
         from: 'user',
@@ -247,9 +227,6 @@ describe('careers apply command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { applyCareerCommand } = await import(
-      '../../../src/commands/careers/apply'
-    );
     await expectExit1(() =>
       applyCareerCommand.parseAsync(['job-posting-123', ...requiredFlags], {
         from: 'user',

--- a/tests/commands/careers/list.test.ts
+++ b/tests/commands/careers/list.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { listCareersCommand } from '../../../src/commands/careers/list';
 import {
   captureTestEnv,
   expectExit1,
@@ -65,9 +66,6 @@ describe('careers list command', () => {
   it('fetches open positions from /careers', async () => {
     spies = setupOutputSpies();
 
-    const { listCareersCommand } = await import(
-      '../../../src/commands/careers/list'
-    );
     await listCareersCommand.parseAsync([], { from: 'user' });
 
     expect(mockGet).toHaveBeenCalledTimes(1);
@@ -77,9 +75,6 @@ describe('careers list command', () => {
   it('outputs JSON result when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { listCareersCommand } = await import(
-      '../../../src/commands/careers/list'
-    );
     await listCareersCommand.parseAsync([], { from: 'user' });
 
     const output = spies.logSpy.mock.calls[0][0] as string;
@@ -97,9 +92,6 @@ describe('careers list command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { listCareersCommand } = await import(
-      '../../../src/commands/careers/list'
-    );
     await expectExit1(() =>
       listCareersCommand.parseAsync([], { from: 'user' }),
     );
@@ -115,9 +107,6 @@ describe('careers list command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { listCareersCommand } = await import(
-      '../../../src/commands/careers/list'
-    );
     await expectExit1(() =>
       listCareersCommand.parseAsync([], { from: 'user' }),
     );

--- a/tests/commands/contact-properties/create.test.ts
+++ b/tests/commands/contact-properties/create.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { createContactPropertyCommand } from '../../../src/commands/contact-properties/create';
 import {
   captureTestEnv,
   expectExit1,
@@ -57,9 +58,6 @@ describe('contact-properties create command', () => {
   it('creates property with --key and --type', async () => {
     spies = setupOutputSpies();
 
-    const { createContactPropertyCommand } = await import(
-      '../../../src/commands/contact-properties/create'
-    );
     await createContactPropertyCommand.parseAsync(
       ['--key', 'company_name', '--type', 'string'],
       { from: 'user' },
@@ -74,9 +72,6 @@ describe('contact-properties create command', () => {
   it('creates number-type property', async () => {
     spies = setupOutputSpies();
 
-    const { createContactPropertyCommand } = await import(
-      '../../../src/commands/contact-properties/create'
-    );
     await createContactPropertyCommand.parseAsync(
       ['--key', 'score', '--type', 'number'],
       { from: 'user' },
@@ -90,9 +85,6 @@ describe('contact-properties create command', () => {
   it('passes string fallback-value to SDK', async () => {
     spies = setupOutputSpies();
 
-    const { createContactPropertyCommand } = await import(
-      '../../../src/commands/contact-properties/create'
-    );
     await createContactPropertyCommand.parseAsync(
       [
         '--key',
@@ -112,9 +104,6 @@ describe('contact-properties create command', () => {
   it('coerces fallback-value to number for number-type properties', async () => {
     spies = setupOutputSpies();
 
-    const { createContactPropertyCommand } = await import(
-      '../../../src/commands/contact-properties/create'
-    );
     await createContactPropertyCommand.parseAsync(
       ['--key', 'score', '--type', 'number', '--fallback-value', '42'],
       { from: 'user' },
@@ -127,9 +116,6 @@ describe('contact-properties create command', () => {
   it('outputs JSON id when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { createContactPropertyCommand } = await import(
-      '../../../src/commands/contact-properties/create'
-    );
     await createContactPropertyCommand.parseAsync(
       ['--key', 'plan', '--type', 'string'],
       { from: 'user' },
@@ -146,9 +132,6 @@ describe('contact-properties create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createContactPropertyCommand } = await import(
-      '../../../src/commands/contact-properties/create'
-    );
     await expectExit1(() =>
       createContactPropertyCommand.parseAsync(['--type', 'string'], {
         from: 'user',
@@ -164,9 +147,6 @@ describe('contact-properties create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createContactPropertyCommand } = await import(
-      '../../../src/commands/contact-properties/create'
-    );
     await expectExit1(() =>
       createContactPropertyCommand.parseAsync(['--key', 'company_name'], {
         from: 'user',
@@ -182,9 +162,6 @@ describe('contact-properties create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createContactPropertyCommand } = await import(
-      '../../../src/commands/contact-properties/create'
-    );
     await expectExit1(() =>
       createContactPropertyCommand.parseAsync(
         [
@@ -210,9 +187,6 @@ describe('contact-properties create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createContactPropertyCommand } = await import(
-      '../../../src/commands/contact-properties/create'
-    );
     await expectExit1(() =>
       createContactPropertyCommand.parseAsync(
         ['--key', 'company_name', '--type', 'string'],
@@ -235,9 +209,6 @@ describe('contact-properties create command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { createContactPropertyCommand } = await import(
-      '../../../src/commands/contact-properties/create'
-    );
     await expectExit1(() =>
       createContactPropertyCommand.parseAsync(
         ['--key', 'company_name', '--type', 'string'],

--- a/tests/commands/contact-properties/delete.test.ts
+++ b/tests/commands/contact-properties/delete.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { deleteContactPropertyCommand } from '../../../src/commands/contact-properties/delete';
 import {
   captureTestEnv,
   expectExit1,
@@ -58,9 +59,6 @@ describe('contact-properties delete command', () => {
   it('deletes property with --yes', async () => {
     spies = setupOutputSpies();
 
-    const { deleteContactPropertyCommand } = await import(
-      '../../../src/commands/contact-properties/delete'
-    );
     await deleteContactPropertyCommand.parseAsync(
       ['b4a3c2d1-6e5f-8a7b-0c9d-2e1f4a3b6c5d', '--yes'],
       {
@@ -77,9 +75,6 @@ describe('contact-properties delete command', () => {
   it('outputs synthesized JSON result when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { deleteContactPropertyCommand } = await import(
-      '../../../src/commands/contact-properties/delete'
-    );
     await deleteContactPropertyCommand.parseAsync(
       ['b4a3c2d1-6e5f-8a7b-0c9d-2e1f4a3b6c5d', '--yes'],
       {
@@ -99,9 +94,6 @@ describe('contact-properties delete command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { deleteContactPropertyCommand } = await import(
-      '../../../src/commands/contact-properties/delete'
-    );
     await expectExit1(() =>
       deleteContactPropertyCommand.parseAsync(
         ['b4a3c2d1-6e5f-8a7b-0c9d-2e1f4a3b6c5d'],
@@ -120,9 +112,6 @@ describe('contact-properties delete command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { deleteContactPropertyCommand } = await import(
-      '../../../src/commands/contact-properties/delete'
-    );
     await expectExit1(() =>
       deleteContactPropertyCommand.parseAsync(
         ['b4a3c2d1-6e5f-8a7b-0c9d-2e1f4a3b6c5d'],
@@ -142,9 +131,6 @@ describe('contact-properties delete command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { deleteContactPropertyCommand } = await import(
-      '../../../src/commands/contact-properties/delete'
-    );
     await expectExit1(() =>
       deleteContactPropertyCommand.parseAsync(
         ['b4a3c2d1-6e5f-8a7b-0c9d-2e1f4a3b6c5d', '--yes'],
@@ -169,9 +155,6 @@ describe('contact-properties delete command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { deleteContactPropertyCommand } = await import(
-      '../../../src/commands/contact-properties/delete'
-    );
     await expectExit1(() =>
       deleteContactPropertyCommand.parseAsync(['nonexistent_id', '--yes'], {
         from: 'user',

--- a/tests/commands/contact-properties/get.test.ts
+++ b/tests/commands/contact-properties/get.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { getContactPropertyCommand } from '../../../src/commands/contact-properties/get';
 import {
   captureTestEnv,
   expectExit1,
@@ -61,9 +62,6 @@ describe('contact-properties get command', () => {
   it('calls SDK with the given ID', async () => {
     spies = setupOutputSpies();
 
-    const { getContactPropertyCommand } = await import(
-      '../../../src/commands/contact-properties/get'
-    );
     await getContactPropertyCommand.parseAsync(
       ['b4a3c2d1-6e5f-8a7b-0c9d-2e1f4a3b6c5d'],
       {
@@ -80,9 +78,6 @@ describe('contact-properties get command', () => {
   it('outputs JSON when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { getContactPropertyCommand } = await import(
-      '../../../src/commands/contact-properties/get'
-    );
     await getContactPropertyCommand.parseAsync(
       ['b4a3c2d1-6e5f-8a7b-0c9d-2e1f4a3b6c5d'],
       {
@@ -105,9 +100,6 @@ describe('contact-properties get command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { getContactPropertyCommand } = await import(
-      '../../../src/commands/contact-properties/get'
-    );
     await expectExit1(() =>
       getContactPropertyCommand.parseAsync(
         ['b4a3c2d1-6e5f-8a7b-0c9d-2e1f4a3b6c5d'],
@@ -130,9 +122,6 @@ describe('contact-properties get command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { getContactPropertyCommand } = await import(
-      '../../../src/commands/contact-properties/get'
-    );
     await expectExit1(() =>
       getContactPropertyCommand.parseAsync(['nonexistent_id'], {
         from: 'user',

--- a/tests/commands/contact-properties/list.test.ts
+++ b/tests/commands/contact-properties/list.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { listContactPropertiesCommand } from '../../../src/commands/contact-properties/list';
 import {
   captureTestEnv,
   expectExit1,
@@ -66,9 +67,6 @@ describe('contact-properties list command', () => {
   it('calls SDK with default limit of 10', async () => {
     spies = setupOutputSpies();
 
-    const { listContactPropertiesCommand } = await import(
-      '../../../src/commands/contact-properties/list'
-    );
     await listContactPropertiesCommand.parseAsync([], { from: 'user' });
 
     expect(mockList).toHaveBeenCalledTimes(1);
@@ -79,9 +77,6 @@ describe('contact-properties list command', () => {
   it('calls SDK with custom --limit', async () => {
     spies = setupOutputSpies();
 
-    const { listContactPropertiesCommand } = await import(
-      '../../../src/commands/contact-properties/list'
-    );
     await listContactPropertiesCommand.parseAsync(['--limit', '25'], {
       from: 'user',
     });
@@ -93,9 +88,6 @@ describe('contact-properties list command', () => {
   it('calls SDK with --after cursor', async () => {
     spies = setupOutputSpies();
 
-    const { listContactPropertiesCommand } = await import(
-      '../../../src/commands/contact-properties/list'
-    );
     await listContactPropertiesCommand.parseAsync(
       ['--after', 'c0c0c0c0-d1d1-e2e2-f3f3-b5b5b5b5b5b5'],
       { from: 'user' },
@@ -108,9 +100,6 @@ describe('contact-properties list command', () => {
   it('outputs JSON list when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { listContactPropertiesCommand } = await import(
-      '../../../src/commands/contact-properties/list'
-    );
     await listContactPropertiesCommand.parseAsync([], { from: 'user' });
 
     const output = spies.logSpy.mock.calls[0][0] as string;
@@ -126,9 +115,6 @@ describe('contact-properties list command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { listContactPropertiesCommand } = await import(
-      '../../../src/commands/contact-properties/list'
-    );
     await expectExit1(() =>
       listContactPropertiesCommand.parseAsync(['--limit', '0'], {
         from: 'user',
@@ -146,9 +132,6 @@ describe('contact-properties list command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { listContactPropertiesCommand } = await import(
-      '../../../src/commands/contact-properties/list'
-    );
     await expectExit1(() =>
       listContactPropertiesCommand.parseAsync([], { from: 'user' }),
     );
@@ -168,9 +151,6 @@ describe('contact-properties list command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { listContactPropertiesCommand } = await import(
-      '../../../src/commands/contact-properties/list'
-    );
     await expectExit1(() =>
       listContactPropertiesCommand.parseAsync([], { from: 'user' }),
     );

--- a/tests/commands/contact-properties/update.test.ts
+++ b/tests/commands/contact-properties/update.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { updateContactPropertyCommand } from '../../../src/commands/contact-properties/update';
 import {
   captureTestEnv,
   expectExit1,
@@ -70,9 +71,6 @@ describe('contact-properties update command', () => {
   it('updates property fallback value', async () => {
     spies = setupOutputSpies();
 
-    const { updateContactPropertyCommand } = await import(
-      '../../../src/commands/contact-properties/update'
-    );
     await updateContactPropertyCommand.parseAsync(
       ['b4a3c2d1-6e5f-8a7b-0c9d-2e1f4a3b6c5d', '--fallback-value', 'Acme Corp'],
       { from: 'user' },
@@ -87,9 +85,6 @@ describe('contact-properties update command', () => {
   it('clears fallback value with --clear-fallback-value', async () => {
     spies = setupOutputSpies();
 
-    const { updateContactPropertyCommand } = await import(
-      '../../../src/commands/contact-properties/update'
-    );
     await updateContactPropertyCommand.parseAsync(
       ['b4a3c2d1-6e5f-8a7b-0c9d-2e1f4a3b6c5d', '--clear-fallback-value'],
       { from: 'user' },
@@ -105,9 +100,6 @@ describe('contact-properties update command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { updateContactPropertyCommand } = await import(
-      '../../../src/commands/contact-properties/update'
-    );
     await expectExit1(() =>
       updateContactPropertyCommand.parseAsync(
         [
@@ -127,9 +119,6 @@ describe('contact-properties update command', () => {
   it('outputs JSON result when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { updateContactPropertyCommand } = await import(
-      '../../../src/commands/contact-properties/update'
-    );
     await updateContactPropertyCommand.parseAsync(
       ['b4a3c2d1-6e5f-8a7b-0c9d-2e1f4a3b6c5d', '--fallback-value', 'Test'],
       { from: 'user' },
@@ -146,9 +135,6 @@ describe('contact-properties update command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { updateContactPropertyCommand } = await import(
-      '../../../src/commands/contact-properties/update'
-    );
     await expectExit1(() =>
       updateContactPropertyCommand.parseAsync(
         ['b4a3c2d1-6e5f-8a7b-0c9d-2e1f4a3b6c5d'],
@@ -167,9 +153,6 @@ describe('contact-properties update command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { updateContactPropertyCommand } = await import(
-      '../../../src/commands/contact-properties/update'
-    );
     await expectExit1(() =>
       updateContactPropertyCommand.parseAsync(
         ['b4a3c2d1-6e5f-8a7b-0c9d-2e1f4a3b6c5d'],
@@ -189,9 +172,6 @@ describe('contact-properties update command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { updateContactPropertyCommand } = await import(
-      '../../../src/commands/contact-properties/update'
-    );
     await expectExit1(() =>
       updateContactPropertyCommand.parseAsync(
         ['b4a3c2d1-6e5f-8a7b-0c9d-2e1f4a3b6c5d', '--fallback-value', 'Test'],
@@ -214,9 +194,6 @@ describe('contact-properties update command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { updateContactPropertyCommand } = await import(
-      '../../../src/commands/contact-properties/update'
-    );
     await expectExit1(() =>
       updateContactPropertyCommand.parseAsync(
         ['nonexistent_id', '--fallback-value', 'Test'],
@@ -242,9 +219,6 @@ describe('contact-properties update command', () => {
       error: null,
     });
 
-    const { updateContactPropertyCommand } = await import(
-      '../../../src/commands/contact-properties/update'
-    );
     await updateContactPropertyCommand.parseAsync(
       ['b4a3c2d1-6e5f-8a7b-0c9d-2e1f4a3b6c5d', '--fallback-value', '42'],
       { from: 'user' },
@@ -269,9 +243,6 @@ describe('contact-properties update command', () => {
       error: null,
     });
 
-    const { updateContactPropertyCommand } = await import(
-      '../../../src/commands/contact-properties/update'
-    );
     await updateContactPropertyCommand.parseAsync(
       ['b4a3c2d1-6e5f-8a7b-0c9d-2e1f4a3b6c5d', '--fallback-value', 'Acme Corp'],
       { from: 'user' },
@@ -301,9 +272,6 @@ describe('contact-properties update command', () => {
       error: null,
     });
 
-    const { updateContactPropertyCommand } = await import(
-      '../../../src/commands/contact-properties/update'
-    );
     await expectExit1(() =>
       updateContactPropertyCommand.parseAsync(
         [

--- a/tests/commands/contacts/add-segment.test.ts
+++ b/tests/commands/contacts/add-segment.test.ts
@@ -1,3 +1,4 @@
+import { Command } from '@commander-js/extra-typings';
 import {
   afterEach,
   beforeEach,
@@ -7,6 +8,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { addContactSegmentCommand } from '../../../src/commands/contacts/add-segment';
 import {
   captureTestEnv,
   expectExit1,
@@ -61,9 +63,6 @@ describe('contacts add-segment command', () => {
   it('adds contact to segment by contact ID', async () => {
     spies = setupOutputSpies();
 
-    const { addContactSegmentCommand } = await import(
-      '../../../src/commands/contacts/add-segment'
-    );
     await addContactSegmentCommand.parseAsync(
       [
         'a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6',
@@ -82,9 +81,6 @@ describe('contacts add-segment command', () => {
   it('adds contact to segment by email', async () => {
     spies = setupOutputSpies();
 
-    const { addContactSegmentCommand } = await import(
-      '../../../src/commands/contacts/add-segment'
-    );
     await addContactSegmentCommand.parseAsync(
       [
         'jane@example.com',
@@ -102,9 +98,6 @@ describe('contacts add-segment command', () => {
   it('outputs JSON result when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { addContactSegmentCommand } = await import(
-      '../../../src/commands/contacts/add-segment'
-    );
     await addContactSegmentCommand.parseAsync(
       [
         'a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6',
@@ -124,9 +117,6 @@ describe('contacts add-segment command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { addContactSegmentCommand } = await import(
-      '../../../src/commands/contacts/add-segment'
-    );
     await expectExit1(() =>
       addContactSegmentCommand.parseAsync(
         ['a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'],
@@ -150,10 +140,6 @@ describe('contacts add-segment command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { Command } = await import('@commander-js/extra-typings');
-    const { addContactSegmentCommand } = await import(
-      '../../../src/commands/contacts/add-segment'
-    );
     const program = new Command()
       .option('--profile <name>')
       .option('--team <name>')
@@ -181,9 +167,6 @@ describe('contacts add-segment command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { addContactSegmentCommand } = await import(
-      '../../../src/commands/contacts/add-segment'
-    );
     await expectExit1(() =>
       addContactSegmentCommand.parseAsync(
         [
@@ -210,9 +193,6 @@ describe('contacts add-segment command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { addContactSegmentCommand } = await import(
-      '../../../src/commands/contacts/add-segment'
-    );
     await expectExit1(() =>
       addContactSegmentCommand.parseAsync(
         [

--- a/tests/commands/contacts/create.test.ts
+++ b/tests/commands/contacts/create.test.ts
@@ -1,3 +1,4 @@
+import { Command } from '@commander-js/extra-typings';
 import {
   afterEach,
   beforeEach,
@@ -7,6 +8,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { createContactCommand } from '../../../src/commands/contacts/create';
 import {
   captureTestEnv,
   expectExit1,
@@ -62,9 +64,6 @@ describe('contacts create command', () => {
   it('creates contact with --email flag', async () => {
     spies = setupOutputSpies();
 
-    const { createContactCommand } = await import(
-      '../../../src/commands/contacts/create'
-    );
     await createContactCommand.parseAsync(['--email', 'jane@example.com'], {
       from: 'user',
     });
@@ -77,9 +76,6 @@ describe('contacts create command', () => {
   it('outputs JSON id when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { createContactCommand } = await import(
-      '../../../src/commands/contacts/create'
-    );
     await createContactCommand.parseAsync(['--email', 'jane@example.com'], {
       from: 'user',
     });
@@ -93,9 +89,6 @@ describe('contacts create command', () => {
   it('passes --first-name and --last-name to SDK', async () => {
     spies = setupOutputSpies();
 
-    const { createContactCommand } = await import(
-      '../../../src/commands/contacts/create'
-    );
     await createContactCommand.parseAsync(
       [
         '--email',
@@ -116,9 +109,6 @@ describe('contacts create command', () => {
   it('passes --unsubscribed flag to SDK', async () => {
     spies = setupOutputSpies();
 
-    const { createContactCommand } = await import(
-      '../../../src/commands/contacts/create'
-    );
     await createContactCommand.parseAsync(
       ['--email', 'jane@example.com', '--unsubscribed'],
       { from: 'user' },
@@ -131,9 +121,6 @@ describe('contacts create command', () => {
   it('parses --properties JSON and passes to SDK', async () => {
     spies = setupOutputSpies();
 
-    const { createContactCommand } = await import(
-      '../../../src/commands/contacts/create'
-    );
     await createContactCommand.parseAsync(
       [
         '--email',
@@ -151,9 +138,6 @@ describe('contacts create command', () => {
   it('passes --segment-id (single) to SDK as segments array', async () => {
     spies = setupOutputSpies();
 
-    const { createContactCommand } = await import(
-      '../../../src/commands/contacts/create'
-    );
     await createContactCommand.parseAsync(
       [
         '--email',
@@ -173,9 +157,6 @@ describe('contacts create command', () => {
   it('passes multiple --segment-id values to SDK', async () => {
     spies = setupOutputSpies();
 
-    const { createContactCommand } = await import(
-      '../../../src/commands/contacts/create'
-    );
     await createContactCommand.parseAsync(
       [
         '--email',
@@ -209,10 +190,6 @@ describe('contacts create command', () => {
       .spyOn(process.stderr, 'write')
       .mockImplementation(() => true);
 
-    const { Command } = await import('@commander-js/extra-typings');
-    const { createContactCommand } = await import(
-      '../../../src/commands/contacts/create'
-    );
     const program = new Command()
       .option('--profile <name>')
       .option('--team <name>')
@@ -242,9 +219,6 @@ describe('contacts create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createContactCommand } = await import(
-      '../../../src/commands/contacts/create'
-    );
     await expectExit1(() =>
       createContactCommand.parseAsync([], { from: 'user' }),
     );
@@ -258,9 +232,6 @@ describe('contacts create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createContactCommand } = await import(
-      '../../../src/commands/contacts/create'
-    );
     await expectExit1(() =>
       createContactCommand.parseAsync(
         ['--email', 'jane@example.com', '--properties', 'not-json'],
@@ -279,9 +250,6 @@ describe('contacts create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createContactCommand } = await import(
-      '../../../src/commands/contacts/create'
-    );
     await expectExit1(() =>
       createContactCommand.parseAsync(['--email', 'jane@example.com'], {
         from: 'user',
@@ -303,9 +271,6 @@ describe('contacts create command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { createContactCommand } = await import(
-      '../../../src/commands/contacts/create'
-    );
     await expectExit1(() =>
       createContactCommand.parseAsync(['--email', 'jane@example.com'], {
         from: 'user',

--- a/tests/commands/contacts/delete.test.ts
+++ b/tests/commands/contacts/delete.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { deleteContactCommand } from '../../../src/commands/contacts/delete';
 import {
   captureTestEnv,
   expectExit1,
@@ -58,9 +59,6 @@ describe('contacts delete command', () => {
   it('deletes contact by ID with --yes', async () => {
     spies = setupOutputSpies();
 
-    const { deleteContactCommand } = await import(
-      '../../../src/commands/contacts/delete'
-    );
     await deleteContactCommand.parseAsync(
       ['a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6', '--yes'],
       {
@@ -77,9 +75,6 @@ describe('contacts delete command', () => {
   it('deletes contact by email with --yes', async () => {
     spies = setupOutputSpies();
 
-    const { deleteContactCommand } = await import(
-      '../../../src/commands/contacts/delete'
-    );
     await deleteContactCommand.parseAsync(['jane@example.com', '--yes'], {
       from: 'user',
     });
@@ -90,9 +85,6 @@ describe('contacts delete command', () => {
   it('outputs synthesized JSON result when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { deleteContactCommand } = await import(
-      '../../../src/commands/contacts/delete'
-    );
     await deleteContactCommand.parseAsync(
       ['a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6', '--yes'],
       {
@@ -112,9 +104,6 @@ describe('contacts delete command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { deleteContactCommand } = await import(
-      '../../../src/commands/contacts/delete'
-    );
     await expectExit1(() =>
       deleteContactCommand.parseAsync(
         ['a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'],
@@ -131,9 +120,6 @@ describe('contacts delete command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { deleteContactCommand } = await import(
-      '../../../src/commands/contacts/delete'
-    );
     await expectExit1(() =>
       deleteContactCommand.parseAsync(
         ['a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'],
@@ -151,9 +137,6 @@ describe('contacts delete command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { deleteContactCommand } = await import(
-      '../../../src/commands/contacts/delete'
-    );
     await expectExit1(() =>
       deleteContactCommand.parseAsync(
         ['a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6', '--yes'],
@@ -178,9 +161,6 @@ describe('contacts delete command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { deleteContactCommand } = await import(
-      '../../../src/commands/contacts/delete'
-    );
     await expectExit1(() =>
       deleteContactCommand.parseAsync(['nonexistent_id', '--yes'], {
         from: 'user',

--- a/tests/commands/contacts/get.test.ts
+++ b/tests/commands/contacts/get.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { getContactCommand } from '../../../src/commands/contacts/get';
 import {
   captureTestEnv,
   expectExit1,
@@ -63,9 +64,6 @@ describe('contacts get command', () => {
   it('calls SDK with contact ID', async () => {
     spies = setupOutputSpies();
 
-    const { getContactCommand } = await import(
-      '../../../src/commands/contacts/get'
-    );
     await getContactCommand.parseAsync(
       ['a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'],
       { from: 'user' },
@@ -80,9 +78,6 @@ describe('contacts get command', () => {
   it('calls SDK with email address', async () => {
     spies = setupOutputSpies();
 
-    const { getContactCommand } = await import(
-      '../../../src/commands/contacts/get'
-    );
     await getContactCommand.parseAsync(['jane@example.com'], { from: 'user' });
 
     expect(mockGet.mock.calls[0][0]).toBe('jane@example.com');
@@ -91,9 +86,6 @@ describe('contacts get command', () => {
   it('outputs JSON when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { getContactCommand } = await import(
-      '../../../src/commands/contacts/get'
-    );
     await getContactCommand.parseAsync(
       ['a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'],
       { from: 'user' },
@@ -112,9 +104,6 @@ describe('contacts get command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { getContactCommand } = await import(
-      '../../../src/commands/contacts/get'
-    );
     await expectExit1(() =>
       getContactCommand.parseAsync(['a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'], {
         from: 'user',
@@ -136,9 +125,6 @@ describe('contacts get command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { getContactCommand } = await import(
-      '../../../src/commands/contacts/get'
-    );
     await expectExit1(() =>
       getContactCommand.parseAsync(['nonexistent_id'], { from: 'user' }),
     );

--- a/tests/commands/contacts/imports/create.test.ts
+++ b/tests/commands/contacts/imports/create.test.ts
@@ -10,6 +10,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { createContactImportCommand } from '../../../../src/commands/contacts/imports/create';
 import {
   captureTestEnv,
   expectExit1,
@@ -71,9 +72,6 @@ describe('contacts imports create command', () => {
   it('reads the CSV file and passes it to the SDK as a File', async () => {
     spies = setupOutputSpies();
 
-    const { createContactImportCommand } = await import(
-      '../../../../src/commands/contacts/imports/create'
-    );
     await createContactImportCommand.parseAsync(['--file', tmpFile], {
       from: 'user',
     });
@@ -87,9 +85,6 @@ describe('contacts imports create command', () => {
   it('outputs JSON contact_import id when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { createContactImportCommand } = await import(
-      '../../../../src/commands/contacts/imports/create'
-    );
     await createContactImportCommand.parseAsync(['--file', tmpFile], {
       from: 'user',
     });
@@ -103,9 +98,6 @@ describe('contacts imports create command', () => {
   it('parses --column-map JSON and passes it to the SDK', async () => {
     spies = setupOutputSpies();
 
-    const { createContactImportCommand } = await import(
-      '../../../../src/commands/contacts/imports/create'
-    );
     await createContactImportCommand.parseAsync(
       [
         '--file',
@@ -126,9 +118,6 @@ describe('contacts imports create command', () => {
   it('passes --on-conflict to the SDK', async () => {
     spies = setupOutputSpies();
 
-    const { createContactImportCommand } = await import(
-      '../../../../src/commands/contacts/imports/create'
-    );
     await createContactImportCommand.parseAsync(
       ['--file', tmpFile, '--on-conflict', 'skip'],
       { from: 'user' },
@@ -141,9 +130,6 @@ describe('contacts imports create command', () => {
   it('maps multiple --segment-id values to a segments array', async () => {
     spies = setupOutputSpies();
 
-    const { createContactImportCommand } = await import(
-      '../../../../src/commands/contacts/imports/create'
-    );
     await createContactImportCommand.parseAsync(
       [
         '--file',
@@ -166,9 +152,6 @@ describe('contacts imports create command', () => {
   it('parses --topics JSON and passes it to the SDK', async () => {
     spies = setupOutputSpies();
 
-    const { createContactImportCommand } = await import(
-      '../../../../src/commands/contacts/imports/create'
-    );
     await createContactImportCommand.parseAsync(
       [
         '--file',
@@ -190,9 +173,6 @@ describe('contacts imports create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createContactImportCommand } = await import(
-      '../../../../src/commands/contacts/imports/create'
-    );
     await expectExit1(() =>
       createContactImportCommand.parseAsync([], { from: 'user' }),
     );
@@ -206,9 +186,6 @@ describe('contacts imports create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createContactImportCommand } = await import(
-      '../../../../src/commands/contacts/imports/create'
-    );
     await expectExit1(() =>
       createContactImportCommand.parseAsync(
         ['--file', '/tmp/nonexistent-resend-contacts.csv'],
@@ -225,9 +202,6 @@ describe('contacts imports create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createContactImportCommand } = await import(
-      '../../../../src/commands/contacts/imports/create'
-    );
     await expectExit1(() =>
       createContactImportCommand.parseAsync(
         ['--file', tmpFile, '--column-map', 'not-json'],
@@ -244,9 +218,6 @@ describe('contacts imports create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createContactImportCommand } = await import(
-      '../../../../src/commands/contacts/imports/create'
-    );
     await expectExit1(() =>
       createContactImportCommand.parseAsync(
         ['--file', tmpFile, '--column-map', '["email"]'],
@@ -270,9 +241,6 @@ describe('contacts imports create command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { createContactImportCommand } = await import(
-      '../../../../src/commands/contacts/imports/create'
-    );
     await expectExit1(() =>
       createContactImportCommand.parseAsync(['--file', tmpFile], {
         from: 'user',

--- a/tests/commands/contacts/imports/get.test.ts
+++ b/tests/commands/contacts/imports/get.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { getContactImportCommand } from '../../../../src/commands/contacts/imports/get';
 import {
   captureTestEnv,
   expectExit1,
@@ -60,9 +61,6 @@ describe('contacts imports get command', () => {
   it('calls SDK imports.get with the id and outputs JSON', async () => {
     spies = setupOutputSpies();
 
-    const { getContactImportCommand } = await import(
-      '../../../../src/commands/contacts/imports/get'
-    );
     await getContactImportCommand.parseAsync(
       ['479e3145-dd38-476b-932c-529ceb705947'],
       { from: 'user' },
@@ -89,9 +87,6 @@ describe('contacts imports get command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { getContactImportCommand } = await import(
-      '../../../../src/commands/contacts/imports/get'
-    );
     await expectExit1(() =>
       getContactImportCommand.parseAsync(
         ['479e3145-dd38-476b-932c-529ceb705947'],

--- a/tests/commands/contacts/imports/list.test.ts
+++ b/tests/commands/contacts/imports/list.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { listContactImportsCommand } from '../../../../src/commands/contacts/imports/list';
 import {
   captureTestEnv,
   expectExit1,
@@ -60,9 +61,6 @@ describe('contacts imports list command', () => {
   it('calls SDK imports.list with the default limit and outputs JSON', async () => {
     spies = setupOutputSpies();
 
-    const { listContactImportsCommand } = await import(
-      '../../../../src/commands/contacts/imports/list'
-    );
     await listContactImportsCommand.parseAsync([], { from: 'user' });
 
     expect(mockList).toHaveBeenCalledWith({ limit: 10 });
@@ -75,9 +73,6 @@ describe('contacts imports list command', () => {
   it('passes --status filter to the SDK', async () => {
     spies = setupOutputSpies();
 
-    const { listContactImportsCommand } = await import(
-      '../../../../src/commands/contacts/imports/list'
-    );
     await listContactImportsCommand.parseAsync(['--status', 'completed'], {
       from: 'user',
     });
@@ -88,9 +83,6 @@ describe('contacts imports list command', () => {
   it('passes --after cursor to the SDK', async () => {
     spies = setupOutputSpies();
 
-    const { listContactImportsCommand } = await import(
-      '../../../../src/commands/contacts/imports/list'
-    );
     await listContactImportsCommand.parseAsync(
       ['--after', '479e3145-dd38-476b-932c-529ceb705947'],
       { from: 'user' },
@@ -107,9 +99,6 @@ describe('contacts imports list command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { listContactImportsCommand } = await import(
-      '../../../../src/commands/contacts/imports/list'
-    );
     await expectExit1(() =>
       listContactImportsCommand.parseAsync(['--limit', '999'], {
         from: 'user',
@@ -126,9 +115,6 @@ describe('contacts imports list command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { listContactImportsCommand } = await import(
-      '../../../../src/commands/contacts/imports/list'
-    );
     await expectExit1(() =>
       listContactImportsCommand.parseAsync([], { from: 'user' }),
     );

--- a/tests/commands/contacts/list.test.ts
+++ b/tests/commands/contacts/list.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { listContactsCommand } from '../../../src/commands/contacts/list';
 import {
   captureTestEnv,
   expectExit1,
@@ -67,9 +68,6 @@ describe('contacts list command', () => {
   it('calls SDK with default limit of 10', async () => {
     spies = setupOutputSpies();
 
-    const { listContactsCommand } = await import(
-      '../../../src/commands/contacts/list'
-    );
     await listContactsCommand.parseAsync([], { from: 'user' });
 
     expect(mockList).toHaveBeenCalledTimes(1);
@@ -80,9 +78,6 @@ describe('contacts list command', () => {
   it('calls SDK with custom --limit', async () => {
     spies = setupOutputSpies();
 
-    const { listContactsCommand } = await import(
-      '../../../src/commands/contacts/list'
-    );
     await listContactsCommand.parseAsync(['--limit', '25'], { from: 'user' });
 
     const args = mockList.mock.calls[0][0] as Record<string, unknown>;
@@ -92,9 +87,6 @@ describe('contacts list command', () => {
   it('calls SDK with --after cursor', async () => {
     spies = setupOutputSpies();
 
-    const { listContactsCommand } = await import(
-      '../../../src/commands/contacts/list'
-    );
     await listContactsCommand.parseAsync(['--after', 'cursor_xyz'], {
       from: 'user',
     });
@@ -106,9 +98,6 @@ describe('contacts list command', () => {
   it('outputs JSON list when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { listContactsCommand } = await import(
-      '../../../src/commands/contacts/list'
-    );
     await listContactsCommand.parseAsync([], { from: 'user' });
 
     const output = spies.logSpy.mock.calls[0][0] as string;
@@ -123,9 +112,6 @@ describe('contacts list command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { listContactsCommand } = await import(
-      '../../../src/commands/contacts/list'
-    );
     await expectExit1(() =>
       listContactsCommand.parseAsync(['--limit', '0'], { from: 'user' }),
     );
@@ -141,9 +127,6 @@ describe('contacts list command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { listContactsCommand } = await import(
-      '../../../src/commands/contacts/list'
-    );
     await expectExit1(() =>
       listContactsCommand.parseAsync([], { from: 'user' }),
     );
@@ -163,9 +146,6 @@ describe('contacts list command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { listContactsCommand } = await import(
-      '../../../src/commands/contacts/list'
-    );
     await expectExit1(() =>
       listContactsCommand.parseAsync([], { from: 'user' }),
     );

--- a/tests/commands/contacts/remove-segment.test.ts
+++ b/tests/commands/contacts/remove-segment.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { removeContactSegmentCommand } from '../../../src/commands/contacts/remove-segment';
 import {
   captureTestEnv,
   expectExit1,
@@ -56,9 +57,6 @@ describe('contacts remove-segment command', () => {
   it('removes contact from segment by contact ID', async () => {
     spies = setupOutputSpies();
 
-    const { removeContactSegmentCommand } = await import(
-      '../../../src/commands/contacts/remove-segment'
-    );
     await removeContactSegmentCommand.parseAsync(
       [
         'a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6',
@@ -76,9 +74,6 @@ describe('contacts remove-segment command', () => {
   it('removes contact from segment by email', async () => {
     spies = setupOutputSpies();
 
-    const { removeContactSegmentCommand } = await import(
-      '../../../src/commands/contacts/remove-segment'
-    );
     await removeContactSegmentCommand.parseAsync(
       ['jane@example.com', '7b1e0a3d-4c5f-4e8a-9b2d-1a3c5e7f9b2d'],
       { from: 'user' },
@@ -92,9 +87,6 @@ describe('contacts remove-segment command', () => {
   it('outputs JSON result when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { removeContactSegmentCommand } = await import(
-      '../../../src/commands/contacts/remove-segment'
-    );
     await removeContactSegmentCommand.parseAsync(
       [
         'a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6',
@@ -116,9 +108,6 @@ describe('contacts remove-segment command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { removeContactSegmentCommand } = await import(
-      '../../../src/commands/contacts/remove-segment'
-    );
     await expectExit1(() =>
       removeContactSegmentCommand.parseAsync(
         [
@@ -146,9 +135,6 @@ describe('contacts remove-segment command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { removeContactSegmentCommand } = await import(
-      '../../../src/commands/contacts/remove-segment'
-    );
     await expectExit1(() =>
       removeContactSegmentCommand.parseAsync(
         [

--- a/tests/commands/contacts/segments.test.ts
+++ b/tests/commands/contacts/segments.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { listContactSegmentsCommand } from '../../../src/commands/contacts/segments';
 import {
   captureTestEnv,
   expectExit1,
@@ -66,9 +67,6 @@ describe('contacts segments command', () => {
   it('lists segments by contact ID', async () => {
     spies = setupOutputSpies();
 
-    const { listContactSegmentsCommand } = await import(
-      '../../../src/commands/contacts/segments'
-    );
     await listContactSegmentsCommand.parseAsync(
       ['a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'],
       {
@@ -85,9 +83,6 @@ describe('contacts segments command', () => {
   it('lists segments by contact email', async () => {
     spies = setupOutputSpies();
 
-    const { listContactSegmentsCommand } = await import(
-      '../../../src/commands/contacts/segments'
-    );
     await listContactSegmentsCommand.parseAsync(['jane@example.com'], {
       from: 'user',
     });
@@ -100,9 +95,6 @@ describe('contacts segments command', () => {
   it('outputs JSON list when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { listContactSegmentsCommand } = await import(
-      '../../../src/commands/contacts/segments'
-    );
     await listContactSegmentsCommand.parseAsync(
       ['a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'],
       {
@@ -123,9 +115,6 @@ describe('contacts segments command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { listContactSegmentsCommand } = await import(
-      '../../../src/commands/contacts/segments'
-    );
     await expectExit1(() =>
       listContactSegmentsCommand.parseAsync(
         ['a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'],
@@ -150,9 +139,6 @@ describe('contacts segments command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { listContactSegmentsCommand } = await import(
-      '../../../src/commands/contacts/segments'
-    );
     await expectExit1(() =>
       listContactSegmentsCommand.parseAsync(
         ['a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'],

--- a/tests/commands/contacts/topics.test.ts
+++ b/tests/commands/contacts/topics.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { listContactTopicsCommand } from '../../../src/commands/contacts/topics';
 import {
   captureTestEnv,
   expectExit1,
@@ -67,9 +68,6 @@ describe('contacts topics command', () => {
   it('lists topics by contact ID', async () => {
     spies = setupOutputSpies();
 
-    const { listContactTopicsCommand } = await import(
-      '../../../src/commands/contacts/topics'
-    );
     await listContactTopicsCommand.parseAsync(
       ['a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'],
       {
@@ -85,9 +83,6 @@ describe('contacts topics command', () => {
   it('lists topics by contact email', async () => {
     spies = setupOutputSpies();
 
-    const { listContactTopicsCommand } = await import(
-      '../../../src/commands/contacts/topics'
-    );
     await listContactTopicsCommand.parseAsync(['jane@example.com'], {
       from: 'user',
     });
@@ -99,9 +94,6 @@ describe('contacts topics command', () => {
   it('outputs JSON list when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { listContactTopicsCommand } = await import(
-      '../../../src/commands/contacts/topics'
-    );
     await listContactTopicsCommand.parseAsync(
       ['a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'],
       {
@@ -123,9 +115,6 @@ describe('contacts topics command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { listContactTopicsCommand } = await import(
-      '../../../src/commands/contacts/topics'
-    );
     await expectExit1(() =>
       listContactTopicsCommand.parseAsync(
         ['a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'],
@@ -148,9 +137,6 @@ describe('contacts topics command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { listContactTopicsCommand } = await import(
-      '../../../src/commands/contacts/topics'
-    );
     await expectExit1(() =>
       listContactTopicsCommand.parseAsync(
         ['a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'],

--- a/tests/commands/contacts/update-topics.test.ts
+++ b/tests/commands/contacts/update-topics.test.ts
@@ -1,3 +1,4 @@
+import { Command } from '@commander-js/extra-typings';
 import {
   afterEach,
   beforeEach,
@@ -7,6 +8,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { updateContactTopicsCommand } from '../../../src/commands/contacts/update-topics';
 import {
   captureTestEnv,
   expectExit1,
@@ -61,9 +63,6 @@ describe('contacts update-topics command', () => {
   it('updates topics by contact ID', async () => {
     spies = setupOutputSpies();
 
-    const { updateContactTopicsCommand } = await import(
-      '../../../src/commands/contacts/update-topics'
-    );
     await updateContactTopicsCommand.parseAsync(
       [
         'a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6',
@@ -82,9 +81,6 @@ describe('contacts update-topics command', () => {
   it('updates topics by contact email', async () => {
     spies = setupOutputSpies();
 
-    const { updateContactTopicsCommand } = await import(
-      '../../../src/commands/contacts/update-topics'
-    );
     await updateContactTopicsCommand.parseAsync(
       [
         'jane@example.com',
@@ -102,9 +98,6 @@ describe('contacts update-topics command', () => {
   it('passes multiple topics in array', async () => {
     spies = setupOutputSpies();
 
-    const { updateContactTopicsCommand } = await import(
-      '../../../src/commands/contacts/update-topics'
-    );
     await updateContactTopicsCommand.parseAsync(
       [
         'a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6',
@@ -121,9 +114,6 @@ describe('contacts update-topics command', () => {
   it('outputs JSON result when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { updateContactTopicsCommand } = await import(
-      '../../../src/commands/contacts/update-topics'
-    );
     await updateContactTopicsCommand.parseAsync(
       [
         'a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6',
@@ -143,9 +133,6 @@ describe('contacts update-topics command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { updateContactTopicsCommand } = await import(
-      '../../../src/commands/contacts/update-topics'
-    );
     await expectExit1(() =>
       updateContactTopicsCommand.parseAsync(
         ['a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'],
@@ -171,10 +158,6 @@ describe('contacts update-topics command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { Command } = await import('@commander-js/extra-typings');
-    const { updateContactTopicsCommand } = await import(
-      '../../../src/commands/contacts/update-topics'
-    );
     const program = new Command()
       .option('--profile <name>')
       .option('--team <name>')
@@ -200,9 +183,6 @@ describe('contacts update-topics command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { updateContactTopicsCommand } = await import(
-      '../../../src/commands/contacts/update-topics'
-    );
     await expectExit1(() =>
       updateContactTopicsCommand.parseAsync(
         ['a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6', '--topics', 'not-json'],
@@ -219,9 +199,6 @@ describe('contacts update-topics command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { updateContactTopicsCommand } = await import(
-      '../../../src/commands/contacts/update-topics'
-    );
     await expectExit1(() =>
       updateContactTopicsCommand.parseAsync(
         ['a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6', '--topics', '{"id":"t1"}'],
@@ -240,9 +217,6 @@ describe('contacts update-topics command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { updateContactTopicsCommand } = await import(
-      '../../../src/commands/contacts/update-topics'
-    );
     await expectExit1(() =>
       updateContactTopicsCommand.parseAsync(
         [
@@ -269,9 +243,6 @@ describe('contacts update-topics command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { updateContactTopicsCommand } = await import(
-      '../../../src/commands/contacts/update-topics'
-    );
     await expectExit1(() =>
       updateContactTopicsCommand.parseAsync(
         [

--- a/tests/commands/contacts/update.test.ts
+++ b/tests/commands/contacts/update.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { updateContactCommand } from '../../../src/commands/contacts/update';
 import {
   captureTestEnv,
   expectExit1,
@@ -57,9 +58,6 @@ describe('contacts update command', () => {
   it('updates contact by ID with --unsubscribed', async () => {
     spies = setupOutputSpies();
 
-    const { updateContactCommand } = await import(
-      '../../../src/commands/contacts/update'
-    );
     await updateContactCommand.parseAsync(
       ['a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6', '--unsubscribed'],
       { from: 'user' },
@@ -74,9 +72,6 @@ describe('contacts update command', () => {
   it('updates contact by email with --no-unsubscribed', async () => {
     spies = setupOutputSpies();
 
-    const { updateContactCommand } = await import(
-      '../../../src/commands/contacts/update'
-    );
     await updateContactCommand.parseAsync(
       ['jane@example.com', '--no-unsubscribed'],
       { from: 'user' },
@@ -90,9 +85,6 @@ describe('contacts update command', () => {
   it('parses --properties JSON and passes to SDK', async () => {
     spies = setupOutputSpies();
 
-    const { updateContactCommand } = await import(
-      '../../../src/commands/contacts/update'
-    );
     await updateContactCommand.parseAsync(
       [
         'a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6',
@@ -109,9 +101,6 @@ describe('contacts update command', () => {
   it('does not include unsubscribed when neither flag is passed', async () => {
     spies = setupOutputSpies();
 
-    const { updateContactCommand } = await import(
-      '../../../src/commands/contacts/update'
-    );
     await updateContactCommand.parseAsync(
       ['a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'],
       { from: 'user' },
@@ -124,9 +113,6 @@ describe('contacts update command', () => {
   it('outputs JSON result when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { updateContactCommand } = await import(
-      '../../../src/commands/contacts/update'
-    );
     await updateContactCommand.parseAsync(
       ['a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6', '--unsubscribed'],
       { from: 'user' },
@@ -143,9 +129,6 @@ describe('contacts update command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { updateContactCommand } = await import(
-      '../../../src/commands/contacts/update'
-    );
     await expectExit1(() =>
       updateContactCommand.parseAsync(
         ['a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6', '--properties', 'bad-json'],
@@ -164,9 +147,6 @@ describe('contacts update command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { updateContactCommand } = await import(
-      '../../../src/commands/contacts/update'
-    );
     await expectExit1(() =>
       updateContactCommand.parseAsync(
         ['a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6', '--unsubscribed'],
@@ -191,9 +171,6 @@ describe('contacts update command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { updateContactCommand } = await import(
-      '../../../src/commands/contacts/update'
-    );
     await expectExit1(() =>
       updateContactCommand.parseAsync(['nonexistent_id', '--unsubscribed'], {
         from: 'user',

--- a/tests/commands/docs.test.ts
+++ b/tests/commands/docs.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { docsCommand } from '../../src/commands/docs';
 import * as browser from '../../src/lib/browser';
 
 describe('resend docs command', () => {
@@ -11,8 +12,6 @@ describe('resend docs command', () => {
   });
 
   it('opens documentation URL in browser', async () => {
-    const { docsCommand } = await import('../../src/commands/docs');
-
     await docsCommand.parseAsync([], { from: 'user' });
 
     expect(browser.openInBrowserOrLog).toHaveBeenCalledTimes(1);

--- a/tests/commands/doctor.test.ts
+++ b/tests/commands/doctor.test.ts
@@ -1,3 +1,4 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Command } from '@commander-js/extra-typings';
@@ -10,6 +11,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { doctorCommand } from '../../src/commands/doctor';
 import {
   captureTestEnv,
   expectExit1,
@@ -43,7 +45,6 @@ vi.mock('resend', () => ({
  * matching the real CLI structure in src/cli.ts.
  */
 async function createDoctorProgram() {
-  const { doctorCommand } = await import('../../src/commands/doctor');
   const program = new Command()
     .name('resend')
     .option('--json', 'Force JSON output')
@@ -263,9 +264,6 @@ describe('doctor command — expired OAuth grant', () => {
   let tmpDir: string;
 
   beforeEach(async () => {
-    const { mkdirSync, writeFileSync } = await import('node:fs');
-    const { tmpdir } = await import('node:os');
-    const { join } = await import('node:path');
     tmpDir = join(
       tmpdir(),
       `resend-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
@@ -297,7 +295,6 @@ describe('doctor command — expired OAuth grant', () => {
   });
 
   afterEach(async () => {
-    const { rmSync } = await import('node:fs');
     restoreEnv();
     rmSync(tmpDir, { recursive: true, force: true });
     spies = undefined;
@@ -363,9 +360,6 @@ describe('doctor command — valid OAuth grant', () => {
   let tmpDir: string;
 
   beforeEach(async () => {
-    const { mkdirSync, writeFileSync } = await import('node:fs');
-    const { tmpdir } = await import('node:os');
-    const { join } = await import('node:path');
     tmpDir = join(
       tmpdir(),
       `resend-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
@@ -398,7 +392,6 @@ describe('doctor command — valid OAuth grant', () => {
   });
 
   afterEach(async () => {
-    const { rmSync } = await import('node:fs');
     restoreEnv();
     rmSync(tmpDir, { recursive: true, force: true });
     spies = undefined;

--- a/tests/commands/domains/claim/create.test.ts
+++ b/tests/commands/domains/claim/create.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { claimCreateCommand } from '../../../../src/commands/domains/claim/create';
 import {
   captureTestEnv,
   expectExit1,
@@ -70,9 +71,6 @@ describe('domains claim create command', () => {
   it('calls SDK claims.create and outputs the domain_claim as JSON', async () => {
     spies = setupOutputSpies();
 
-    const { claimCreateCommand } = await import(
-      '../../../../src/commands/domains/claim/create'
-    );
     await claimCreateCommand.parseAsync(['--name', 'example.com'], {
       from: 'user',
     });
@@ -91,9 +89,6 @@ describe('domains claim create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { claimCreateCommand } = await import(
-      '../../../../src/commands/domains/claim/create'
-    );
     await expectExit1(() =>
       claimCreateCommand.parseAsync([], { from: 'user' }),
     );
@@ -104,9 +99,6 @@ describe('domains claim create command', () => {
 
   it('passes customReturnPath when --custom-return-path is set', async () => {
     spies = setupOutputSpies();
-    const { claimCreateCommand } = await import(
-      '../../../../src/commands/domains/claim/create'
-    );
     await claimCreateCommand.parseAsync(
       ['--name', 'example.com', '--custom-return-path', 'bounce'],
       { from: 'user' },
@@ -119,9 +111,6 @@ describe('domains claim create command', () => {
 
   it('passes openTracking=true with --open-tracking', async () => {
     spies = setupOutputSpies();
-    const { claimCreateCommand } = await import(
-      '../../../../src/commands/domains/claim/create'
-    );
     await claimCreateCommand.parseAsync(
       ['--name', 'example.com', '--open-tracking'],
       { from: 'user' },
@@ -134,9 +123,6 @@ describe('domains claim create command', () => {
 
   it('passes openTracking=false with --no-open-tracking', async () => {
     spies = setupOutputSpies();
-    const { claimCreateCommand } = await import(
-      '../../../../src/commands/domains/claim/create'
-    );
     await claimCreateCommand.parseAsync(
       ['--name', 'example.com', '--no-open-tracking'],
       { from: 'user' },
@@ -149,9 +135,6 @@ describe('domains claim create command', () => {
 
   it('passes clickTracking=true with --click-tracking', async () => {
     spies = setupOutputSpies();
-    const { claimCreateCommand } = await import(
-      '../../../../src/commands/domains/claim/create'
-    );
     await claimCreateCommand.parseAsync(
       ['--name', 'example.com', '--click-tracking'],
       { from: 'user' },
@@ -164,9 +147,6 @@ describe('domains claim create command', () => {
 
   it('passes clickTracking=false with --no-click-tracking', async () => {
     spies = setupOutputSpies();
-    const { claimCreateCommand } = await import(
-      '../../../../src/commands/domains/claim/create'
-    );
     await claimCreateCommand.parseAsync(
       ['--name', 'example.com', '--no-click-tracking'],
       { from: 'user' },
@@ -188,9 +168,6 @@ describe('domains claim create command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { claimCreateCommand } = await import(
-      '../../../../src/commands/domains/claim/create'
-    );
     await expectExit1(() =>
       claimCreateCommand.parseAsync(['--name', 'example.com'], {
         from: 'user',

--- a/tests/commands/domains/claim/get.test.ts
+++ b/tests/commands/domains/claim/get.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { claimGetCommand } from '../../../../src/commands/domains/claim/get';
 import {
   captureTestEnv,
   expectExit1,
@@ -70,9 +71,6 @@ describe('domains claim get command', () => {
   it('calls SDK claims.get with the domain id and outputs JSON', async () => {
     spies = setupOutputSpies();
 
-    const { claimGetCommand } = await import(
-      '../../../../src/commands/domains/claim/get'
-    );
     await claimGetCommand.parseAsync(['placeholder-id'], { from: 'user' });
 
     expect(mockGet).toHaveBeenCalledWith('placeholder-id');
@@ -93,9 +91,6 @@ describe('domains claim get command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { claimGetCommand } = await import(
-      '../../../../src/commands/domains/claim/get'
-    );
     await expectExit1(() =>
       claimGetCommand.parseAsync(['placeholder-id'], { from: 'user' }),
     );

--- a/tests/commands/domains/claim/verify.test.ts
+++ b/tests/commands/domains/claim/verify.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { claimVerifyCommand } from '../../../../src/commands/domains/claim/verify';
 import {
   captureTestEnv,
   expectExit1,
@@ -70,9 +71,6 @@ describe('domains claim verify command', () => {
   it('calls SDK claims.verify with the domain id and outputs JSON', async () => {
     spies = setupOutputSpies();
 
-    const { claimVerifyCommand } = await import(
-      '../../../../src/commands/domains/claim/verify'
-    );
     await claimVerifyCommand.parseAsync(['placeholder-id'], { from: 'user' });
 
     expect(mockVerify).toHaveBeenCalledWith('placeholder-id');
@@ -93,9 +91,6 @@ describe('domains claim verify command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { claimVerifyCommand } = await import(
-      '../../../../src/commands/domains/claim/verify'
-    );
     await expectExit1(() =>
       claimVerifyCommand.parseAsync(['placeholder-id'], { from: 'user' }),
     );

--- a/tests/commands/domains/create.test.ts
+++ b/tests/commands/domains/create.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { createDomainCommand } from '../../../src/commands/domains/create';
 import {
   captureTestEnv,
   expectExit1,
@@ -72,9 +73,6 @@ describe('domains create command', () => {
   it('creates domain with --name flag', async () => {
     spies = setupOutputSpies();
 
-    const { createDomainCommand } = await import(
-      '../../../src/commands/domains/create'
-    );
     await createDomainCommand.parseAsync(['--name', 'example.com'], {
       from: 'user',
     });
@@ -87,9 +85,6 @@ describe('domains create command', () => {
   it('passes region and tls flags to SDK', async () => {
     spies = setupOutputSpies();
 
-    const { createDomainCommand } = await import(
-      '../../../src/commands/domains/create'
-    );
     await createDomainCommand.parseAsync(
       ['--name', 'example.com', '--region', 'eu-west-1', '--tls', 'enforced'],
       { from: 'user' },
@@ -103,9 +98,6 @@ describe('domains create command', () => {
   it('passes trackingSubdomain when --tracking-subdomain is set', async () => {
     spies = setupOutputSpies();
 
-    const { createDomainCommand } = await import(
-      '../../../src/commands/domains/create'
-    );
     await createDomainCommand.parseAsync(
       ['--name', 'example.com', '--tracking-subdomain', 'track'],
       { from: 'user' },
@@ -118,9 +110,6 @@ describe('domains create command', () => {
   it('passes customReturnPath when --custom-return-path is set', async () => {
     spies = setupOutputSpies();
 
-    const { createDomainCommand } = await import(
-      '../../../src/commands/domains/create'
-    );
     await createDomainCommand.parseAsync(
       ['--name', 'example.com', '--custom-return-path', 'bounce'],
       { from: 'user' },
@@ -133,9 +122,6 @@ describe('domains create command', () => {
   it('forwards an explicit empty --custom-return-path to the API', async () => {
     spies = setupOutputSpies();
 
-    const { createDomainCommand } = await import(
-      '../../../src/commands/domains/create'
-    );
     await createDomainCommand.parseAsync(
       ['--name', 'example.com', '--custom-return-path', ''],
       { from: 'user' },
@@ -148,9 +134,6 @@ describe('domains create command', () => {
   it('omits customReturnPath when flag is absent', async () => {
     spies = setupOutputSpies();
 
-    const { createDomainCommand } = await import(
-      '../../../src/commands/domains/create'
-    );
     await createDomainCommand.parseAsync(['--name', 'example.com'], {
       from: 'user',
     });
@@ -162,9 +145,6 @@ describe('domains create command', () => {
   it('passes receiving capability when --receiving flag is set', async () => {
     spies = setupOutputSpies();
 
-    const { createDomainCommand } = await import(
-      '../../../src/commands/domains/create'
-    );
     await createDomainCommand.parseAsync(
       ['--name', 'example.com', '--receiving'],
       { from: 'user' },
@@ -177,9 +157,6 @@ describe('domains create command', () => {
   it('outputs JSON result when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { createDomainCommand } = await import(
-      '../../../src/commands/domains/create'
-    );
     await createDomainCommand.parseAsync(['--name', 'example.com'], {
       from: 'user',
     });
@@ -195,9 +172,6 @@ describe('domains create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createDomainCommand } = await import(
-      '../../../src/commands/domains/create'
-    );
     await expectExit1(() =>
       createDomainCommand.parseAsync([], { from: 'user' }),
     );
@@ -213,9 +187,6 @@ describe('domains create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createDomainCommand } = await import(
-      '../../../src/commands/domains/create'
-    );
     await expectExit1(() =>
       createDomainCommand.parseAsync(['--name', 'example.com'], {
         from: 'user',
@@ -237,9 +208,6 @@ describe('domains create command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { createDomainCommand } = await import(
-      '../../../src/commands/domains/create'
-    );
     await expectExit1(() =>
       createDomainCommand.parseAsync(['--name', 'example.com'], {
         from: 'user',

--- a/tests/commands/domains/delete.test.ts
+++ b/tests/commands/domains/delete.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { deleteDomainCommand } from '../../../src/commands/domains/delete';
 import {
   captureTestEnv,
   expectExit1,
@@ -54,9 +55,6 @@ describe('domains delete command', () => {
   it('deletes domain with --yes flag', async () => {
     spies = setupOutputSpies();
 
-    const { deleteDomainCommand } = await import(
-      '../../../src/commands/domains/delete'
-    );
     await deleteDomainCommand.parseAsync(['test-domain-id', '--yes'], {
       from: 'user',
     });
@@ -67,9 +65,6 @@ describe('domains delete command', () => {
   it('outputs deleted domain JSON on success', async () => {
     spies = setupOutputSpies();
 
-    const { deleteDomainCommand } = await import(
-      '../../../src/commands/domains/delete'
-    );
     await deleteDomainCommand.parseAsync(['test-domain-id', '--yes'], {
       from: 'user',
     });
@@ -85,9 +80,6 @@ describe('domains delete command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { deleteDomainCommand } = await import(
-      '../../../src/commands/domains/delete'
-    );
     await expectExit1(() =>
       deleteDomainCommand.parseAsync(['test-domain-id'], { from: 'user' }),
     );
@@ -101,9 +93,6 @@ describe('domains delete command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { deleteDomainCommand } = await import(
-      '../../../src/commands/domains/delete'
-    );
     await expectExit1(() =>
       deleteDomainCommand.parseAsync(['test-domain-id'], { from: 'user' }),
     );
@@ -118,9 +107,6 @@ describe('domains delete command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { deleteDomainCommand } = await import(
-      '../../../src/commands/domains/delete'
-    );
     await expectExit1(() =>
       deleteDomainCommand.parseAsync(['test-domain-id', '--yes'], {
         from: 'user',
@@ -142,9 +128,6 @@ describe('domains delete command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { deleteDomainCommand } = await import(
-      '../../../src/commands/domains/delete'
-    );
     await expectExit1(() =>
       deleteDomainCommand.parseAsync(['test-domain-id', '--yes'], {
         from: 'user',

--- a/tests/commands/domains/get.test.ts
+++ b/tests/commands/domains/get.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { getDomainCommand } from '../../../src/commands/domains/get';
 import {
   captureTestEnv,
   expectExit1,
@@ -73,9 +74,6 @@ describe('domains get command', () => {
   it('calls SDK get with correct id', async () => {
     spies = setupOutputSpies();
 
-    const { getDomainCommand } = await import(
-      '../../../src/commands/domains/get'
-    );
     await getDomainCommand.parseAsync(['test-domain-id'], { from: 'user' });
 
     expect(mockGet).toHaveBeenCalledWith('test-domain-id');
@@ -84,9 +82,6 @@ describe('domains get command', () => {
   it('outputs full domain JSON in non-interactive mode', async () => {
     spies = setupOutputSpies();
 
-    const { getDomainCommand } = await import(
-      '../../../src/commands/domains/get'
-    );
     await getDomainCommand.parseAsync(['test-domain-id'], { from: 'user' });
 
     const output = spies.logSpy.mock.calls[0][0] as string;
@@ -115,9 +110,6 @@ describe('domains get command', () => {
     });
     spies = setupOutputSpies();
 
-    const { getDomainCommand } = await import(
-      '../../../src/commands/domains/get'
-    );
     await getDomainCommand.parseAsync(['test-domain-id'], { from: 'user' });
 
     const output = spies.logSpy.mock.calls[0][0] as string;
@@ -134,9 +126,6 @@ describe('domains get command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { getDomainCommand } = await import(
-      '../../../src/commands/domains/get'
-    );
     await expectExit1(() =>
       getDomainCommand.parseAsync(['test-domain-id'], { from: 'user' }),
     );
@@ -156,9 +145,6 @@ describe('domains get command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { getDomainCommand } = await import(
-      '../../../src/commands/domains/get'
-    );
     await expectExit1(() =>
       getDomainCommand.parseAsync(['test-domain-id'], { from: 'user' }),
     );

--- a/tests/commands/domains/list.test.ts
+++ b/tests/commands/domains/list.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { listDomainsCommand } from '../../../src/commands/domains/list';
 import {
   captureTestEnv,
   expectExit1,
@@ -83,9 +84,6 @@ describe('domains list command', () => {
   it('calls SDK list and outputs domains as JSON', async () => {
     spies = setupOutputSpies();
 
-    const { listDomainsCommand } = await import(
-      '../../../src/commands/domains/list'
-    );
     await listDomainsCommand.parseAsync([], { from: 'user' });
 
     expect(mockList).toHaveBeenCalledTimes(1);
@@ -98,9 +96,6 @@ describe('domains list command', () => {
   it('passes limit to SDK', async () => {
     spies = setupOutputSpies();
 
-    const { listDomainsCommand } = await import(
-      '../../../src/commands/domains/list'
-    );
     await listDomainsCommand.parseAsync(['--limit', '25'], { from: 'user' });
 
     expect(getFirstCallArgs()).toMatchObject({ limit: 25 });
@@ -109,9 +104,6 @@ describe('domains list command', () => {
   it('passes after cursor to SDK', async () => {
     spies = setupOutputSpies();
 
-    const { listDomainsCommand } = await import(
-      '../../../src/commands/domains/list'
-    );
     await listDomainsCommand.parseAsync(['--after', 'some-cursor'], {
       from: 'user',
     });
@@ -124,9 +116,6 @@ describe('domains list command', () => {
   it('passes before cursor to SDK', async () => {
     spies = setupOutputSpies();
 
-    const { listDomainsCommand } = await import(
-      '../../../src/commands/domains/list'
-    );
     await listDomainsCommand.parseAsync(['--before', 'some-cursor'], {
       from: 'user',
     });
@@ -141,9 +130,6 @@ describe('domains list command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { listDomainsCommand } = await import(
-      '../../../src/commands/domains/list'
-    );
     await expectExit1(() =>
       listDomainsCommand.parseAsync(
         ['--after', 'cursor_after', '--before', 'cursor_before'],
@@ -159,9 +145,6 @@ describe('domains list command', () => {
   it('uses default limit of 10 when not specified', async () => {
     spies = setupOutputSpies();
 
-    const { listDomainsCommand } = await import(
-      '../../../src/commands/domains/list'
-    );
     await listDomainsCommand.parseAsync([], { from: 'user' });
 
     expect(getFirstCallArgs()).toMatchObject({ limit: 10 });
@@ -174,9 +157,6 @@ describe('domains list command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { listDomainsCommand } = await import(
-      '../../../src/commands/domains/list'
-    );
     await expectExit1(() =>
       listDomainsCommand.parseAsync([], { from: 'user' }),
     );
@@ -194,9 +174,6 @@ describe('domains list command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { listDomainsCommand } = await import(
-      '../../../src/commands/domains/list'
-    );
     await expectExit1(() =>
       listDomainsCommand.parseAsync([], { from: 'user' }),
     );

--- a/tests/commands/domains/update.test.ts
+++ b/tests/commands/domains/update.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { updateDomainCommand } from '../../../src/commands/domains/update';
 import {
   captureTestEnv,
   expectExit1,
@@ -54,9 +55,6 @@ describe('domains update command', () => {
   it('calls SDK update with correct id', async () => {
     spies = setupOutputSpies();
 
-    const { updateDomainCommand } = await import(
-      '../../../src/commands/domains/update'
-    );
     await updateDomainCommand.parseAsync(
       ['test-domain-id', '--tls', 'enforced'],
       { from: 'user' },
@@ -71,9 +69,6 @@ describe('domains update command', () => {
   it('passes openTracking=true when --open-tracking is set', async () => {
     spies = setupOutputSpies();
 
-    const { updateDomainCommand } = await import(
-      '../../../src/commands/domains/update'
-    );
     await updateDomainCommand.parseAsync(
       ['test-domain-id', '--open-tracking'],
       { from: 'user' },
@@ -86,9 +81,6 @@ describe('domains update command', () => {
   it('passes openTracking=false when --no-open-tracking is set', async () => {
     spies = setupOutputSpies();
 
-    const { updateDomainCommand } = await import(
-      '../../../src/commands/domains/update'
-    );
     await updateDomainCommand.parseAsync(
       ['test-domain-id', '--no-open-tracking'],
       { from: 'user' },
@@ -101,9 +93,6 @@ describe('domains update command', () => {
   it('does not include tracking keys in payload when no tracking flags are passed', async () => {
     spies = setupOutputSpies();
 
-    const { updateDomainCommand } = await import(
-      '../../../src/commands/domains/update'
-    );
     await updateDomainCommand.parseAsync(
       ['test-domain-id', '--tls', 'enforced'],
       { from: 'user' },
@@ -117,9 +106,6 @@ describe('domains update command', () => {
   it('passes clickTracking=true when --click-tracking is set', async () => {
     spies = setupOutputSpies();
 
-    const { updateDomainCommand } = await import(
-      '../../../src/commands/domains/update'
-    );
     await updateDomainCommand.parseAsync(
       ['test-domain-id', '--click-tracking'],
       { from: 'user' },
@@ -132,9 +118,6 @@ describe('domains update command', () => {
   it('passes clickTracking=false when --no-click-tracking is set', async () => {
     spies = setupOutputSpies();
 
-    const { updateDomainCommand } = await import(
-      '../../../src/commands/domains/update'
-    );
     await updateDomainCommand.parseAsync(
       ['test-domain-id', '--no-click-tracking'],
       { from: 'user' },
@@ -147,9 +130,6 @@ describe('domains update command', () => {
   it('passes trackingSubdomain when --tracking-subdomain is set', async () => {
     spies = setupOutputSpies();
 
-    const { updateDomainCommand } = await import(
-      '../../../src/commands/domains/update'
-    );
     await updateDomainCommand.parseAsync(
       ['test-domain-id', '--tracking-subdomain', 'track'],
       { from: 'user' },
@@ -162,9 +142,6 @@ describe('domains update command', () => {
   it('does not error when only --tracking-subdomain is provided', async () => {
     spies = setupOutputSpies();
 
-    const { updateDomainCommand } = await import(
-      '../../../src/commands/domains/update'
-    );
     await updateDomainCommand.parseAsync(
       ['test-domain-id', '--tracking-subdomain', 'track'],
       { from: 'user' },
@@ -178,9 +155,6 @@ describe('domains update command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { updateDomainCommand } = await import(
-      '../../../src/commands/domains/update'
-    );
     await expectExit1(() =>
       updateDomainCommand.parseAsync(['test-domain-id'], { from: 'user' }),
     );
@@ -193,9 +167,6 @@ describe('domains update command', () => {
   it('outputs domain JSON on success', async () => {
     spies = setupOutputSpies();
 
-    const { updateDomainCommand } = await import(
-      '../../../src/commands/domains/update'
-    );
     await updateDomainCommand.parseAsync(
       ['test-domain-id', '--tls', 'opportunistic'],
       { from: 'user' },
@@ -214,9 +185,6 @@ describe('domains update command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { updateDomainCommand } = await import(
-      '../../../src/commands/domains/update'
-    );
     await expectExit1(() =>
       updateDomainCommand.parseAsync(['test-domain-id', '--tls', 'enforced'], {
         from: 'user',
@@ -238,9 +206,6 @@ describe('domains update command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { updateDomainCommand } = await import(
-      '../../../src/commands/domains/update'
-    );
     await expectExit1(() =>
       updateDomainCommand.parseAsync(['test-domain-id', '--tls', 'enforced'], {
         from: 'user',

--- a/tests/commands/domains/verify.test.ts
+++ b/tests/commands/domains/verify.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { verifyDomainCommand } from '../../../src/commands/domains/verify';
 import {
   captureTestEnv,
   expectExit1,
@@ -54,9 +55,6 @@ describe('domains verify command', () => {
   it('calls SDK verify with correct id', async () => {
     spies = setupOutputSpies();
 
-    const { verifyDomainCommand } = await import(
-      '../../../src/commands/domains/verify'
-    );
     await verifyDomainCommand.parseAsync(['test-domain-id'], { from: 'user' });
 
     expect(mockVerify).toHaveBeenCalledWith('test-domain-id');
@@ -65,9 +63,6 @@ describe('domains verify command', () => {
   it('outputs JSON object in non-interactive mode (stdout not a TTY)', async () => {
     spies = setupOutputSpies();
 
-    const { verifyDomainCommand } = await import(
-      '../../../src/commands/domains/verify'
-    );
     await verifyDomainCommand.parseAsync(['test-domain-id'], { from: 'user' });
 
     const output = spies.logSpy.mock.calls[0][0] as string;
@@ -83,9 +78,6 @@ describe('domains verify command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { verifyDomainCommand } = await import(
-      '../../../src/commands/domains/verify'
-    );
     await expectExit1(() =>
       verifyDomainCommand.parseAsync(['test-domain-id'], { from: 'user' }),
     );
@@ -105,9 +97,6 @@ describe('domains verify command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { verifyDomainCommand } = await import(
-      '../../../src/commands/domains/verify'
-    );
     await expectExit1(() =>
       verifyDomainCommand.parseAsync(['test-domain-id'], { from: 'user' }),
     );

--- a/tests/commands/emails/attachment.test.ts
+++ b/tests/commands/emails/attachment.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { getAttachmentCommand } from '../../../src/commands/emails/attachment';
 import {
   captureTestEnv,
   expectExit1,
@@ -64,9 +65,6 @@ describe('emails attachment command', () => {
   it('calls SDK get with emailId and attachmentId', async () => {
     spies = setupOutputSpies();
 
-    const { getAttachmentCommand } = await import(
-      '../../../src/commands/emails/attachment'
-    );
     await getAttachmentCommand.parseAsync(['email123', 'attach_abc123'], {
       from: 'user',
     });
@@ -80,9 +78,6 @@ describe('emails attachment command', () => {
   it('outputs JSON with attachment fields when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { getAttachmentCommand } = await import(
-      '../../../src/commands/emails/attachment'
-    );
     await getAttachmentCommand.parseAsync(['email123', 'attach_abc123'], {
       from: 'user',
     });
@@ -104,9 +99,6 @@ describe('emails attachment command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { getAttachmentCommand } = await import(
-      '../../../src/commands/emails/attachment'
-    );
     await expectExit1(() =>
       getAttachmentCommand.parseAsync(['email123', 'attach_abc123'], {
         from: 'user',
@@ -126,9 +118,6 @@ describe('emails attachment command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { getAttachmentCommand } = await import(
-      '../../../src/commands/emails/attachment'
-    );
     await expectExit1(() =>
       getAttachmentCommand.parseAsync(['email123', 'attach_nonexistent'], {
         from: 'user',

--- a/tests/commands/emails/attachments.test.ts
+++ b/tests/commands/emails/attachments.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { listAttachmentsCommand } from '../../../src/commands/emails/attachments';
 import {
   captureTestEnv,
   expectExit1,
@@ -69,9 +70,6 @@ describe('emails attachments command', () => {
   it('calls SDK list with emailId and default pagination', async () => {
     spies = setupOutputSpies();
 
-    const { listAttachmentsCommand } = await import(
-      '../../../src/commands/emails/attachments'
-    );
     await listAttachmentsCommand.parseAsync(['email123'], { from: 'user' });
 
     expect(mockList).toHaveBeenCalledTimes(1);
@@ -83,9 +81,6 @@ describe('emails attachments command', () => {
   it('passes --limit to pagination options', async () => {
     spies = setupOutputSpies();
 
-    const { listAttachmentsCommand } = await import(
-      '../../../src/commands/emails/attachments'
-    );
     await listAttachmentsCommand.parseAsync(['email123', '--limit', '5'], {
       from: 'user',
     });
@@ -97,9 +92,6 @@ describe('emails attachments command', () => {
   it('outputs JSON list with attachment data when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { listAttachmentsCommand } = await import(
-      '../../../src/commands/emails/attachments'
-    );
     await listAttachmentsCommand.parseAsync(['email123'], { from: 'user' });
 
     const output = spies.logSpy.mock.calls[0][0] as string;
@@ -116,9 +108,6 @@ describe('emails attachments command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { listAttachmentsCommand } = await import(
-      '../../../src/commands/emails/attachments'
-    );
     await expectExit1(() =>
       listAttachmentsCommand.parseAsync(['email123', '--limit', '200'], {
         from: 'user',
@@ -136,9 +125,6 @@ describe('emails attachments command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { listAttachmentsCommand } = await import(
-      '../../../src/commands/emails/attachments'
-    );
     await expectExit1(() =>
       listAttachmentsCommand.parseAsync(['email123'], { from: 'user' }),
     );
@@ -156,9 +142,6 @@ describe('emails attachments command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { listAttachmentsCommand } = await import(
-      '../../../src/commands/emails/attachments'
-    );
     await expectExit1(() =>
       listAttachmentsCommand.parseAsync(['nonexistent'], { from: 'user' }),
     );

--- a/tests/commands/emails/batch.test.ts
+++ b/tests/commands/emails/batch.test.ts
@@ -11,6 +11,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { batchCommand } from '../../../src/commands/emails/batch';
 import * as files from '../../../src/lib/files';
 import {
   captureTestEnv,
@@ -104,7 +105,6 @@ describe('batch command', () => {
     spies = setupOutputSpies();
 
     const file = await writeTmpJson(VALID_EMAILS);
-    const { batchCommand } = await import('../../../src/commands/emails/batch');
     await batchCommand.parseAsync(['--file', file], { from: 'user' });
 
     expect(mockBatchSend).toHaveBeenCalledTimes(1);
@@ -117,7 +117,6 @@ describe('batch command', () => {
     spies = setupOutputSpies();
 
     const file = await writeTmpJson(VALID_EMAILS);
-    const { batchCommand } = await import('../../../src/commands/emails/batch');
     await batchCommand.parseAsync(['--file', file], { from: 'user' });
 
     const output = spies.logSpy.mock.calls[0][0] as string;
@@ -130,7 +129,6 @@ describe('batch command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { batchCommand } = await import('../../../src/commands/emails/batch');
     await expectExit1(() => batchCommand.parseAsync([], { from: 'user' }));
 
     const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
@@ -142,7 +140,6 @@ describe('batch command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { batchCommand } = await import('../../../src/commands/emails/batch');
     await expectExit1(() =>
       batchCommand.parseAsync(
         ['--file', '/tmp/nonexistent-resend-batch.json'],
@@ -166,7 +163,6 @@ describe('batch command', () => {
     writeFileSync(path, 'not valid json{{{');
     tmpFile = path;
 
-    const { batchCommand } = await import('../../../src/commands/emails/batch');
     await expectExit1(() =>
       batchCommand.parseAsync(['--file', path], { from: 'user' }),
     );
@@ -184,7 +180,6 @@ describe('batch command', () => {
       from: 'you@domain.com',
       to: ['user@example.com'],
     });
-    const { batchCommand } = await import('../../../src/commands/emails/batch');
     await expectExit1(() =>
       batchCommand.parseAsync(['--file', file], { from: 'user' }),
     );
@@ -202,7 +197,6 @@ describe('batch command', () => {
     exitSpy = mockExitThrow();
 
     const file = await writeTmpJson([null]);
-    const { batchCommand } = await import('../../../src/commands/emails/batch');
     await expectExit1(() =>
       batchCommand.parseAsync(['--file', file], { from: 'user' }),
     );
@@ -224,7 +218,6 @@ describe('batch command', () => {
       },
     ];
     const file = await writeTmpJson(emails);
-    const { batchCommand } = await import('../../../src/commands/emails/batch');
     await expectExit1(() =>
       batchCommand.parseAsync(['--file', file], { from: 'user' }),
     );
@@ -244,7 +237,6 @@ describe('batch command', () => {
       },
     ];
     const file = await writeTmpJson(emails);
-    const { batchCommand } = await import('../../../src/commands/emails/batch');
     await batchCommand.parseAsync(['--file', file], { from: 'user' });
 
     expect(mockBatchSend).toHaveBeenCalledTimes(1);
@@ -265,7 +257,6 @@ describe('batch command', () => {
       },
     ];
     const file = await writeTmpJson(emails);
-    const { batchCommand } = await import('../../../src/commands/emails/batch');
     await batchCommand.parseAsync(['--file', file], { from: 'user' });
 
     const sent = mockBatchSend.mock.calls[0][0] as Record<string, unknown>[];
@@ -288,7 +279,6 @@ describe('batch command', () => {
       text: `Hello ${i}`,
     }));
     const file = await writeTmpJson(emails);
-    const { batchCommand } = await import('../../../src/commands/emails/batch');
     await batchCommand.parseAsync(['--file', file], { from: 'user' });
 
     expect(mockBatchSend).toHaveBeenCalledTimes(1);
@@ -300,7 +290,6 @@ describe('batch command', () => {
     spies = setupOutputSpies();
 
     const file = await writeTmpJson(VALID_EMAILS);
-    const { batchCommand } = await import('../../../src/commands/emails/batch');
     await batchCommand.parseAsync(
       ['--file', file, '--idempotency-key', 'my-key-123'],
       { from: 'user' },
@@ -315,7 +304,6 @@ describe('batch command', () => {
     spies = setupOutputSpies();
 
     const file = await writeTmpJson(VALID_EMAILS);
-    const { batchCommand } = await import('../../../src/commands/emails/batch');
     await batchCommand.parseAsync(
       ['--file', file, '--batch-validation', 'permissive'],
       { from: 'user' },
@@ -337,7 +325,6 @@ describe('batch command', () => {
     exitSpy = mockExitThrow();
 
     const file = await writeTmpJson(VALID_EMAILS);
-    const { batchCommand } = await import('../../../src/commands/emails/batch');
     await expectExit1(() =>
       batchCommand.parseAsync(['--file', file], { from: 'user' }),
     );
@@ -362,7 +349,6 @@ describe('batch command', () => {
       .mockImplementation(() => true);
 
     const file = await writeTmpJson(VALID_EMAILS);
-    const { batchCommand } = await import('../../../src/commands/emails/batch');
     await batchCommand.parseAsync(['--file', file], { from: 'user' });
 
     const allOutput = logSpy.mock.calls.map((c) => c[0]).join('\n');
@@ -385,7 +371,6 @@ describe('batch command', () => {
     }));
 
     const file = await writeTmpJson(VALID_EMAILS);
-    const { batchCommand } = await import('../../../src/commands/emails/batch');
     await batchCommand.parseAsync(
       ['--file', file, '--batch-validation', 'permissive'],
       { from: 'user' },
@@ -403,7 +388,6 @@ describe('batch command', () => {
     spies = setupOutputSpies();
 
     const file = await writeTmpJson(VALID_EMAILS);
-    const { batchCommand } = await import('../../../src/commands/emails/batch');
     await batchCommand.parseAsync(['--file', file], { from: 'user' });
 
     const output = spies.logSpy.mock.calls[0][0] as string;
@@ -419,7 +403,6 @@ describe('batch command', () => {
       .spyOn(files, 'readFile')
       .mockReturnValue(JSON.stringify(VALID_EMAILS));
 
-    const { batchCommand } = await import('../../../src/commands/emails/batch');
     await batchCommand.parseAsync(['--file', '-'], { from: 'user' });
 
     expect(readFileSpy).toHaveBeenCalledWith('-', expect.anything());
@@ -442,7 +425,6 @@ describe('batch command', () => {
       },
     ];
     const file = await writeTmpJson(emailsWithoutHtml);
-    const { batchCommand } = await import('../../../src/commands/emails/batch');
     await batchCommand.parseAsync(
       ['--file', file, '--react-email', './emails/welcome.tsx'],
       { from: 'user' },
@@ -475,7 +457,6 @@ describe('batch command', () => {
     }));
 
     const file = await writeTmpJson(VALID_EMAILS);
-    const { batchCommand } = await import('../../../src/commands/emails/batch');
     await expectExit1(() =>
       batchCommand.parseAsync(['--file', file], { from: 'user' }),
     );

--- a/tests/commands/emails/cancel.test.ts
+++ b/tests/commands/emails/cancel.test.ts
@@ -9,6 +9,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { cancelCommand } from '../../../src/commands/emails/cancel';
 import {
   captureTestEnv,
   expectExit1,
@@ -56,9 +57,6 @@ describe('emails cancel command', () => {
   it('calls SDK cancel with correct id', async () => {
     spies = setupOutputSpies();
 
-    const { cancelCommand } = await import(
-      '../../../src/commands/emails/cancel'
-    );
     await cancelCommand.parseAsync(['test-email-id'], { from: 'user' });
 
     expect(mockCancel).toHaveBeenCalledWith('test-email-id');
@@ -67,9 +65,6 @@ describe('emails cancel command', () => {
   it('outputs JSON object in non-interactive mode', async () => {
     spies = setupOutputSpies();
 
-    const { cancelCommand } = await import(
-      '../../../src/commands/emails/cancel'
-    );
     await cancelCommand.parseAsync(['test-email-id'], { from: 'user' });
 
     const output = spies.logSpy.mock.calls[0][0] as string;
@@ -88,9 +83,6 @@ describe('emails cancel command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { cancelCommand } = await import(
-      '../../../src/commands/emails/cancel'
-    );
     await expectExit1(() =>
       cancelCommand.parseAsync(['test-email-id'], { from: 'user' }),
     );
@@ -110,9 +102,6 @@ describe('emails cancel command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { cancelCommand } = await import(
-      '../../../src/commands/emails/cancel'
-    );
     await expectExit1(() =>
       cancelCommand.parseAsync(['test-email-id'], { from: 'user' }),
     );

--- a/tests/commands/emails/get.test.ts
+++ b/tests/commands/emails/get.test.ts
@@ -9,6 +9,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { getEmailCommand } from '../../../src/commands/emails/get';
 import {
   captureTestEnv,
   expectExit1,
@@ -71,9 +72,6 @@ describe('emails get command', () => {
   it('calls SDK get with the provided id', async () => {
     spies = setupOutputSpies();
 
-    const { getEmailCommand } = await import(
-      '../../../src/commands/emails/get'
-    );
     await getEmailCommand.parseAsync(['email_abc123'], { from: 'user' });
 
     expect(mockGet).toHaveBeenCalledWith('email_abc123');
@@ -82,9 +80,6 @@ describe('emails get command', () => {
   it('outputs JSON with full email fields when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { getEmailCommand } = await import(
-      '../../../src/commands/emails/get'
-    );
     await getEmailCommand.parseAsync(['email_abc123'], { from: 'user' });
 
     const output = spies.logSpy.mock.calls[0][0] as string;
@@ -106,9 +101,6 @@ describe('emails get command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { getEmailCommand } = await import(
-      '../../../src/commands/emails/get'
-    );
     await expectExit1(() =>
       getEmailCommand.parseAsync(['email_abc123'], { from: 'user' }),
     );
@@ -126,9 +118,6 @@ describe('emails get command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { getEmailCommand } = await import(
-      '../../../src/commands/emails/get'
-    );
     await expectExit1(() =>
       getEmailCommand.parseAsync(['email_nonexistent'], { from: 'user' }),
     );

--- a/tests/commands/emails/metrics.test.ts
+++ b/tests/commands/emails/metrics.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { metricsCommand } from '../../../src/commands/emails/metrics';
 import {
   captureTestEnv,
   expectExit1,
@@ -61,9 +62,6 @@ describe('emails metrics command', () => {
   it('calls SDK metrics with no options by default', async () => {
     spies = setupOutputSpies();
 
-    const { metricsCommand } = await import(
-      '../../../src/commands/emails/metrics'
-    );
     await metricsCommand.parseAsync([], { from: 'user' });
 
     expect(mockMetrics).toHaveBeenCalledWith({
@@ -82,9 +80,6 @@ describe('emails metrics command', () => {
   it('parses comma-separated dimensions and a filter into arrays', async () => {
     spies = setupOutputSpies();
 
-    const { metricsCommand } = await import(
-      '../../../src/commands/emails/metrics'
-    );
     await metricsCommand.parseAsync(
       ['--dimensions', 'period,broadcast', '--broadcast-id', 'b1,b2'],
       { from: 'user' },
@@ -101,9 +96,6 @@ describe('emails metrics command', () => {
   it('outputs JSON in non-interactive mode', async () => {
     spies = setupOutputSpies();
 
-    const { metricsCommand } = await import(
-      '../../../src/commands/emails/metrics'
-    );
     await metricsCommand.parseAsync([], { from: 'user' });
 
     const output = spies.logSpy.mock.calls[0][0] as string;
@@ -120,9 +112,6 @@ describe('emails metrics command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { metricsCommand } = await import(
-      '../../../src/commands/emails/metrics'
-    );
     await expectExit1(() =>
       metricsCommand.parseAsync(['--dimensions', 'email,broadcast'], {
         from: 'user',
@@ -142,9 +131,6 @@ describe('emails metrics command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { metricsCommand } = await import(
-      '../../../src/commands/emails/metrics'
-    );
     await expectExit1(() =>
       metricsCommand.parseAsync(['--email-id', 'e1', '--broadcast-id', 'b1'], {
         from: 'user',
@@ -162,9 +148,6 @@ describe('emails metrics command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { metricsCommand } = await import(
-      '../../../src/commands/emails/metrics'
-    );
     await expectExit1(() =>
       metricsCommand.parseAsync(['--email-id', '', '--broadcast-id', 'b1'], {
         from: 'user',

--- a/tests/commands/emails/receiving/attachment.test.ts
+++ b/tests/commands/emails/receiving/attachment.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { getAttachmentCommand } from '../../../../src/commands/emails/receiving/attachment';
 import {
   captureTestEnv,
   expectExit1,
@@ -64,9 +65,6 @@ describe('emails receiving attachment command', () => {
   it('calls SDK get with emailId and attachmentId', async () => {
     spies = setupOutputSpies();
 
-    const { getAttachmentCommand } = await import(
-      '../../../../src/commands/emails/receiving/attachment'
-    );
     await getAttachmentCommand.parseAsync(['rcv_email123', 'attach_abc123'], {
       from: 'user',
     });
@@ -80,9 +78,6 @@ describe('emails receiving attachment command', () => {
   it('outputs JSON with attachment fields when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { getAttachmentCommand } = await import(
-      '../../../../src/commands/emails/receiving/attachment'
-    );
     await getAttachmentCommand.parseAsync(['rcv_email123', 'attach_abc123'], {
       from: 'user',
     });
@@ -104,9 +99,6 @@ describe('emails receiving attachment command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { getAttachmentCommand } = await import(
-      '../../../../src/commands/emails/receiving/attachment'
-    );
     await expectExit1(() =>
       getAttachmentCommand.parseAsync(['rcv_email123', 'attach_abc123'], {
         from: 'user',
@@ -126,9 +118,6 @@ describe('emails receiving attachment command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { getAttachmentCommand } = await import(
-      '../../../../src/commands/emails/receiving/attachment'
-    );
     await expectExit1(() =>
       getAttachmentCommand.parseAsync(['rcv_email123', 'attach_nonexistent'], {
         from: 'user',

--- a/tests/commands/emails/receiving/attachments.test.ts
+++ b/tests/commands/emails/receiving/attachments.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { listAttachmentsCommand } from '../../../../src/commands/emails/receiving/attachments';
 import {
   captureTestEnv,
   expectExit1,
@@ -69,9 +70,6 @@ describe('emails receiving attachments command', () => {
   it('calls SDK list with emailId and default pagination', async () => {
     spies = setupOutputSpies();
 
-    const { listAttachmentsCommand } = await import(
-      '../../../../src/commands/emails/receiving/attachments'
-    );
     await listAttachmentsCommand.parseAsync(['rcv_email123'], { from: 'user' });
 
     expect(mockList).toHaveBeenCalledTimes(1);
@@ -83,9 +81,6 @@ describe('emails receiving attachments command', () => {
   it('passes --limit to pagination options', async () => {
     spies = setupOutputSpies();
 
-    const { listAttachmentsCommand } = await import(
-      '../../../../src/commands/emails/receiving/attachments'
-    );
     await listAttachmentsCommand.parseAsync(['rcv_email123', '--limit', '5'], {
       from: 'user',
     });
@@ -97,9 +92,6 @@ describe('emails receiving attachments command', () => {
   it('outputs JSON list with attachment data when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { listAttachmentsCommand } = await import(
-      '../../../../src/commands/emails/receiving/attachments'
-    );
     await listAttachmentsCommand.parseAsync(['rcv_email123'], { from: 'user' });
 
     const output = spies.logSpy.mock.calls[0][0] as string;
@@ -116,9 +108,6 @@ describe('emails receiving attachments command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { listAttachmentsCommand } = await import(
-      '../../../../src/commands/emails/receiving/attachments'
-    );
     await expectExit1(() =>
       listAttachmentsCommand.parseAsync(['rcv_email123', '--limit', '200'], {
         from: 'user',
@@ -136,9 +125,6 @@ describe('emails receiving attachments command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { listAttachmentsCommand } = await import(
-      '../../../../src/commands/emails/receiving/attachments'
-    );
     await expectExit1(() =>
       listAttachmentsCommand.parseAsync(['rcv_email123'], { from: 'user' }),
     );
@@ -156,9 +142,6 @@ describe('emails receiving attachments command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { listAttachmentsCommand } = await import(
-      '../../../../src/commands/emails/receiving/attachments'
-    );
     await expectExit1(() =>
       listAttachmentsCommand.parseAsync(['rcv_nonexistent'], { from: 'user' }),
     );

--- a/tests/commands/emails/receiving/forward.test.ts
+++ b/tests/commands/emails/receiving/forward.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { forwardCommand } from '../../../../src/commands/emails/receiving/forward';
 import {
   captureTestEnv,
   expectExit1,
@@ -54,9 +55,6 @@ describe('emails receiving forward command', () => {
   it('calls SDK forward with correct emailId, to, and from', async () => {
     spies = setupOutputSpies();
 
-    const { forwardCommand } = await import(
-      '../../../../src/commands/emails/receiving/forward'
-    );
     await forwardCommand.parseAsync(
       ['rcv_abc123', '--to', 'user@example.com', '--from', 'you@domain.com'],
       { from: 'user' },
@@ -72,9 +70,6 @@ describe('emails receiving forward command', () => {
   it('outputs JSON object in non-interactive mode', async () => {
     spies = setupOutputSpies();
 
-    const { forwardCommand } = await import(
-      '../../../../src/commands/emails/receiving/forward'
-    );
     await forwardCommand.parseAsync(
       ['rcv_abc123', '--to', 'user@example.com', '--from', 'you@domain.com'],
       { from: 'user' },
@@ -92,9 +87,6 @@ describe('emails receiving forward command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { forwardCommand } = await import(
-      '../../../../src/commands/emails/receiving/forward'
-    );
     await expectExit1(() =>
       forwardCommand.parseAsync(
         ['rcv_abc123', '--to', 'user@example.com', '--from', 'you@domain.com'],
@@ -117,9 +109,6 @@ describe('emails receiving forward command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { forwardCommand } = await import(
-      '../../../../src/commands/emails/receiving/forward'
-    );
     await expectExit1(() =>
       forwardCommand.parseAsync(
         ['rcv_abc123', '--to', 'user@example.com', '--from', 'you@domain.com'],

--- a/tests/commands/emails/receiving/get.test.ts
+++ b/tests/commands/emails/receiving/get.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { getReceivingCommand } from '../../../../src/commands/emails/receiving/get';
 import {
   captureTestEnv,
   expectExit1,
@@ -73,9 +74,6 @@ describe('emails receiving get command', () => {
   it('calls SDK get with the provided id', async () => {
     spies = setupOutputSpies();
 
-    const { getReceivingCommand } = await import(
-      '../../../../src/commands/emails/receiving/get'
-    );
     await getReceivingCommand.parseAsync(['rcv_abc123'], { from: 'user' });
 
     expect(mockGet).toHaveBeenCalledTimes(1);
@@ -85,9 +83,6 @@ describe('emails receiving get command', () => {
   it('outputs JSON with full email fields when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { getReceivingCommand } = await import(
-      '../../../../src/commands/emails/receiving/get'
-    );
     await getReceivingCommand.parseAsync(['rcv_abc123'], { from: 'user' });
 
     const output = spies.logSpy.mock.calls[0][0] as string;
@@ -108,9 +103,6 @@ describe('emails receiving get command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { getReceivingCommand } = await import(
-      '../../../../src/commands/emails/receiving/get'
-    );
     await expectExit1(() =>
       getReceivingCommand.parseAsync(['rcv_abc123'], { from: 'user' }),
     );
@@ -128,9 +120,6 @@ describe('emails receiving get command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { getReceivingCommand } = await import(
-      '../../../../src/commands/emails/receiving/get'
-    );
     await expectExit1(() =>
       getReceivingCommand.parseAsync(['rcv_nonexistent'], { from: 'user' }),
     );

--- a/tests/commands/emails/receiving/list.test.ts
+++ b/tests/commands/emails/receiving/list.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { listReceivingCommand } from '../../../../src/commands/emails/receiving/list';
 import {
   captureTestEnv,
   expectExit1,
@@ -71,9 +72,6 @@ describe('emails receiving list command', () => {
   it('calls SDK list with default pagination', async () => {
     spies = setupOutputSpies();
 
-    const { listReceivingCommand } = await import(
-      '../../../../src/commands/emails/receiving/list'
-    );
     await listReceivingCommand.parseAsync([], { from: 'user' });
 
     expect(mockList).toHaveBeenCalledTimes(1);
@@ -84,9 +82,6 @@ describe('emails receiving list command', () => {
   it('passes --limit to pagination options', async () => {
     spies = setupOutputSpies();
 
-    const { listReceivingCommand } = await import(
-      '../../../../src/commands/emails/receiving/list'
-    );
     await listReceivingCommand.parseAsync(['--limit', '5'], { from: 'user' });
 
     const args = mockList.mock.calls[0][0] as Record<string, unknown>;
@@ -96,9 +91,6 @@ describe('emails receiving list command', () => {
   it('passes --after cursor to pagination options', async () => {
     spies = setupOutputSpies();
 
-    const { listReceivingCommand } = await import(
-      '../../../../src/commands/emails/receiving/list'
-    );
     await listReceivingCommand.parseAsync(['--after', 'rcv_cursor123'], {
       from: 'user',
     });
@@ -110,9 +102,6 @@ describe('emails receiving list command', () => {
   it('outputs JSON list with received email data when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { listReceivingCommand } = await import(
-      '../../../../src/commands/emails/receiving/list'
-    );
     await listReceivingCommand.parseAsync([], { from: 'user' });
 
     const output = spies.logSpy.mock.calls[0][0] as string;
@@ -129,9 +118,6 @@ describe('emails receiving list command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { listReceivingCommand } = await import(
-      '../../../../src/commands/emails/receiving/list'
-    );
     await expectExit1(() =>
       listReceivingCommand.parseAsync(['--limit', '200'], { from: 'user' }),
     );
@@ -147,9 +133,6 @@ describe('emails receiving list command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { listReceivingCommand } = await import(
-      '../../../../src/commands/emails/receiving/list'
-    );
     await expectExit1(() =>
       listReceivingCommand.parseAsync([], { from: 'user' }),
     );
@@ -169,9 +152,6 @@ describe('emails receiving list command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { listReceivingCommand } = await import(
-      '../../../../src/commands/emails/receiving/list'
-    );
     await expectExit1(() =>
       listReceivingCommand.parseAsync([], { from: 'user' }),
     );

--- a/tests/commands/emails/share.test.ts
+++ b/tests/commands/emails/share.test.ts
@@ -9,6 +9,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { shareCommand } from '../../../src/commands/emails/share';
 import {
   captureTestEnv,
   expectExit1,
@@ -60,7 +61,6 @@ describe('emails share command', () => {
   it('calls SDK share with correct id and no options', async () => {
     spies = setupOutputSpies();
 
-    const { shareCommand } = await import('../../../src/commands/emails/share');
     await shareCommand.parseAsync(['test-email-id'], { from: 'user' });
 
     expect(mockShare).toHaveBeenCalledWith('test-email-id', undefined);
@@ -69,7 +69,6 @@ describe('emails share command', () => {
   it('calls SDK share with expiresIn when --expires-in is passed', async () => {
     spies = setupOutputSpies();
 
-    const { shareCommand } = await import('../../../src/commands/emails/share');
     await shareCommand.parseAsync(['test-email-id', '--expires-in', '1 day'], {
       from: 'user',
     });
@@ -82,7 +81,6 @@ describe('emails share command', () => {
   it('passes an empty --expires-in through to the SDK instead of dropping it', async () => {
     spies = setupOutputSpies();
 
-    const { shareCommand } = await import('../../../src/commands/emails/share');
     await shareCommand.parseAsync(['test-email-id', '--expires-in', ''], {
       from: 'user',
     });
@@ -93,7 +91,6 @@ describe('emails share command', () => {
   it('outputs JSON object in non-interactive mode', async () => {
     spies = setupOutputSpies();
 
-    const { shareCommand } = await import('../../../src/commands/emails/share');
     await shareCommand.parseAsync(['test-email-id'], { from: 'user' });
 
     const output = spies.logSpy.mock.calls[0][0] as string;
@@ -113,7 +110,6 @@ describe('emails share command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { shareCommand } = await import('../../../src/commands/emails/share');
     await expectExit1(() =>
       shareCommand.parseAsync(['test-email-id'], { from: 'user' }),
     );
@@ -133,7 +129,6 @@ describe('emails share command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { shareCommand } = await import('../../../src/commands/emails/share');
     await expectExit1(() =>
       shareCommand.parseAsync(['test-email-id'], { from: 'user' }),
     );

--- a/tests/commands/emails/update.test.ts
+++ b/tests/commands/emails/update.test.ts
@@ -9,6 +9,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { updateCommand } from '../../../src/commands/emails/update';
 import {
   captureTestEnv,
   expectExit1,
@@ -56,9 +57,6 @@ describe('emails update command', () => {
   it('calls SDK update with correct id and scheduledAt', async () => {
     spies = setupOutputSpies();
 
-    const { updateCommand } = await import(
-      '../../../src/commands/emails/update'
-    );
     await updateCommand.parseAsync(
       ['test-email-id', '--scheduled-at', '2024-08-05T11:52:01.858Z'],
       { from: 'user' },
@@ -73,9 +71,6 @@ describe('emails update command', () => {
   it('outputs JSON object in non-interactive mode', async () => {
     spies = setupOutputSpies();
 
-    const { updateCommand } = await import(
-      '../../../src/commands/emails/update'
-    );
     await updateCommand.parseAsync(
       ['test-email-id', '--scheduled-at', '2024-08-05T11:52:01.858Z'],
       { from: 'user' },
@@ -97,9 +92,6 @@ describe('emails update command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { updateCommand } = await import(
-      '../../../src/commands/emails/update'
-    );
     await expectExit1(() =>
       updateCommand.parseAsync(
         ['test-email-id', '--scheduled-at', '2024-08-05T11:52:01.858Z'],
@@ -122,9 +114,6 @@ describe('emails update command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { updateCommand } = await import(
-      '../../../src/commands/emails/update'
-    );
     await expectExit1(() =>
       updateCommand.parseAsync(
         ['test-email-id', '--scheduled-at', '2024-08-05T11:52:01.858Z'],

--- a/tests/commands/logs/get.test.ts
+++ b/tests/commands/logs/get.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { getLogCommand } from '../../../src/commands/logs/get';
 import {
   captureTestEnv,
   expectExit1,
@@ -64,7 +65,6 @@ describe('logs get command', () => {
   it('calls SDK get with the provided id', async () => {
     spies = setupOutputSpies();
 
-    const { getLogCommand } = await import('../../../src/commands/logs/get');
     await getLogCommand.parseAsync(['3d4a472d-bc6d-4dd2-aa9d-d3d11b549e55'], {
       from: 'user',
     });
@@ -78,7 +78,6 @@ describe('logs get command', () => {
   it('outputs JSON with log fields when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { getLogCommand } = await import('../../../src/commands/logs/get');
     await getLogCommand.parseAsync(['3d4a472d-bc6d-4dd2-aa9d-d3d11b549e55'], {
       from: 'user',
     });
@@ -98,7 +97,6 @@ describe('logs get command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { getLogCommand } = await import('../../../src/commands/logs/get');
     await expectExit1(() =>
       getLogCommand.parseAsync(['3d4a472d-bc6d-4dd2-aa9d-d3d11b549e55'], {
         from: 'user',
@@ -118,7 +116,6 @@ describe('logs get command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { getLogCommand } = await import('../../../src/commands/logs/get');
     await expectExit1(() =>
       getLogCommand.parseAsync(['nonexistent-id'], { from: 'user' }),
     );

--- a/tests/commands/logs/list.test.ts
+++ b/tests/commands/logs/list.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { listLogsCommand } from '../../../src/commands/logs/list';
 import {
   captureTestEnv,
   expectExit1,
@@ -67,7 +68,6 @@ describe('logs list command', () => {
   it('calls SDK list method with default pagination', async () => {
     spies = setupOutputSpies();
 
-    const { listLogsCommand } = await import('../../../src/commands/logs/list');
     await listLogsCommand.parseAsync([], { from: 'user' });
 
     expect(mockList).toHaveBeenCalledTimes(1);
@@ -78,7 +78,6 @@ describe('logs list command', () => {
   it('passes --limit to pagination options', async () => {
     spies = setupOutputSpies();
 
-    const { listLogsCommand } = await import('../../../src/commands/logs/list');
     await listLogsCommand.parseAsync(['--limit', '5'], { from: 'user' });
 
     const args = mockList.mock.calls[0][0] as Record<string, unknown>;
@@ -88,7 +87,6 @@ describe('logs list command', () => {
   it('passes --after cursor to pagination options', async () => {
     spies = setupOutputSpies();
 
-    const { listLogsCommand } = await import('../../../src/commands/logs/list');
     await listLogsCommand.parseAsync(
       ['--after', '3d4a472d-bc6d-4dd2-aa9d-d3d11b549e55'],
       { from: 'user' },
@@ -101,7 +99,6 @@ describe('logs list command', () => {
   it('outputs JSON list with log data when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { listLogsCommand } = await import('../../../src/commands/logs/list');
     await listLogsCommand.parseAsync([], { from: 'user' });
 
     const output = spies.logSpy.mock.calls[0][0] as string;
@@ -117,7 +114,6 @@ describe('logs list command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { listLogsCommand } = await import('../../../src/commands/logs/list');
     await expectExit1(() =>
       listLogsCommand.parseAsync(['--limit', '200'], { from: 'user' }),
     );
@@ -133,7 +129,6 @@ describe('logs list command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { listLogsCommand } = await import('../../../src/commands/logs/list');
     await expectExit1(() => listLogsCommand.parseAsync([], { from: 'user' }));
 
     const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
@@ -151,7 +146,6 @@ describe('logs list command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { listLogsCommand } = await import('../../../src/commands/logs/list');
     await expectExit1(() => listLogsCommand.parseAsync([], { from: 'user' }));
 
     const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');

--- a/tests/commands/logs/open.test.ts
+++ b/tests/commands/logs/open.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { openLogsCommand } from '../../../src/commands/logs/open';
 import * as browser from '../../../src/lib/browser';
 
 describe('logs open command', () => {
@@ -11,7 +12,6 @@ describe('logs open command', () => {
   });
 
   it('with no args opens logs list', async () => {
-    const { openLogsCommand } = await import('../../../src/commands/logs/open');
     await openLogsCommand.parseAsync([], { from: 'user' });
 
     expect(browser.openInBrowserOrLog).toHaveBeenCalledTimes(1);
@@ -22,7 +22,6 @@ describe('logs open command', () => {
   });
 
   it('with id opens log detail URL', async () => {
-    const { openLogsCommand } = await import('../../../src/commands/logs/open');
     await openLogsCommand.parseAsync(['3d4a472d-bc6d-4dd2-aa9d-d3d11b549e55'], {
       from: 'user',
     });

--- a/tests/commands/oauth-grants/list.test.ts
+++ b/tests/commands/oauth-grants/list.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { listOAuthGrantsCommand } from '../../../src/commands/oauth-grants/list';
 import { captureTestEnv, setupOutputSpies } from '../../helpers';
 
 const mockList = vi.fn(async () => ({
@@ -63,9 +64,6 @@ describe('oauth-grants list command', () => {
   it('uses default limit of 10 when not specified', async () => {
     spies = setupOutputSpies();
 
-    const { listOAuthGrantsCommand } = await import(
-      '../../../src/commands/oauth-grants/list'
-    );
     await listOAuthGrantsCommand.parseAsync([], { from: 'user' });
 
     expect(mockList).toHaveBeenCalledTimes(1);
@@ -75,9 +73,6 @@ describe('oauth-grants list command', () => {
   it('outputs JSON list when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { listOAuthGrantsCommand } = await import(
-      '../../../src/commands/oauth-grants/list'
-    );
     await listOAuthGrantsCommand.parseAsync([], { from: 'user' });
 
     const output = (spies.logSpy.mock.calls[0] as unknown[])[0] as string;
@@ -92,9 +87,6 @@ describe('oauth-grants list command', () => {
   it('passes limit to SDK', async () => {
     spies = setupOutputSpies();
 
-    const { listOAuthGrantsCommand } = await import(
-      '../../../src/commands/oauth-grants/list'
-    );
     await listOAuthGrantsCommand.parseAsync(['--limit', '25'], {
       from: 'user',
     });
@@ -105,9 +97,6 @@ describe('oauth-grants list command', () => {
   it('passes after cursor to SDK', async () => {
     spies = setupOutputSpies();
 
-    const { listOAuthGrantsCommand } = await import(
-      '../../../src/commands/oauth-grants/list'
-    );
     await listOAuthGrantsCommand.parseAsync(['--after', 'some-cursor'], {
       from: 'user',
     });
@@ -118,9 +107,6 @@ describe('oauth-grants list command', () => {
   it('passes before cursor to SDK', async () => {
     spies = setupOutputSpies();
 
-    const { listOAuthGrantsCommand } = await import(
-      '../../../src/commands/oauth-grants/list'
-    );
     await listOAuthGrantsCommand.parseAsync(['--before', 'some-cursor'], {
       from: 'user',
     });

--- a/tests/commands/oauth-grants/revoke.test.ts
+++ b/tests/commands/oauth-grants/revoke.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { revokeOAuthGrantCommand } from '../../../src/commands/oauth-grants/revoke';
 import {
   captureTestEnv,
   expectExit1,
@@ -59,9 +60,6 @@ describe('oauth-grants revoke command', () => {
   it('revokes an OAuth grant with the --yes flag', async () => {
     spies = setupOutputSpies();
 
-    const { revokeOAuthGrantCommand } = await import(
-      '../../../src/commands/oauth-grants/revoke'
-    );
     await revokeOAuthGrantCommand.parseAsync(['test-grant-id', '--yes'], {
       from: 'user',
     });
@@ -72,9 +70,6 @@ describe('oauth-grants revoke command', () => {
   it('outputs the revoked grant JSON on success', async () => {
     spies = setupOutputSpies();
 
-    const { revokeOAuthGrantCommand } = await import(
-      '../../../src/commands/oauth-grants/revoke'
-    );
     await revokeOAuthGrantCommand.parseAsync(['test-grant-id', '--yes'], {
       from: 'user',
     });
@@ -91,9 +86,6 @@ describe('oauth-grants revoke command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { revokeOAuthGrantCommand } = await import(
-      '../../../src/commands/oauth-grants/revoke'
-    );
     await expectExit1(() =>
       revokeOAuthGrantCommand.parseAsync(['test-grant-id'], { from: 'user' }),
     );
@@ -107,9 +99,6 @@ describe('oauth-grants revoke command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { revokeOAuthGrantCommand } = await import(
-      '../../../src/commands/oauth-grants/revoke'
-    );
     await expectExit1(() =>
       revokeOAuthGrantCommand.parseAsync(['test-grant-id'], { from: 'user' }),
     );
@@ -128,9 +117,6 @@ describe('oauth-grants revoke command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { revokeOAuthGrantCommand } = await import(
-      '../../../src/commands/oauth-grants/revoke'
-    );
     await expectExit1(() =>
       revokeOAuthGrantCommand.parseAsync(['test-grant-id', '--yes'], {
         from: 'user',

--- a/tests/commands/open.test.ts
+++ b/tests/commands/open.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { openCommand } from '../../src/commands/open';
 import * as browser from '../../src/lib/browser';
 
 describe('resend open command', () => {
@@ -11,7 +12,6 @@ describe('resend open command', () => {
   });
 
   it('opens emails URL in browser', async () => {
-    const { openCommand } = await import('../../src/commands/open');
     await openCommand.parseAsync([], { from: 'user' });
 
     expect(browser.openInBrowserOrLog).toHaveBeenCalledTimes(1);

--- a/tests/commands/segments/create.test.ts
+++ b/tests/commands/segments/create.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { createSegmentCommand } from '../../../src/commands/segments/create';
 import {
   captureTestEnv,
   expectExit1,
@@ -58,9 +59,6 @@ describe('segments create command', () => {
   it('creates segment with --name flag', async () => {
     spies = setupOutputSpies();
 
-    const { createSegmentCommand } = await import(
-      '../../../src/commands/segments/create'
-    );
     await createSegmentCommand.parseAsync(
       ['--name', 'Newsletter Subscribers'],
       { from: 'user' },
@@ -74,9 +72,6 @@ describe('segments create command', () => {
   it('outputs JSON with id and object when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { createSegmentCommand } = await import(
-      '../../../src/commands/segments/create'
-    );
     await createSegmentCommand.parseAsync(
       ['--name', 'Newsletter Subscribers'],
       { from: 'user' },
@@ -94,9 +89,6 @@ describe('segments create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createSegmentCommand } = await import(
-      '../../../src/commands/segments/create'
-    );
     await expectExit1(() =>
       createSegmentCommand.parseAsync([], { from: 'user' }),
     );
@@ -110,9 +102,6 @@ describe('segments create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createSegmentCommand } = await import(
-      '../../../src/commands/segments/create'
-    );
     await expectExit1(() =>
       createSegmentCommand.parseAsync([], { from: 'user' }),
     );
@@ -127,9 +116,6 @@ describe('segments create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createSegmentCommand } = await import(
-      '../../../src/commands/segments/create'
-    );
     await expectExit1(() =>
       createSegmentCommand.parseAsync(['--name', 'Test'], { from: 'user' }),
     );
@@ -149,9 +135,6 @@ describe('segments create command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { createSegmentCommand } = await import(
-      '../../../src/commands/segments/create'
-    );
     await expectExit1(() =>
       createSegmentCommand.parseAsync(['--name', 'Newsletter Subscribers'], {
         from: 'user',

--- a/tests/commands/segments/delete.test.ts
+++ b/tests/commands/segments/delete.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { deleteSegmentCommand } from '../../../src/commands/segments/delete';
 import {
   captureTestEnv,
   expectExit1,
@@ -58,9 +59,6 @@ describe('segments delete command', () => {
   it('deletes segment with --yes flag', async () => {
     spies = setupOutputSpies();
 
-    const { deleteSegmentCommand } = await import(
-      '../../../src/commands/segments/delete'
-    );
     await deleteSegmentCommand.parseAsync(
       ['3f2a1b4c-5d6e-7f8a-9b0c-1d2e3f4a5b6c', '--yes'],
       {
@@ -77,9 +75,6 @@ describe('segments delete command', () => {
   it('outputs synthesized JSON result when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { deleteSegmentCommand } = await import(
-      '../../../src/commands/segments/delete'
-    );
     await deleteSegmentCommand.parseAsync(
       ['3f2a1b4c-5d6e-7f8a-9b0c-1d2e3f4a5b6c', '--yes'],
       {
@@ -99,9 +94,6 @@ describe('segments delete command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { deleteSegmentCommand } = await import(
-      '../../../src/commands/segments/delete'
-    );
     await expectExit1(() =>
       deleteSegmentCommand.parseAsync(
         ['3f2a1b4c-5d6e-7f8a-9b0c-1d2e3f4a5b6c'],
@@ -118,9 +110,6 @@ describe('segments delete command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { deleteSegmentCommand } = await import(
-      '../../../src/commands/segments/delete'
-    );
     await expectExit1(() =>
       deleteSegmentCommand.parseAsync(
         ['3f2a1b4c-5d6e-7f8a-9b0c-1d2e3f4a5b6c'],
@@ -138,9 +127,6 @@ describe('segments delete command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { deleteSegmentCommand } = await import(
-      '../../../src/commands/segments/delete'
-    );
     await expectExit1(() =>
       deleteSegmentCommand.parseAsync(
         ['3f2a1b4c-5d6e-7f8a-9b0c-1d2e3f4a5b6c', '--yes'],
@@ -165,9 +151,6 @@ describe('segments delete command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { deleteSegmentCommand } = await import(
-      '../../../src/commands/segments/delete'
-    );
     await expectExit1(() =>
       deleteSegmentCommand.parseAsync(
         ['00000000-0000-0000-0000-000000000000', '--yes'],

--- a/tests/commands/segments/get.test.ts
+++ b/tests/commands/segments/get.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { getSegmentCommand } from '../../../src/commands/segments/get';
 import {
   captureTestEnv,
   expectExit1,
@@ -59,9 +60,6 @@ describe('segments get command', () => {
   it('calls SDK with the provided segment ID', async () => {
     spies = setupOutputSpies();
 
-    const { getSegmentCommand } = await import(
-      '../../../src/commands/segments/get'
-    );
     await getSegmentCommand.parseAsync(
       ['3f2a1b4c-5d6e-7f8a-9b0c-1d2e3f4a5b6c'],
       { from: 'user' },
@@ -76,9 +74,6 @@ describe('segments get command', () => {
   it('outputs JSON segment data when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { getSegmentCommand } = await import(
-      '../../../src/commands/segments/get'
-    );
     await getSegmentCommand.parseAsync(
       ['3f2a1b4c-5d6e-7f8a-9b0c-1d2e3f4a5b6c'],
       { from: 'user' },
@@ -99,9 +94,6 @@ describe('segments get command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { getSegmentCommand } = await import(
-      '../../../src/commands/segments/get'
-    );
     await expectExit1(() =>
       getSegmentCommand.parseAsync(['3f2a1b4c-5d6e-7f8a-9b0c-1d2e3f4a5b6c'], {
         from: 'user',
@@ -123,9 +115,6 @@ describe('segments get command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { getSegmentCommand } = await import(
-      '../../../src/commands/segments/get'
-    );
     await expectExit1(() =>
       getSegmentCommand.parseAsync(['00000000-0000-0000-0000-000000000000'], {
         from: 'user',

--- a/tests/commands/segments/list.test.ts
+++ b/tests/commands/segments/list.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { listSegmentsCommand } from '../../../src/commands/segments/list';
 import {
   captureTestEnv,
   expectExit1,
@@ -64,9 +65,6 @@ describe('segments list command', () => {
   it('calls SDK with default limit of 10', async () => {
     spies = setupOutputSpies();
 
-    const { listSegmentsCommand } = await import(
-      '../../../src/commands/segments/list'
-    );
     await listSegmentsCommand.parseAsync([], { from: 'user' });
 
     expect(mockList).toHaveBeenCalledTimes(1);
@@ -77,9 +75,6 @@ describe('segments list command', () => {
   it('calls SDK with custom --limit', async () => {
     spies = setupOutputSpies();
 
-    const { listSegmentsCommand } = await import(
-      '../../../src/commands/segments/list'
-    );
     await listSegmentsCommand.parseAsync(['--limit', '25'], { from: 'user' });
 
     const args = mockList.mock.calls[0][0] as Record<string, unknown>;
@@ -89,9 +84,6 @@ describe('segments list command', () => {
   it('calls SDK with --after cursor', async () => {
     spies = setupOutputSpies();
 
-    const { listSegmentsCommand } = await import(
-      '../../../src/commands/segments/list'
-    );
     await listSegmentsCommand.parseAsync(['--after', 'cursor_xyz'], {
       from: 'user',
     });
@@ -103,9 +95,6 @@ describe('segments list command', () => {
   it('outputs JSON list when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { listSegmentsCommand } = await import(
-      '../../../src/commands/segments/list'
-    );
     await listSegmentsCommand.parseAsync([], { from: 'user' });
 
     const output = spies.logSpy.mock.calls[0][0] as string;
@@ -121,9 +110,6 @@ describe('segments list command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { listSegmentsCommand } = await import(
-      '../../../src/commands/segments/list'
-    );
     await expectExit1(() =>
       listSegmentsCommand.parseAsync(['--limit', '0'], { from: 'user' }),
     );
@@ -139,9 +125,6 @@ describe('segments list command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { listSegmentsCommand } = await import(
-      '../../../src/commands/segments/list'
-    );
     await expectExit1(() =>
       listSegmentsCommand.parseAsync([], { from: 'user' }),
     );
@@ -161,9 +144,6 @@ describe('segments list command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { listSegmentsCommand } = await import(
-      '../../../src/commands/segments/list'
-    );
     await expectExit1(() =>
       listSegmentsCommand.parseAsync([], { from: 'user' }),
     );

--- a/tests/commands/suppressions/add.test.ts
+++ b/tests/commands/suppressions/add.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { addSuppressionCommand } from '../../../src/commands/suppressions/add';
 import {
   captureTestEnv,
   expectExit1,
@@ -53,9 +54,6 @@ describe('suppressions add command', () => {
 
   it('suppresses the email passed as an argument', async () => {
     spies = setupOutputSpies();
-    const { addSuppressionCommand } = await import(
-      '../../../src/commands/suppressions/add'
-    );
     await addSuppressionCommand.parseAsync(['spam@example.com'], {
       from: 'user',
     });
@@ -65,9 +63,6 @@ describe('suppressions add command', () => {
 
   it('outputs the created suppression JSON when non-interactive', async () => {
     spies = setupOutputSpies();
-    const { addSuppressionCommand } = await import(
-      '../../../src/commands/suppressions/add'
-    );
     await addSuppressionCommand.parseAsync(['spam@example.com'], {
       from: 'user',
     });
@@ -83,9 +78,6 @@ describe('suppressions add command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { addSuppressionCommand } = await import(
-      '../../../src/commands/suppressions/add'
-    );
     await expectExit1(() =>
       addSuppressionCommand.parseAsync([], { from: 'user' }),
     );
@@ -104,9 +96,6 @@ describe('suppressions add command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { addSuppressionCommand } = await import(
-      '../../../src/commands/suppressions/add'
-    );
     await expectExit1(() =>
       addSuppressionCommand.parseAsync(['spam@example.com'], { from: 'user' }),
     );

--- a/tests/commands/suppressions/batch.test.ts
+++ b/tests/commands/suppressions/batch.test.ts
@@ -10,6 +10,8 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { batchAddSuppressionsCommand } from '../../../src/commands/suppressions/batch/add';
+import { batchRemoveSuppressionsCommand } from '../../../src/commands/suppressions/batch/remove';
 import {
   captureTestEnv,
   expectExit1,
@@ -67,9 +69,6 @@ describe('suppressions batch commands', () => {
     writeFileSync(tmpFile, JSON.stringify(['a@example.com', 'b@example.com']));
     _spies = setupOutputSpies();
 
-    const { batchAddSuppressionsCommand } = await import(
-      '../../../src/commands/suppressions/batch/add'
-    );
     await batchAddSuppressionsCommand.parseAsync(['--file', tmpFile], {
       from: 'user',
     });
@@ -83,9 +82,6 @@ describe('suppressions batch commands', () => {
     writeFileSync(tmpFile, JSON.stringify(['a@example.com']));
     _spies = setupOutputSpies();
 
-    const { batchRemoveSuppressionsCommand } = await import(
-      '../../../src/commands/suppressions/batch/remove'
-    );
     await batchRemoveSuppressionsCommand.parseAsync(['--file', tmpFile], {
       from: 'user',
     });
@@ -97,9 +93,6 @@ describe('suppressions batch commands', () => {
     writeFileSync(tmpFile, JSON.stringify(['sup-1', 'sup-2']));
     _spies = setupOutputSpies();
 
-    const { batchRemoveSuppressionsCommand } = await import(
-      '../../../src/commands/suppressions/batch/remove'
-    );
     await batchRemoveSuppressionsCommand.parseAsync(
       ['--file', tmpFile, '--ids'],
       { from: 'user' },
@@ -114,9 +107,6 @@ describe('suppressions batch commands', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { batchAddSuppressionsCommand } = await import(
-      '../../../src/commands/suppressions/batch/add'
-    );
     await expectExit1(() =>
       batchAddSuppressionsCommand.parseAsync(['--file', tmpFile], {
         from: 'user',
@@ -133,9 +123,6 @@ describe('suppressions batch commands', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { batchAddSuppressionsCommand } = await import(
-      '../../../src/commands/suppressions/batch/add'
-    );
     await expectExit1(() =>
       batchAddSuppressionsCommand.parseAsync([], { from: 'user' }),
     );

--- a/tests/commands/suppressions/delete.test.ts
+++ b/tests/commands/suppressions/delete.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { deleteSuppressionCommand } from '../../../src/commands/suppressions/delete';
 import {
   captureTestEnv,
   expectExit1,
@@ -53,9 +54,6 @@ describe('suppressions delete command', () => {
 
   it('removes a suppression by email with --yes', async () => {
     spies = setupOutputSpies();
-    const { deleteSuppressionCommand } = await import(
-      '../../../src/commands/suppressions/delete'
-    );
     await deleteSuppressionCommand.parseAsync(['spam@example.com', '--yes'], {
       from: 'user',
     });
@@ -65,9 +63,6 @@ describe('suppressions delete command', () => {
 
   it('outputs synthesized deleted JSON on success', async () => {
     spies = setupOutputSpies();
-    const { deleteSuppressionCommand } = await import(
-      '../../../src/commands/suppressions/delete'
-    );
     await deleteSuppressionCommand.parseAsync(['sup-1', '--yes'], {
       from: 'user',
     });
@@ -84,9 +79,6 @@ describe('suppressions delete command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { deleteSuppressionCommand } = await import(
-      '../../../src/commands/suppressions/delete'
-    );
     await expectExit1(() =>
       deleteSuppressionCommand.parseAsync(['sup-1'], { from: 'user' }),
     );
@@ -105,9 +97,6 @@ describe('suppressions delete command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { deleteSuppressionCommand } = await import(
-      '../../../src/commands/suppressions/delete'
-    );
     await expectExit1(() =>
       deleteSuppressionCommand.parseAsync(['sup-1', '--yes'], { from: 'user' }),
     );

--- a/tests/commands/suppressions/get.test.ts
+++ b/tests/commands/suppressions/get.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { getSuppressionCommand } from '../../../src/commands/suppressions/get';
 import {
   captureTestEnv,
   expectExit1,
@@ -60,9 +61,6 @@ describe('suppressions get command', () => {
 
   it('fetches by email argument', async () => {
     spies = setupOutputSpies();
-    const { getSuppressionCommand } = await import(
-      '../../../src/commands/suppressions/get'
-    );
     await getSuppressionCommand.parseAsync(['spam@example.com'], {
       from: 'user',
     });
@@ -72,9 +70,6 @@ describe('suppressions get command', () => {
 
   it('fetches by id argument', async () => {
     spies = setupOutputSpies();
-    const { getSuppressionCommand } = await import(
-      '../../../src/commands/suppressions/get'
-    );
     await getSuppressionCommand.parseAsync(['sup-1'], { from: 'user' });
 
     expect(mockGet).toHaveBeenCalledWith('sup-1');
@@ -82,9 +77,6 @@ describe('suppressions get command', () => {
 
   it('outputs the suppression JSON when non-interactive', async () => {
     spies = setupOutputSpies();
-    const { getSuppressionCommand } = await import(
-      '../../../src/commands/suppressions/get'
-    );
     await getSuppressionCommand.parseAsync(['spam@example.com'], {
       from: 'user',
     });
@@ -104,9 +96,6 @@ describe('suppressions get command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { getSuppressionCommand } = await import(
-      '../../../src/commands/suppressions/get'
-    );
     await expectExit1(() =>
       getSuppressionCommand.parseAsync(['sup-1'], { from: 'user' }),
     );

--- a/tests/commands/suppressions/list.test.ts
+++ b/tests/commands/suppressions/list.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { listSuppressionsCommand } from '../../../src/commands/suppressions/list';
 import {
   captureTestEnv,
   expectExit1,
@@ -82,9 +83,6 @@ describe('suppressions list command', () => {
 
   it('uses default limit of 10 when not specified', async () => {
     spies = setupOutputSpies();
-    const { listSuppressionsCommand } = await import(
-      '../../../src/commands/suppressions/list'
-    );
     await listSuppressionsCommand.parseAsync([], { from: 'user' });
 
     expect(mockList).toHaveBeenCalledTimes(1);
@@ -93,9 +91,6 @@ describe('suppressions list command', () => {
 
   it('outputs JSON list when non-interactive', async () => {
     spies = setupOutputSpies();
-    const { listSuppressionsCommand } = await import(
-      '../../../src/commands/suppressions/list'
-    );
     await listSuppressionsCommand.parseAsync([], { from: 'user' });
 
     const output = spies.logSpy.mock.calls[0][0] as string;
@@ -107,9 +102,6 @@ describe('suppressions list command', () => {
 
   it('passes origin filter to SDK', async () => {
     spies = setupOutputSpies();
-    const { listSuppressionsCommand } = await import(
-      '../../../src/commands/suppressions/list'
-    );
     await listSuppressionsCommand.parseAsync(['--origin', 'bounce'], {
       from: 'user',
     });
@@ -125,9 +117,6 @@ describe('suppressions list command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { listSuppressionsCommand } = await import(
-      '../../../src/commands/suppressions/list'
-    );
     await expect(
       listSuppressionsCommand.parseAsync(['--origin', 'nope'], {
         from: 'user',
@@ -139,9 +128,6 @@ describe('suppressions list command', () => {
 
   it('passes after cursor to SDK', async () => {
     spies = setupOutputSpies();
-    const { listSuppressionsCommand } = await import(
-      '../../../src/commands/suppressions/list'
-    );
     await listSuppressionsCommand.parseAsync(['--after', 'cur'], {
       from: 'user',
     });
@@ -181,9 +167,6 @@ describe('suppressions list command', () => {
     delete process.env.TERM;
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
-    const { listSuppressionsCommand } = await import(
-      '../../../src/commands/suppressions/list'
-    );
     await listSuppressionsCommand.parseAsync(['--origin', 'bounce'], {
       from: 'user',
     });
@@ -204,9 +187,6 @@ describe('suppressions list command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { listSuppressionsCommand } = await import(
-      '../../../src/commands/suppressions/list'
-    );
     await expectExit1(() =>
       listSuppressionsCommand.parseAsync([], { from: 'user' }),
     );

--- a/tests/commands/templates/create.test.ts
+++ b/tests/commands/templates/create.test.ts
@@ -1,3 +1,4 @@
+import { Command } from '@commander-js/extra-typings';
 import {
   afterEach,
   beforeEach,
@@ -7,6 +8,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { createTemplateCommand } from '../../../src/commands/templates/create';
 import * as files from '../../../src/lib/files';
 import {
   captureTestEnv,
@@ -72,9 +74,6 @@ describe('templates create command', () => {
   it('creates template with required flags', async () => {
     spies = setupOutputSpies();
 
-    const { createTemplateCommand } = await import(
-      '../../../src/commands/templates/create'
-    );
     await createTemplateCommand.parseAsync(
       ['--name', 'Welcome', '--html', '<h1>Hello</h1>'],
       { from: 'user' },
@@ -89,9 +88,6 @@ describe('templates create command', () => {
   it('outputs JSON result when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { createTemplateCommand } = await import(
-      '../../../src/commands/templates/create'
-    );
     await createTemplateCommand.parseAsync(
       ['--name', 'Welcome', '--html', '<h1>Hello</h1>'],
       { from: 'user' },
@@ -107,9 +103,6 @@ describe('templates create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createTemplateCommand } = await import(
-      '../../../src/commands/templates/create'
-    );
     await expectExit1(() =>
       createTemplateCommand.parseAsync(['--html', '<h1>Hello</h1>'], {
         from: 'user',
@@ -125,9 +118,6 @@ describe('templates create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createTemplateCommand } = await import(
-      '../../../src/commands/templates/create'
-    );
     await expectExit1(() =>
       createTemplateCommand.parseAsync(['--name', 'Welcome'], {
         from: 'user',
@@ -150,10 +140,6 @@ describe('templates create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { Command } = await import('@commander-js/extra-typings');
-    const { createTemplateCommand } = await import(
-      '../../../src/commands/templates/create'
-    );
     const program = new Command()
       .option('--profile <name>')
       .option('--team <name>')
@@ -180,10 +166,6 @@ describe('templates create command', () => {
       .mockReturnValueOnce('<h1>HTML</h1>')
       .mockReturnValueOnce('Plain text from file');
 
-    const { createTemplateCommand } = await import(
-      '../../../src/commands/templates/create'
-    );
-
     await createTemplateCommand.parseAsync(
       [
         '--name',
@@ -206,9 +188,6 @@ describe('templates create command', () => {
     spies = setupOutputSpies();
     readFileSpy = vi.spyOn(files, 'readFile').mockReturnValue('From file');
 
-    const { createTemplateCommand } = await import(
-      '../../../src/commands/templates/create'
-    );
     await createTemplateCommand.parseAsync(
       [
         '--name',
@@ -236,9 +215,6 @@ describe('templates create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createTemplateCommand } = await import(
-      '../../../src/commands/templates/create'
-    );
     await expectExit1(() =>
       createTemplateCommand.parseAsync(
         ['--name', 'Welcome', '--html', '<h1>Hello</h1>'],
@@ -253,9 +229,6 @@ describe('templates create command', () => {
   it('creates template with --react-email flag', async () => {
     spies = setupOutputSpies();
 
-    const { createTemplateCommand } = await import(
-      '../../../src/commands/templates/create'
-    );
     await createTemplateCommand.parseAsync(
       ['--name', 'Welcome', '--react-email', './emails/welcome.tsx'],
       { from: 'user' },
@@ -274,9 +247,6 @@ describe('templates create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createTemplateCommand } = await import(
-      '../../../src/commands/templates/create'
-    );
     await expectExit1(() =>
       createTemplateCommand.parseAsync(
         [
@@ -306,9 +276,6 @@ describe('templates create command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { createTemplateCommand } = await import(
-      '../../../src/commands/templates/create'
-    );
     await expectExit1(() =>
       createTemplateCommand.parseAsync(
         ['--name', 'Welcome', '--html', '<h1>Hello</h1>'],

--- a/tests/commands/templates/open.test.ts
+++ b/tests/commands/templates/open.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { openTemplateCommand } from '../../../src/commands/templates/open';
 import * as browser from '../../../src/lib/browser';
 
 describe('templates open command', () => {
@@ -11,9 +12,6 @@ describe('templates open command', () => {
   });
 
   it('with no args opens templates list', async () => {
-    const { openTemplateCommand } = await import(
-      '../../../src/commands/templates/open'
-    );
     await openTemplateCommand.parseAsync([], { from: 'user' });
 
     expect(browser.openInBrowserOrLog).toHaveBeenCalledTimes(1);
@@ -24,9 +22,6 @@ describe('templates open command', () => {
   });
 
   it('with id opens template URL', async () => {
-    const { openTemplateCommand } = await import(
-      '../../../src/commands/templates/open'
-    );
     await openTemplateCommand.parseAsync(
       ['78261eea-8f8b-4381-83c6-79fa7120f1cf'],
       { from: 'user' },

--- a/tests/commands/templates/update.test.ts
+++ b/tests/commands/templates/update.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { updateTemplateCommand } from '../../../src/commands/templates/update';
 import * as files from '../../../src/lib/files';
 import {
   captureTestEnv,
@@ -87,9 +88,6 @@ describe('templates update command', () => {
   it('updates template name', async () => {
     spies = setupOutputSpies();
 
-    const { updateTemplateCommand } = await import(
-      '../../../src/commands/templates/update'
-    );
     await updateTemplateCommand.parseAsync(
       ['tmpl_abc123', '--name', 'Updated Name'],
       { from: 'user' },
@@ -104,9 +102,6 @@ describe('templates update command', () => {
   it('omits fields not provided from SDK payload', async () => {
     spies = setupOutputSpies();
 
-    const { updateTemplateCommand } = await import(
-      '../../../src/commands/templates/update'
-    );
     await updateTemplateCommand.parseAsync(
       ['tmpl_abc123', '--subject', 'New Subject'],
       { from: 'user' },
@@ -125,9 +120,6 @@ describe('templates update command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { updateTemplateCommand } = await import(
-      '../../../src/commands/templates/update'
-    );
     await expectExit1(() =>
       updateTemplateCommand.parseAsync([], { from: 'user' }),
     );
@@ -145,9 +137,6 @@ describe('templates update command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { updateTemplateCommand } = await import(
-      '../../../src/commands/templates/update'
-    );
     await expectExit1(() =>
       updateTemplateCommand.parseAsync(
         ['tmpl_abc123', '--react-email', './emails/welcome.tsx', '--html', ''],
@@ -166,9 +155,6 @@ describe('templates update command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { updateTemplateCommand } = await import(
-      '../../../src/commands/templates/update'
-    );
     await expectExit1(() =>
       updateTemplateCommand.parseAsync(
         ['tmpl_abc123', '--html', '', '--html-file', '/fake/template.html'],
@@ -185,9 +171,6 @@ describe('templates update command', () => {
     spies = setupOutputSpies();
     readFileSpy = vi.spyOn(files, 'readFile').mockReturnValue('From file');
 
-    const { updateTemplateCommand } = await import(
-      '../../../src/commands/templates/update'
-    );
     await updateTemplateCommand.parseAsync(
       ['tmpl_abc123', '--text', '', '--text-file', '/fake/body.txt'],
       { from: 'user' },

--- a/tests/commands/topics/create.test.ts
+++ b/tests/commands/topics/create.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { createTopicCommand } from '../../../src/commands/topics/create';
 import {
   captureTestEnv,
   expectExit1,
@@ -54,9 +55,6 @@ describe('topics create command', () => {
   it('creates topic with --name and default subscription', async () => {
     spies = setupOutputSpies();
 
-    const { createTopicCommand } = await import(
-      '../../../src/commands/topics/create'
-    );
     await createTopicCommand.parseAsync(['--name', 'Product Updates'], {
       from: 'user',
     });
@@ -70,9 +68,6 @@ describe('topics create command', () => {
   it('creates topic with explicit --default-subscription opt_out', async () => {
     spies = setupOutputSpies();
 
-    const { createTopicCommand } = await import(
-      '../../../src/commands/topics/create'
-    );
     await createTopicCommand.parseAsync(
       ['--name', 'Weekly Digest', '--default-subscription', 'opt_out'],
       { from: 'user' },
@@ -85,9 +80,6 @@ describe('topics create command', () => {
   it('includes description when --description is provided', async () => {
     spies = setupOutputSpies();
 
-    const { createTopicCommand } = await import(
-      '../../../src/commands/topics/create'
-    );
     await createTopicCommand.parseAsync(
       [
         '--name',
@@ -105,9 +97,6 @@ describe('topics create command', () => {
   it('outputs JSON with id when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { createTopicCommand } = await import(
-      '../../../src/commands/topics/create'
-    );
     await createTopicCommand.parseAsync(['--name', 'Product Updates'], {
       from: 'user',
     });
@@ -122,9 +111,6 @@ describe('topics create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createTopicCommand } = await import(
-      '../../../src/commands/topics/create'
-    );
     await expectExit1(() =>
       createTopicCommand.parseAsync([], { from: 'user' }),
     );
@@ -138,9 +124,6 @@ describe('topics create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createTopicCommand } = await import(
-      '../../../src/commands/topics/create'
-    );
     await expectExit1(() =>
       createTopicCommand.parseAsync([], { from: 'user' }),
     );
@@ -155,9 +138,6 @@ describe('topics create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createTopicCommand } = await import(
-      '../../../src/commands/topics/create'
-    );
     await expectExit1(() =>
       createTopicCommand.parseAsync(['--name', 'Test'], { from: 'user' }),
     );
@@ -177,9 +157,6 @@ describe('topics create command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { createTopicCommand } = await import(
-      '../../../src/commands/topics/create'
-    );
     await expectExit1(() =>
       createTopicCommand.parseAsync(['--name', 'Product Updates'], {
         from: 'user',

--- a/tests/commands/topics/delete.test.ts
+++ b/tests/commands/topics/delete.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { deleteTopicCommand } from '../../../src/commands/topics/delete';
 import {
   captureTestEnv,
   expectExit1,
@@ -54,9 +55,6 @@ describe('topics delete command', () => {
   it('deletes topic with --yes flag', async () => {
     spies = setupOutputSpies();
 
-    const { deleteTopicCommand } = await import(
-      '../../../src/commands/topics/delete'
-    );
     await deleteTopicCommand.parseAsync(['top_abc123', '--yes'], {
       from: 'user',
     });
@@ -68,9 +66,6 @@ describe('topics delete command', () => {
   it('outputs synthesized JSON result when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { deleteTopicCommand } = await import(
-      '../../../src/commands/topics/delete'
-    );
     await deleteTopicCommand.parseAsync(['top_abc123', '--yes'], {
       from: 'user',
     });
@@ -87,9 +82,6 @@ describe('topics delete command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { deleteTopicCommand } = await import(
-      '../../../src/commands/topics/delete'
-    );
     await expectExit1(() =>
       deleteTopicCommand.parseAsync(['top_abc123'], { from: 'user' }),
     );
@@ -103,9 +95,6 @@ describe('topics delete command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { deleteTopicCommand } = await import(
-      '../../../src/commands/topics/delete'
-    );
     await expectExit1(() =>
       deleteTopicCommand.parseAsync(['top_abc123'], { from: 'user' }),
     );
@@ -120,9 +109,6 @@ describe('topics delete command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { deleteTopicCommand } = await import(
-      '../../../src/commands/topics/delete'
-    );
     await expectExit1(() =>
       deleteTopicCommand.parseAsync(['top_abc123', '--yes'], { from: 'user' }),
     );
@@ -142,9 +128,6 @@ describe('topics delete command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { deleteTopicCommand } = await import(
-      '../../../src/commands/topics/delete'
-    );
     await expectExit1(() =>
       deleteTopicCommand.parseAsync(['top_nonexistent', '--yes'], {
         from: 'user',

--- a/tests/commands/topics/get.test.ts
+++ b/tests/commands/topics/get.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { getTopicCommand } from '../../../src/commands/topics/get';
 import {
   captureTestEnv,
   expectExit1,
@@ -60,9 +61,6 @@ describe('topics get command', () => {
   it('calls SDK with the provided topic ID', async () => {
     spies = setupOutputSpies();
 
-    const { getTopicCommand } = await import(
-      '../../../src/commands/topics/get'
-    );
     await getTopicCommand.parseAsync(['top_abc123'], { from: 'user' });
 
     expect(mockGet).toHaveBeenCalledTimes(1);
@@ -72,9 +70,6 @@ describe('topics get command', () => {
   it('outputs JSON topic data when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { getTopicCommand } = await import(
-      '../../../src/commands/topics/get'
-    );
     await getTopicCommand.parseAsync(['top_abc123'], { from: 'user' });
 
     const output = spies.logSpy.mock.calls[0][0] as string;
@@ -93,9 +88,6 @@ describe('topics get command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { getTopicCommand } = await import(
-      '../../../src/commands/topics/get'
-    );
     await expectExit1(() =>
       getTopicCommand.parseAsync(['top_abc123'], { from: 'user' }),
     );
@@ -113,9 +105,6 @@ describe('topics get command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { getTopicCommand } = await import(
-      '../../../src/commands/topics/get'
-    );
     await expectExit1(() =>
       getTopicCommand.parseAsync(['top_nonexistent'], { from: 'user' }),
     );

--- a/tests/commands/topics/list.test.ts
+++ b/tests/commands/topics/list.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { listTopicsCommand } from '../../../src/commands/topics/list';
 import {
   captureTestEnv,
   expectExit1,
@@ -64,9 +65,6 @@ describe('topics list command', () => {
   it('calls SDK list method', async () => {
     spies = setupOutputSpies();
 
-    const { listTopicsCommand } = await import(
-      '../../../src/commands/topics/list'
-    );
     await listTopicsCommand.parseAsync([], { from: 'user' });
 
     expect(mockList).toHaveBeenCalledTimes(1);
@@ -75,9 +73,6 @@ describe('topics list command', () => {
   it('outputs JSON list when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { listTopicsCommand } = await import(
-      '../../../src/commands/topics/list'
-    );
     await listTopicsCommand.parseAsync([], { from: 'user' });
 
     const output = spies.logSpy.mock.calls[0][0] as string;
@@ -94,9 +89,6 @@ describe('topics list command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { listTopicsCommand } = await import(
-      '../../../src/commands/topics/list'
-    );
     await expectExit1(() => listTopicsCommand.parseAsync([], { from: 'user' }));
 
     const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
@@ -114,9 +106,6 @@ describe('topics list command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { listTopicsCommand } = await import(
-      '../../../src/commands/topics/list'
-    );
     await expectExit1(() => listTopicsCommand.parseAsync([], { from: 'user' }));
 
     const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');

--- a/tests/commands/topics/update.test.ts
+++ b/tests/commands/topics/update.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { updateTopicCommand } from '../../../src/commands/topics/update';
 import {
   captureTestEnv,
   expectExit1,
@@ -54,9 +55,6 @@ describe('topics update command', () => {
   it('calls SDK with id and name when --name is provided', async () => {
     spies = setupOutputSpies();
 
-    const { updateTopicCommand } = await import(
-      '../../../src/commands/topics/update'
-    );
     await updateTopicCommand.parseAsync(
       ['top_abc123', '--name', 'Security Alerts'],
       { from: 'user' },
@@ -71,9 +69,6 @@ describe('topics update command', () => {
   it('calls SDK with id and description when --description is provided', async () => {
     spies = setupOutputSpies();
 
-    const { updateTopicCommand } = await import(
-      '../../../src/commands/topics/update'
-    );
     await updateTopicCommand.parseAsync(
       ['top_abc123', '--description', 'Updated desc'],
       { from: 'user' },
@@ -88,9 +83,6 @@ describe('topics update command', () => {
   it('outputs JSON with id when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { updateTopicCommand } = await import(
-      '../../../src/commands/topics/update'
-    );
     await updateTopicCommand.parseAsync(
       ['top_abc123', '--name', 'Security Alerts'],
       { from: 'user' },
@@ -106,9 +98,6 @@ describe('topics update command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { updateTopicCommand } = await import(
-      '../../../src/commands/topics/update'
-    );
     await expectExit1(() =>
       updateTopicCommand.parseAsync(['top_abc123'], { from: 'user' }),
     );
@@ -122,9 +111,6 @@ describe('topics update command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { updateTopicCommand } = await import(
-      '../../../src/commands/topics/update'
-    );
     await expectExit1(() =>
       updateTopicCommand.parseAsync(['top_abc123'], { from: 'user' }),
     );
@@ -139,9 +125,6 @@ describe('topics update command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { updateTopicCommand } = await import(
-      '../../../src/commands/topics/update'
-    );
     await expectExit1(() =>
       updateTopicCommand.parseAsync(['top_abc123', '--name', 'Test'], {
         from: 'user',
@@ -163,9 +146,6 @@ describe('topics update command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { updateTopicCommand } = await import(
-      '../../../src/commands/topics/update'
-    );
     await expectExit1(() =>
       updateTopicCommand.parseAsync(['top_nonexistent', '--name', 'Test'], {
         from: 'user',

--- a/tests/commands/webhooks/create.test.ts
+++ b/tests/commands/webhooks/create.test.ts
@@ -1,3 +1,4 @@
+import { Command } from '@commander-js/extra-typings';
 import {
   afterEach,
   beforeEach,
@@ -7,6 +8,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { createWebhookCommand } from '../../../src/commands/webhooks/create';
 import {
   captureTestEnv,
   expectExit1,
@@ -63,9 +65,6 @@ describe('webhooks create command', () => {
   it('creates webhook with --endpoint and explicit --events', async () => {
     spies = setupOutputSpies();
 
-    const { createWebhookCommand } = await import(
-      '../../../src/commands/webhooks/create'
-    );
     await createWebhookCommand.parseAsync(
       [
         '--endpoint',
@@ -86,9 +85,6 @@ describe('webhooks create command', () => {
   it('expands "all" shorthand to all 19 events', async () => {
     spies = setupOutputSpies();
 
-    const { createWebhookCommand } = await import(
-      '../../../src/commands/webhooks/create'
-    );
     await createWebhookCommand.parseAsync(
       ['--endpoint', 'https://app.example.com/hooks', '--events', 'all'],
       { from: 'user' },
@@ -104,9 +100,6 @@ describe('webhooks create command', () => {
   it('outputs JSON with id and signing_secret when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { createWebhookCommand } = await import(
-      '../../../src/commands/webhooks/create'
-    );
     await createWebhookCommand.parseAsync(
       ['--endpoint', 'https://app.example.com/hooks', '--events', 'email.sent'],
       { from: 'user' },
@@ -121,9 +114,6 @@ describe('webhooks create command', () => {
   it('splits comma-separated events', async () => {
     spies = setupOutputSpies();
 
-    const { createWebhookCommand } = await import(
-      '../../../src/commands/webhooks/create'
-    );
     await createWebhookCommand.parseAsync(
       [
         '--endpoint',
@@ -142,9 +132,6 @@ describe('webhooks create command', () => {
   it('handles mixed comma and space-separated events', async () => {
     spies = setupOutputSpies();
 
-    const { createWebhookCommand } = await import(
-      '../../../src/commands/webhooks/create'
-    );
     await createWebhookCommand.parseAsync(
       [
         '--endpoint',
@@ -168,9 +155,6 @@ describe('webhooks create command', () => {
   it('trims spaces around comma-separated events', async () => {
     spies = setupOutputSpies();
 
-    const { createWebhookCommand } = await import(
-      '../../../src/commands/webhooks/create'
-    );
     await createWebhookCommand.parseAsync(
       [
         '--endpoint',
@@ -191,9 +175,6 @@ describe('webhooks create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createWebhookCommand } = await import(
-      '../../../src/commands/webhooks/create'
-    );
     await expectExit1(() =>
       createWebhookCommand.parseAsync(['--events', 'email.sent'], {
         from: 'user',
@@ -209,9 +190,6 @@ describe('webhooks create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createWebhookCommand } = await import(
-      '../../../src/commands/webhooks/create'
-    );
     await expectExit1(() =>
       createWebhookCommand.parseAsync(
         ['--endpoint', 'https://app.example.com/hooks'],
@@ -235,10 +213,6 @@ describe('webhooks create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { Command } = await import('@commander-js/extra-typings');
-    const { createWebhookCommand } = await import(
-      '../../../src/commands/webhooks/create'
-    );
     const program = new Command()
       .option('--profile <name>')
       .option('--team <name>')
@@ -264,9 +238,6 @@ describe('webhooks create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createWebhookCommand } = await import(
-      '../../../src/commands/webhooks/create'
-    );
     await expectExit1(() =>
       createWebhookCommand.parseAsync(['--events', 'email.sent'], {
         from: 'user',
@@ -283,9 +254,6 @@ describe('webhooks create command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { createWebhookCommand } = await import(
-      '../../../src/commands/webhooks/create'
-    );
     await expectExit1(() =>
       createWebhookCommand.parseAsync(
         [
@@ -313,9 +281,6 @@ describe('webhooks create command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { createWebhookCommand } = await import(
-      '../../../src/commands/webhooks/create'
-    );
     await expectExit1(() =>
       createWebhookCommand.parseAsync(
         [

--- a/tests/commands/webhooks/delete.test.ts
+++ b/tests/commands/webhooks/delete.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { deleteWebhookCommand } from '../../../src/commands/webhooks/delete';
 import {
   captureTestEnv,
   expectExit1,
@@ -54,9 +55,6 @@ describe('webhooks delete command', () => {
   it('deletes webhook with --yes flag', async () => {
     spies = setupOutputSpies();
 
-    const { deleteWebhookCommand } = await import(
-      '../../../src/commands/webhooks/delete'
-    );
     await deleteWebhookCommand.parseAsync(['wh_abc123', '--yes'], {
       from: 'user',
     });
@@ -68,9 +66,6 @@ describe('webhooks delete command', () => {
   it('outputs synthesized JSON result when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { deleteWebhookCommand } = await import(
-      '../../../src/commands/webhooks/delete'
-    );
     await deleteWebhookCommand.parseAsync(['wh_abc123', '--yes'], {
       from: 'user',
     });
@@ -87,9 +82,6 @@ describe('webhooks delete command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { deleteWebhookCommand } = await import(
-      '../../../src/commands/webhooks/delete'
-    );
     await expectExit1(() =>
       deleteWebhookCommand.parseAsync(['wh_abc123'], { from: 'user' }),
     );
@@ -103,9 +95,6 @@ describe('webhooks delete command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { deleteWebhookCommand } = await import(
-      '../../../src/commands/webhooks/delete'
-    );
     await expectExit1(() =>
       deleteWebhookCommand.parseAsync(['wh_abc123'], { from: 'user' }),
     );
@@ -120,9 +109,6 @@ describe('webhooks delete command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { deleteWebhookCommand } = await import(
-      '../../../src/commands/webhooks/delete'
-    );
     await expectExit1(() =>
       deleteWebhookCommand.parseAsync(['wh_abc123', '--yes'], { from: 'user' }),
     );
@@ -142,9 +128,6 @@ describe('webhooks delete command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { deleteWebhookCommand } = await import(
-      '../../../src/commands/webhooks/delete'
-    );
     await expectExit1(() =>
       deleteWebhookCommand.parseAsync(['wh_nonexistent', '--yes'], {
         from: 'user',

--- a/tests/commands/webhooks/get.test.ts
+++ b/tests/commands/webhooks/get.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { getWebhookCommand } from '../../../src/commands/webhooks/get';
 import {
   captureTestEnv,
   expectExit1,
@@ -62,9 +63,6 @@ describe('webhooks get command', () => {
   it('calls SDK get with the provided id', async () => {
     spies = setupOutputSpies();
 
-    const { getWebhookCommand } = await import(
-      '../../../src/commands/webhooks/get'
-    );
     await getWebhookCommand.parseAsync(['wh_abc123'], { from: 'user' });
 
     expect(mockGet).toHaveBeenCalledTimes(1);
@@ -74,9 +72,6 @@ describe('webhooks get command', () => {
   it('outputs JSON with webhook fields when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { getWebhookCommand } = await import(
-      '../../../src/commands/webhooks/get'
-    );
     await getWebhookCommand.parseAsync(['wh_abc123'], { from: 'user' });
 
     const output = spies.logSpy.mock.calls[0][0] as string;
@@ -93,9 +88,6 @@ describe('webhooks get command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { getWebhookCommand } = await import(
-      '../../../src/commands/webhooks/get'
-    );
     await expectExit1(() =>
       getWebhookCommand.parseAsync(['wh_abc123'], { from: 'user' }),
     );
@@ -113,9 +105,6 @@ describe('webhooks get command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { getWebhookCommand } = await import(
-      '../../../src/commands/webhooks/get'
-    );
     await expectExit1(() =>
       getWebhookCommand.parseAsync(['wh_nonexistent'], { from: 'user' }),
     );

--- a/tests/commands/webhooks/list.test.ts
+++ b/tests/commands/webhooks/list.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { listWebhooksCommand } from '../../../src/commands/webhooks/list';
 import {
   captureTestEnv,
   expectExit1,
@@ -66,9 +67,6 @@ describe('webhooks list command', () => {
   it('calls SDK list method with default pagination', async () => {
     spies = setupOutputSpies();
 
-    const { listWebhooksCommand } = await import(
-      '../../../src/commands/webhooks/list'
-    );
     await listWebhooksCommand.parseAsync([], { from: 'user' });
 
     expect(mockList).toHaveBeenCalledTimes(1);
@@ -79,9 +77,6 @@ describe('webhooks list command', () => {
   it('passes --limit to pagination options', async () => {
     spies = setupOutputSpies();
 
-    const { listWebhooksCommand } = await import(
-      '../../../src/commands/webhooks/list'
-    );
     await listWebhooksCommand.parseAsync(['--limit', '5'], { from: 'user' });
 
     const args = mockList.mock.calls[0][0] as Record<string, unknown>;
@@ -91,9 +86,6 @@ describe('webhooks list command', () => {
   it('passes --after cursor to pagination options', async () => {
     spies = setupOutputSpies();
 
-    const { listWebhooksCommand } = await import(
-      '../../../src/commands/webhooks/list'
-    );
     await listWebhooksCommand.parseAsync(['--after', 'wh_cursor123'], {
       from: 'user',
     });
@@ -105,9 +97,6 @@ describe('webhooks list command', () => {
   it('outputs JSON list with webhook data when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { listWebhooksCommand } = await import(
-      '../../../src/commands/webhooks/list'
-    );
     await listWebhooksCommand.parseAsync([], { from: 'user' });
 
     const output = spies.logSpy.mock.calls[0][0] as string;
@@ -125,9 +114,6 @@ describe('webhooks list command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { listWebhooksCommand } = await import(
-      '../../../src/commands/webhooks/list'
-    );
     await expectExit1(() =>
       listWebhooksCommand.parseAsync(['--limit', '200'], { from: 'user' }),
     );
@@ -143,9 +129,6 @@ describe('webhooks list command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { listWebhooksCommand } = await import(
-      '../../../src/commands/webhooks/list'
-    );
     await expectExit1(() =>
       listWebhooksCommand.parseAsync([], { from: 'user' }),
     );
@@ -165,9 +148,6 @@ describe('webhooks list command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { listWebhooksCommand } = await import(
-      '../../../src/commands/webhooks/list'
-    );
     await expectExit1(() =>
       listWebhooksCommand.parseAsync([], { from: 'user' }),
     );

--- a/tests/commands/webhooks/listen-forward.test.ts
+++ b/tests/commands/webhooks/listen-forward.test.ts
@@ -1,5 +1,6 @@
 import { createServer, type Server } from 'node:http';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { listenWebhookCommand } from '../../../src/commands/webhooks/listen';
 import {
   captureTestEnv,
   setNonInteractive,
@@ -75,10 +76,6 @@ describe('webhook listen --forward-to status propagation', () => {
     setNonInteractive();
     setupOutputSpies();
 
-    const { listenWebhookCommand } = await import(
-      '../../../src/commands/webhooks/listen'
-    );
-
     const listenerPort = 10_000 + Math.floor(Math.random() * 50_000);
 
     listenWebhookCommand
@@ -145,10 +142,6 @@ describe('webhook listen --forward-to status propagation', () => {
   it('returns 502 when forward target is unreachable', async () => {
     setNonInteractive();
     setupOutputSpies();
-
-    const { listenWebhookCommand } = await import(
-      '../../../src/commands/webhooks/listen'
-    );
 
     const listenerPort = 10_000 + Math.floor(Math.random() * 50_000);
 

--- a/tests/commands/webhooks/update.test.ts
+++ b/tests/commands/webhooks/update.test.ts
@@ -7,6 +7,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { updateWebhookCommand } from '../../../src/commands/webhooks/update';
 import {
   captureTestEnv,
   expectExit1,
@@ -54,9 +55,6 @@ describe('webhooks update command', () => {
   it('updates endpoint with --endpoint flag', async () => {
     spies = setupOutputSpies();
 
-    const { updateWebhookCommand } = await import(
-      '../../../src/commands/webhooks/update'
-    );
     await updateWebhookCommand.parseAsync(
       ['wh_abc123', '--endpoint', 'https://new-app.example.com/hooks'],
       { from: 'user' },
@@ -71,9 +69,6 @@ describe('webhooks update command', () => {
   it('updates events with --events flag', async () => {
     spies = setupOutputSpies();
 
-    const { updateWebhookCommand } = await import(
-      '../../../src/commands/webhooks/update'
-    );
     await updateWebhookCommand.parseAsync(
       ['wh_abc123', '--events', 'email.sent', 'email.bounced'],
       { from: 'user' },
@@ -86,9 +81,6 @@ describe('webhooks update command', () => {
   it('expands "all" shorthand in --events to 19 events', async () => {
     spies = setupOutputSpies();
 
-    const { updateWebhookCommand } = await import(
-      '../../../src/commands/webhooks/update'
-    );
     await updateWebhookCommand.parseAsync(['wh_abc123', '--events', 'all'], {
       from: 'user',
     });
@@ -100,9 +92,6 @@ describe('webhooks update command', () => {
   it('updates status with --status flag', async () => {
     spies = setupOutputSpies();
 
-    const { updateWebhookCommand } = await import(
-      '../../../src/commands/webhooks/update'
-    );
     await updateWebhookCommand.parseAsync(
       ['wh_abc123', '--status', 'disabled'],
       { from: 'user' },
@@ -115,9 +104,6 @@ describe('webhooks update command', () => {
   it('outputs JSON result when non-interactive', async () => {
     spies = setupOutputSpies();
 
-    const { updateWebhookCommand } = await import(
-      '../../../src/commands/webhooks/update'
-    );
     await updateWebhookCommand.parseAsync(
       ['wh_abc123', '--status', 'enabled'],
       { from: 'user' },
@@ -134,9 +120,6 @@ describe('webhooks update command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { updateWebhookCommand } = await import(
-      '../../../src/commands/webhooks/update'
-    );
     await expectExit1(() =>
       updateWebhookCommand.parseAsync(['wh_abc123'], { from: 'user' }),
     );
@@ -150,9 +133,6 @@ describe('webhooks update command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { updateWebhookCommand } = await import(
-      '../../../src/commands/webhooks/update'
-    );
     await expectExit1(() =>
       updateWebhookCommand.parseAsync(['wh_abc123'], { from: 'user' }),
     );
@@ -171,9 +151,6 @@ describe('webhooks update command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { updateWebhookCommand } = await import(
-      '../../../src/commands/webhooks/update'
-    );
     await expectExit1(() =>
       updateWebhookCommand.parseAsync(['wh_abc123', '--events', ','], {
         from: 'user',
@@ -199,9 +176,6 @@ describe('webhooks update command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { updateWebhookCommand } = await import(
-      '../../../src/commands/webhooks/update'
-    );
     await expectExit1(() =>
       updateWebhookCommand.parseAsync(['wh_abc123', '--events', ' , , '], {
         from: 'user',
@@ -223,9 +197,6 @@ describe('webhooks update command', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { updateWebhookCommand } = await import(
-      '../../../src/commands/webhooks/update'
-    );
     await expectExit1(() =>
       updateWebhookCommand.parseAsync(['wh_abc123', '--status', 'enabled'], {
         from: 'user',
@@ -247,9 +218,6 @@ describe('webhooks update command', () => {
       .mockImplementation(() => true);
     exitSpy = mockExitThrow();
 
-    const { updateWebhookCommand } = await import(
-      '../../../src/commands/webhooks/update'
-    );
     await expectExit1(() =>
       updateWebhookCommand.parseAsync(
         ['wh_nonexistent', '--status', 'disabled'],

--- a/tests/lib/client.test.ts
+++ b/tests/lib/client.test.ts
@@ -11,6 +11,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { createClient, requireClient } from '../../src/lib/client';
 import {
   captureTestEnv,
   expectExit1,
@@ -28,7 +29,6 @@ describe('createClient', () => {
   it('returns Resend instance when flag value provided', async () => {
     // Force file backend so tests don't interact with real OS keychain
     process.env.RESEND_CREDENTIAL_STORE = 'file';
-    const { createClient } = await import('../../src/lib/client');
     const client = await createClient('re_test_key');
     expect(client).toBeInstanceOf(Resend);
   });
@@ -36,7 +36,6 @@ describe('createClient', () => {
   it('returns Resend instance when env var set', async () => {
     process.env.RESEND_API_KEY = 're_env_key';
     process.env.RESEND_CREDENTIAL_STORE = 'file';
-    const { createClient } = await import('../../src/lib/client');
     const client = await createClient();
     expect(client).toBeInstanceOf(Resend);
   });
@@ -45,14 +44,12 @@ describe('createClient', () => {
     delete process.env.RESEND_API_KEY;
     process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend-test';
     process.env.RESEND_CREDENTIAL_STORE = 'file';
-    const { createClient } = await import('../../src/lib/client');
     await expect(createClient()).rejects.toThrow('No API key found');
   });
 
   it('flag value takes priority over env var', async () => {
     process.env.RESEND_API_KEY = 're_env_key';
     process.env.RESEND_CREDENTIAL_STORE = 'file';
-    const { createClient } = await import('../../src/lib/client');
     const client = await createClient('re_flag_key');
     expect(client).toBeInstanceOf(Resend);
   });
@@ -80,7 +77,6 @@ describe('createClient', () => {
       }),
     );
 
-    const { createClient } = await import('../../src/lib/client');
     // Should not throw — resolves staging profile's key
     const client = await createClient(undefined, 'staging');
     expect(client).toBeInstanceOf(Resend);
@@ -133,7 +129,6 @@ describe('requireClient permission check', () => {
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { requireClient } = await import('../../src/lib/client');
     await expectExit1(() => requireClient({ json: true }));
 
     const output = errSpy.mock.calls[0][0] as string;
@@ -166,7 +161,6 @@ describe('requireClient permission check', () => {
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { requireClient } = await import('../../src/lib/client');
     await expectExit1(() => requireClient({ json: true }));
 
     const output = errSpy.mock.calls[0][0] as string;
@@ -199,7 +193,6 @@ describe('requireClient permission check', () => {
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { requireClient } = await import('../../src/lib/client');
     await expectExit1(() => requireClient({ json: true }));
 
     const output = errSpy.mock.calls[0][0] as string;
@@ -220,7 +213,6 @@ describe('requireClient permission check', () => {
       }),
     );
 
-    const { requireClient } = await import('../../src/lib/client');
     const client = await requireClient({}, { permission: 'sending_access' });
     expect(client).toBeInstanceOf(Resend);
   });
@@ -238,7 +230,6 @@ describe('requireClient permission check', () => {
       }),
     );
 
-    const { requireClient } = await import('../../src/lib/client');
     const client = await requireClient({});
     expect(client).toBeInstanceOf(Resend);
   });
@@ -254,7 +245,6 @@ describe('requireClient permission check', () => {
       }),
     );
 
-    const { requireClient } = await import('../../src/lib/client');
     const client = await requireClient({});
     expect(client).toBeInstanceOf(Resend);
   });

--- a/tests/lib/credential-backends/windows.test.ts
+++ b/tests/lib/credential-backends/windows.test.ts
@@ -1,4 +1,6 @@
+import { execFile, spawn } from 'node:child_process';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { WindowsBackend } from '../../../src/lib/credential-backends/windows';
 
 // We mock child_process to verify stdin usage without requiring Windows
 vi.mock('node:child_process', () => {
@@ -46,10 +48,6 @@ describe('WindowsBackend', () => {
   });
 
   it('set() passes secret via stdin, NOT in PowerShell script args', async () => {
-    const { spawn } = await import('node:child_process');
-    const { WindowsBackend } = await import(
-      '../../../src/lib/credential-backends/windows'
-    );
     const backend = new WindowsBackend();
 
     await backend.set('resend-cli', 'default', 're_secret_key_1234');
@@ -72,10 +70,6 @@ describe('WindowsBackend', () => {
   });
 
   it('get() does not use stdin', async () => {
-    const { execFile } = await import('node:child_process');
-    const { WindowsBackend } = await import(
-      '../../../src/lib/credential-backends/windows'
-    );
     const backend = new WindowsBackend();
 
     await backend.get('resend-cli', 'default');

--- a/tests/lib/files.test.ts
+++ b/tests/lib/files.test.ts
@@ -2,6 +2,7 @@ import { unlinkSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+import { readFile } from '../../src/lib/files';
 import { expectExit1, mockExitThrow } from '../helpers';
 
 const globalOpts = { json: false, apiKey: undefined };
@@ -26,14 +27,12 @@ describe('readFile', () => {
 
   it('reads file content and returns it as a string', async () => {
     writeFileSync(tmpFile, '<h1>Hello</h1>', 'utf-8');
-    const { readFile } = await import('../../src/lib/files');
     const content = readFile(tmpFile, globalOpts);
     expect(content).toBe('<h1>Hello</h1>');
   });
 
   it('reads JSON file content and returns it as a string', async () => {
     writeFileSync(tmpFile, '[{"id":1}]', 'utf-8');
-    const { readFile } = await import('../../src/lib/files');
     const content = readFile(tmpFile, globalOpts);
     expect(content).toBe('[{"id":1}]');
   });
@@ -42,7 +41,6 @@ describe('readFile', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { readFile } = await import('../../src/lib/files');
     await expectExit1(async () =>
       readFile('/nonexistent/path/data.txt', globalOpts),
     );
@@ -55,7 +53,6 @@ describe('readFile', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     exitSpy = mockExitThrow();
 
-    const { readFile } = await import('../../src/lib/files');
     await expectExit1(async () => readFile('/nonexistent/file.txt', jsonOpts));
 
     const raw = errorSpy?.mock.calls.map((c) => c[0]).join(' ');

--- a/tests/lib/prompts.test.ts
+++ b/tests/lib/prompts.test.ts
@@ -1,4 +1,10 @@
 import { afterEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+import {
+  confirmDelete,
+  pickId,
+  pickItem,
+  promptForMissing,
+} from '../../src/lib/prompts';
 import { expectExit1, mockExitThrow } from '../helpers';
 
 const originalStdinIsTTY = process.stdin.isTTY;
@@ -37,7 +43,6 @@ afterEach(() => {
 
 describe('promptForMissing', () => {
   it('returns options unchanged when nothing is missing', async () => {
-    const { promptForMissing } = await import('../../src/lib/prompts');
     const opts = { from: 'a@b.com', to: 'c@d.com', subject: 'Hi' };
     const result = await promptForMissing(
       opts,
@@ -54,8 +59,6 @@ describe('promptForMissing', () => {
   it('exits with missing_flags error in non-interactive mode', async () => {
     setTTY(undefined);
     setupSpies();
-
-    const { promptForMissing } = await import('../../src/lib/prompts');
 
     await expectExit1(() =>
       promptForMissing(
@@ -79,8 +82,6 @@ describe('promptForMissing', () => {
     setTTY(undefined);
     setupSpies();
 
-    const { promptForMissing } = await import('../../src/lib/prompts');
-
     await expectExit1(() =>
       promptForMissing(
         { from: undefined },
@@ -96,8 +97,6 @@ describe('promptForMissing', () => {
     setTTY(true);
     setupSpies();
 
-    const { promptForMissing } = await import('../../src/lib/prompts');
-
     await expectExit1(() =>
       promptForMissing(
         { from: undefined },
@@ -110,7 +109,6 @@ describe('promptForMissing', () => {
   });
 
   it('skips fields marked as required=false', async () => {
-    const { promptForMissing } = await import('../../src/lib/prompts');
     const opts = { from: 'a@b.com', to: undefined };
     const result = await promptForMissing(
       opts,
@@ -126,7 +124,6 @@ describe('promptForMissing', () => {
 
 describe('pickId', () => {
   it('returns id immediately when provided', async () => {
-    const { pickId } = await import('../../src/lib/prompts');
     const result = await pickId('test-id', {} as never, {});
     expect(result).toBe('test-id');
   });
@@ -134,8 +131,6 @@ describe('pickId', () => {
   it('exits with missing_id error in non-interactive mode', async () => {
     setTTY(undefined);
     setupSpies();
-
-    const { pickId } = await import('../../src/lib/prompts');
 
     await expectExit1(() => pickId(undefined, {} as never, {}));
 
@@ -146,8 +141,6 @@ describe('pickId', () => {
     setTTY(true);
     setupSpies();
 
-    const { pickId } = await import('../../src/lib/prompts');
-
     await expectExit1(() => pickId(undefined, {} as never, { json: true }));
 
     const parsed = JSON.parse(spyOutput());
@@ -157,7 +150,6 @@ describe('pickId', () => {
   it('returns undefined in non-interactive mode when optional', async () => {
     setTTY(undefined);
 
-    const { pickId } = await import('../../src/lib/prompts');
     const result = await pickId(undefined, {} as never, {}, { optional: true });
     expect(result).toBeUndefined();
   });
@@ -165,7 +157,6 @@ describe('pickId', () => {
   it('returns undefined when --json is set and optional', async () => {
     setTTY(true);
 
-    const { pickId } = await import('../../src/lib/prompts');
     const result = await pickId(
       undefined,
       {} as never,
@@ -176,7 +167,6 @@ describe('pickId', () => {
   });
 
   it('returns id immediately when provided and optional', async () => {
-    const { pickId } = await import('../../src/lib/prompts');
     const result = await pickId('test-id', {} as never, {}, { optional: true });
     expect(result).toBe('test-id');
   });
@@ -184,7 +174,6 @@ describe('pickId', () => {
 
 describe('pickItem', () => {
   it('returns id and label matching the id when provided directly', async () => {
-    const { pickItem } = await import('../../src/lib/prompts');
     const result = await pickItem('test-id', {} as never, {});
     expect(result).toEqual({ id: 'test-id', label: 'test-id' });
   });
@@ -192,8 +181,6 @@ describe('pickItem', () => {
   it('exits with missing_id error in non-interactive mode', async () => {
     setTTY(undefined);
     setupSpies();
-
-    const { pickItem } = await import('../../src/lib/prompts');
 
     await expectExit1(() => pickItem(undefined, {} as never, {}));
 
@@ -203,7 +190,6 @@ describe('pickItem', () => {
   it('returns undefined in non-interactive mode when optional', async () => {
     setTTY(undefined);
 
-    const { pickItem } = await import('../../src/lib/prompts');
     const result = await pickItem(
       undefined,
       {} as never,
@@ -214,7 +200,6 @@ describe('pickItem', () => {
   });
 
   it('returns id and label matching the id when provided and optional', async () => {
-    const { pickItem } = await import('../../src/lib/prompts');
     const result = await pickItem(
       'test-id',
       {} as never,
@@ -230,8 +215,6 @@ describe('confirmDelete', () => {
     setTTY(undefined);
     setupSpies();
 
-    const { confirmDelete } = await import('../../src/lib/prompts');
-
     await expectExit1(() =>
       confirmDelete('res_123', 'Delete resource res_123?', { json: false }),
     );
@@ -243,7 +226,6 @@ describe('confirmDelete', () => {
     setTTY(undefined);
     setupSpies();
 
-    const { confirmDelete } = await import('../../src/lib/prompts');
     await expectExit1(() =>
       confirmDelete('res_123', 'Delete?', { json: true }),
     );
@@ -256,7 +238,6 @@ describe('confirmDelete', () => {
     setTTY(true);
     setupSpies();
 
-    const { confirmDelete } = await import('../../src/lib/prompts');
     await expectExit1(() =>
       confirmDelete('res_123', 'Delete?', { json: true }),
     );

--- a/tests/lib/react-email-bundler.test.ts
+++ b/tests/lib/react-email-bundler.test.ts
@@ -8,6 +8,7 @@ import {
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { bundleReactEmail } from '../../src/lib/react-email-bundler';
 
 const mockBuild = vi.fn(
   async (opts: { outdir: string; entryPoints: string[] }) => {
@@ -22,8 +23,6 @@ const mockBuild = vi.fn(
 vi.mock('../../src/lib/esbuild/load-esbuild', () => ({
   loadEsbuild: () => ({ build: mockBuild }),
 }));
-
-const { bundleReactEmail } = await import('../../src/lib/react-email-bundler');
 
 const createdDirs: string[] = [];
 

--- a/tests/lib/telemetry.test.ts
+++ b/tests/lib/telemetry.test.ts
@@ -23,6 +23,7 @@ vi.hoisted(() => {
   process.env.POSTHOG_PUBLIC_KEY = 'phc_test_key';
 });
 
+import * as cp from 'node:child_process';
 import {
   flushFromFile,
   flushPayload,
@@ -111,7 +112,6 @@ describe('trackCommand', () => {
     delete process.env.RESEND_TELEMETRY_DISABLED;
 
     unrefMock = vi.fn();
-    const cp = await import('node:child_process');
     spawnMock = vi
       .mocked(cp.spawn)
       // @ts-expect-error -- only unref() is needed for this test


### PR DESCRIPTION
## Summary
- Removes the per-`it()` `await import(...)` boilerplate from 98 test files and hoists the imports to the top of each file as static imports.
- No functional reason for the dynamic imports: `vi.mock()` is hoisted by Vitest regardless of import style, and ES module caching means a dynamic `import()` returns the same cached instance every time within a test file, so it provided zero isolation.
- Left the 6 files that call `vi.resetModules()` between tests untouched (`spinner.test.ts`, `tty.test.ts`, `config-async.test.ts`, `whoami.test.ts`, `emails/send.test.ts`, `emails/receiving/listen.test.ts`) — there, dynamic import is genuinely needed to pick up a fresh module after the cache reset.

Follow-up to https://github.com/resend/resend-cli/pull/366#discussion_r3830116783.

## Test plan
- [x] `pnpm test` — 131 test files, 1128 tests passing
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)