### PR TITLE
feat(segments): add update command to rename a segment

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "esbuild": "0.28.1",
     "esbuild-wasm": "0.28.0",
     "picocolors": "1.1.1",
-    "resend": "6.22.0"
+    "resend": "6.23.0"
   },
   "pkg": {
     "scripts": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-cli",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "description": "The official CLI for Resend",
   "license": "MIT",
   "repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: 1.1.1
         version: 1.1.1
       resend:
-        specifier: 6.22.0
-        version: 6.22.0
+        specifier: 6.23.0
+        version: 6.23.0
     devDependencies:
       '@biomejs/biome':
         specifier: 2.4.11
@@ -1226,8 +1226,8 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
-  resend@6.22.0:
-    resolution: {integrity: sha512-dP1jyl0n1Dx7GYDb0bcsbv9Yx0oBRLhUtSyNFRIOsSzV9MvCVbua/3WP6YUP2JptAU5BciEWGInV+hFjUuYLUw==}
+  resend@6.23.0:
+    resolution: {integrity: sha512-Yzdq6egQDmhkHzkYOiD0e0zj2m8TUxAPH6vzhF+KQWUhcK1BYgoUjr1dcazLu41+I4A2YLDEY3b0Df25wCVwiA==}
     engines: {node: '>=20'}
     peerDependencies:
       '@react-email/render': '*'
@@ -2431,7 +2431,7 @@ snapshots:
 
   require-directory@2.1.1: {}
 
-  resend@6.22.0:
+  resend@6.23.0:
     dependencies:
       postal-mime: 2.7.5
       standardwebhooks: 1.0.0

--- a/skills/resend-cli/SKILL.md
+++ b/skills/resend-cli/SKILL.md
@@ -153,7 +153,7 @@ Auth resolves: `--api-key` flag > `RESEND_API_KEY` env > config file (`resend lo
 | `broadcasts` | create, send, get, update, delete, list, cancel, open, clicked-links, recipients |
 | `contacts` | create, update, delete, segments, topics, imports |
 | `contact-properties` | create, update, delete, list |
-| `segments` | create, get, list, delete, contacts |
+| `segments` | create, get, list, update, delete, contacts |
 | `templates` | create, publish, duplicate, delete, list |
 | `topics` | create, update, delete, list |
 | `webhooks` | create, update, listen, delete, list |

--- a/skills/resend-cli/references/segments.md
+++ b/skills/resend-cli/references/segments.md
@@ -28,6 +28,20 @@ Detailed flag specifications for `resend segments` commands.
 
 ---
 
+## segments update
+
+Rename a segment.
+
+**Argument:** `[id]` — Segment UUID (interactive picker if omitted)
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--name <name>` | string | Yes (non-interactive) | New segment name |
+
+**Output:** `{"object":"segment","id":"...","name":"..."}`
+
+---
+
 ## segments delete
 
 **Argument:** `<id>` — Segment UUID

--- a/skills/resend-cli/references/segments.md
+++ b/skills/resend-cli/references/segments.md
@@ -38,7 +38,7 @@ Rename a segment.
 |------|------|----------|-------------|
 | `--name <name>` | string | Yes (non-interactive) | New segment name |
 
-**Output:** `{"object":"segment","id":"...","name":"..."}`
+**Output:** `{"object":"segment","id":"..."}`
 
 ---
 

--- a/src/commands/segments/index.ts
+++ b/src/commands/segments/index.ts
@@ -5,6 +5,7 @@ import { createSegmentCommand } from './create';
 import { deleteSegmentCommand } from './delete';
 import { getSegmentCommand } from './get';
 import { listSegmentsCommand } from './list';
+import { updateSegmentCommand } from './update';
 
 export const segmentsCommand = new Command('segments')
   .description('Manage segments')
@@ -18,13 +19,12 @@ Contacts can belong to multiple segments.
 Segment membership is managed through the contacts namespace:
   resend contacts add-segment <contactId> --segment-id <segmentId>
   resend contacts remove-segment <contactId> <segmentId>
-  resend contacts segments <contactId>
-
-There is no "update" endpoint — to rename a segment, delete it and recreate.`,
+  resend contacts segments <contactId>`,
       examples: [
         'resend segments list',
         'resend segments create --name "Newsletter Subscribers"',
         'resend segments get 78261eea-8f8b-4381-83c6-79fa7120f1cf',
+        'resend segments update 78261eea-8f8b-4381-83c6-79fa7120f1cf --name "Active Subscribers"',
         'resend segments contacts 78261eea-8f8b-4381-83c6-79fa7120f1cf',
         'resend segments delete 78261eea-8f8b-4381-83c6-79fa7120f1cf --yes',
       ],
@@ -34,4 +34,5 @@ There is no "update" endpoint — to rename a segment, delete it and recreate.`,
   .addCommand(createSegmentCommand)
   .addCommand(getSegmentCommand)
   .addCommand(listSegmentsCommand, { isDefault: true })
+  .addCommand(updateSegmentCommand)
   .addCommand(deleteSegmentCommand);

--- a/src/commands/segments/update.ts
+++ b/src/commands/segments/update.ts
@@ -13,7 +13,7 @@ export const updateSegmentCommand = new Command('update')
     'after',
     buildHelpText({
       context: `Non-interactive: --name is required (no prompts when stdin/stdout is not a TTY).`,
-      output: `  {"object":"segment","id":"<uuid>","name":"<name>"}`,
+      output: `  {"object":"segment","id":"<uuid>"}`,
       errorCodes: ['auth_error', 'missing_name', 'update_error'],
       examples: [
         'resend segments update 78261eea-8f8b-4381-83c6-79fa7120f1cf --name "Active Subscribers"',
@@ -45,10 +45,9 @@ export const updateSegmentCommand = new Command('update')
       {
         loading: 'Updating segment...',
         sdkCall: (resend) =>
-          resend.patch<{ object: 'segment'; id: string; name: string }>(
-            `/segments/${id}`,
-            { name },
-          ),
+          resend.patch<{ object: 'segment'; id: string }>(`/segments/${id}`, {
+            name,
+          }),
         errorCode: 'update_error',
         successMsg: `Segment updated: ${id}`,
       },

--- a/src/commands/segments/update.ts
+++ b/src/commands/segments/update.ts
@@ -44,10 +44,7 @@ export const updateSegmentCommand = new Command('update')
     await runWrite(
       {
         loading: 'Updating segment...',
-        sdkCall: (resend) =>
-          resend.patch<{ object: 'segment'; id: string }>(`/segments/${id}`, {
-            name,
-          }),
+        sdkCall: (resend) => resend.segments.update(id, { name }),
         errorCode: 'update_error',
         successMsg: `Segment updated: ${id}`,
       },

--- a/src/commands/segments/update.ts
+++ b/src/commands/segments/update.ts
@@ -2,6 +2,7 @@ import { Command } from '@commander-js/extra-typings';
 import { runWrite } from '../../lib/actions';
 import type { GlobalOpts } from '../../lib/client';
 import { buildHelpText } from '../../lib/help-text';
+import { outputError } from '../../lib/output';
 import { pickId, requireText } from '../../lib/prompts';
 import { segmentPickerConfig } from './utils';
 
@@ -40,6 +41,13 @@ export const updateSegmentCommand = new Command('update')
       { message: 'Missing --name flag.', code: 'missing_name' },
       globalOpts,
     );
+
+    if (!name) {
+      outputError(
+        { message: 'Name is required.', code: 'missing_name' },
+        { json: globalOpts.json },
+      );
+    }
 
     await runWrite(
       {

--- a/src/commands/segments/update.ts
+++ b/src/commands/segments/update.ts
@@ -1,0 +1,57 @@
+import { Command } from '@commander-js/extra-typings';
+import { runWrite } from '../../lib/actions';
+import type { GlobalOpts } from '../../lib/client';
+import { buildHelpText } from '../../lib/help-text';
+import { pickId, requireText } from '../../lib/prompts';
+import { segmentPickerConfig } from './utils';
+
+export const updateSegmentCommand = new Command('update')
+  .description('Rename a segment')
+  .argument('[id]', 'Segment UUID')
+  .option('--name <name>', 'New segment name')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      context: `Non-interactive: --name is required (no prompts when stdin/stdout is not a TTY).`,
+      output: `  {"object":"segment","id":"<uuid>","name":"<name>"}`,
+      errorCodes: ['auth_error', 'missing_name', 'update_error'],
+      examples: [
+        'resend segments update 78261eea-8f8b-4381-83c6-79fa7120f1cf --name "Active Subscribers"',
+        'resend segments update 78261eea-8f8b-4381-83c6-79fa7120f1cf --name "Active Subscribers" --json',
+      ],
+    }),
+  )
+  .action(async (idArg, opts, cmd) => {
+    const globalOpts = cmd.optsWithGlobals() as GlobalOpts;
+    const id = await pickId(idArg, segmentPickerConfig, globalOpts);
+
+    const name = await requireText(
+      opts.name,
+      {
+        message: 'New segment name',
+        placeholder: 'e.g. Active Subscribers',
+        validate: (v) => {
+          if (!v) {
+            return 'Name is required';
+          }
+          return undefined;
+        },
+      },
+      { message: 'Missing --name flag.', code: 'missing_name' },
+      globalOpts,
+    );
+
+    await runWrite(
+      {
+        loading: 'Updating segment...',
+        sdkCall: (resend) =>
+          resend.patch<{ object: 'segment'; id: string; name: string }>(
+            `/segments/${id}`,
+            { name },
+          ),
+        errorCode: 'update_error',
+        successMsg: `Segment updated: ${id}`,
+      },
+      globalOpts,
+    );
+  });

--- a/tests/commands/segments/update.test.ts
+++ b/tests/commands/segments/update.test.ts
@@ -1,0 +1,206 @@
+import { Command } from '@commander-js/extra-typings';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from 'vitest';
+import { updateSegmentCommand } from '../../../src/commands/segments/update';
+import {
+  captureTestEnv,
+  expectExit1,
+  mockExitThrow,
+  mockSdkError,
+  setNonInteractive,
+  setupOutputSpies,
+} from '../../helpers';
+
+const mockPatch = vi.fn(async () => ({
+  data: {
+    object: 'segment' as const,
+    id: '3f2a1b4c-5d6e-7f8a-9b0c-1d2e3f4a5b6c',
+    name: 'Active Subscribers',
+  },
+  error: null,
+}));
+
+vi.mock('resend', () => ({
+  Resend: class MockResend {
+    constructor(public key: string) {}
+    patch = mockPatch;
+  },
+}));
+
+describe('segments update command', () => {
+  const restoreEnv = captureTestEnv();
+  let spies: ReturnType<typeof setupOutputSpies> | undefined;
+  let errorSpy: MockInstance | undefined;
+  let stderrSpy: MockInstance | undefined;
+  let exitSpy: MockInstance | undefined;
+  let commandRef: { parent: unknown } | undefined;
+
+  beforeEach(() => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    mockPatch.mockClear();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    errorSpy?.mockRestore();
+    stderrSpy?.mockRestore();
+    exitSpy?.mockRestore();
+    spies = undefined;
+    errorSpy = undefined;
+    stderrSpy = undefined;
+    exitSpy = undefined;
+    if (commandRef) {
+      commandRef.parent = null;
+      commandRef = undefined;
+    }
+  });
+
+  it('updates segment with id and --name flag', async () => {
+    spies = setupOutputSpies();
+
+    await updateSegmentCommand.parseAsync(
+      ['3f2a1b4c-5d6e-7f8a-9b0c-1d2e3f4a5b6c', '--name', 'Active Subscribers'],
+      { from: 'user' },
+    );
+
+    expect(mockPatch).toHaveBeenCalledTimes(1);
+    expect(mockPatch.mock.calls[0][0]).toBe(
+      '/segments/3f2a1b4c-5d6e-7f8a-9b0c-1d2e3f4a5b6c',
+    );
+    const payload = mockPatch.mock.calls[0][1] as Record<string, unknown>;
+    expect(payload.name).toBe('Active Subscribers');
+  });
+
+  it('outputs JSON result when non-interactive', async () => {
+    spies = setupOutputSpies();
+
+    await updateSegmentCommand.parseAsync(
+      ['3f2a1b4c-5d6e-7f8a-9b0c-1d2e3f4a5b6c', '--name', 'Active Subscribers'],
+      { from: 'user' },
+    );
+
+    const output = spies.logSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output);
+    expect(parsed.object).toBe('segment');
+    expect(parsed.id).toBe('3f2a1b4c-5d6e-7f8a-9b0c-1d2e3f4a5b6c');
+    expect(parsed.name).toBe('Active Subscribers');
+  });
+
+  it('errors with missing_name when --name absent in non-interactive mode', async () => {
+    setNonInteractive();
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = mockExitThrow();
+
+    await expectExit1(() =>
+      updateSegmentCommand.parseAsync(
+        ['3f2a1b4c-5d6e-7f8a-9b0c-1d2e3f4a5b6c'],
+        { from: 'user' },
+      ),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('missing_name');
+  });
+
+  it('errors with missing_name when --json is set even in TTY', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: true,
+      writable: true,
+    });
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: true,
+      writable: true,
+    });
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = mockExitThrow();
+
+    const program = new Command()
+      .option('--profile <name>')
+      .option('--team <name>')
+      .option('--json')
+      .option('--api-key <key>')
+      .option('-q, --quiet')
+      .addCommand(updateSegmentCommand);
+    commandRef = updateSegmentCommand as unknown as { parent: unknown };
+
+    await expectExit1(() =>
+      program.parseAsync(
+        ['update', '3f2a1b4c-5d6e-7f8a-9b0c-1d2e3f4a5b6c', '--json'],
+        { from: 'user' },
+      ),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('missing_name');
+  });
+
+  it('does not call SDK when missing_name error is raised', async () => {
+    setNonInteractive();
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = mockExitThrow();
+
+    await expectExit1(() =>
+      updateSegmentCommand.parseAsync(
+        ['3f2a1b4c-5d6e-7f8a-9b0c-1d2e3f4a5b6c'],
+        { from: 'user' },
+      ),
+    );
+
+    expect(mockPatch).not.toHaveBeenCalled();
+  });
+
+  it('errors with auth_error when no API key', async () => {
+    setNonInteractive();
+    delete process.env.RESEND_API_KEY;
+    process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = mockExitThrow();
+
+    await expectExit1(() =>
+      updateSegmentCommand.parseAsync(
+        [
+          '3f2a1b4c-5d6e-7f8a-9b0c-1d2e3f4a5b6c',
+          '--name',
+          'Active Subscribers',
+        ],
+        { from: 'user' },
+      ),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('auth_error');
+  });
+
+  it('errors with update_error when SDK returns an error', async () => {
+    setNonInteractive();
+    mockPatch.mockResolvedValueOnce(
+      mockSdkError('Segment not found', 'not_found'),
+    );
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    exitSpy = mockExitThrow();
+
+    await expectExit1(() =>
+      updateSegmentCommand.parseAsync(
+        [
+          '3f2a1b4c-5d6e-7f8a-9b0c-1d2e3f4a5b6c',
+          '--name',
+          'Active Subscribers',
+        ],
+        { from: 'user' },
+      ),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('update_error');
+  });
+});

--- a/tests/commands/segments/update.test.ts
+++ b/tests/commands/segments/update.test.ts
@@ -18,7 +18,7 @@ import {
   setupOutputSpies,
 } from '../../helpers';
 
-const mockPatch = vi.fn(async () => ({
+const mockUpdate = vi.fn(async () => ({
   data: {
     object: 'segment' as const,
     id: '3f2a1b4c-5d6e-7f8a-9b0c-1d2e3f4a5b6c',
@@ -29,7 +29,7 @@ const mockPatch = vi.fn(async () => ({
 vi.mock('resend', () => ({
   Resend: class MockResend {
     constructor(public key: string) {}
-    patch = mockPatch;
+    segments = { update: mockUpdate };
   },
 }));
 
@@ -43,7 +43,7 @@ describe('segments update command', () => {
 
   beforeEach(() => {
     process.env.RESEND_API_KEY = 're_test_key';
-    mockPatch.mockClear();
+    mockUpdate.mockClear();
   });
 
   afterEach(() => {
@@ -69,11 +69,11 @@ describe('segments update command', () => {
       { from: 'user' },
     );
 
-    expect(mockPatch).toHaveBeenCalledTimes(1);
-    expect(mockPatch.mock.calls[0][0]).toBe(
-      '/segments/3f2a1b4c-5d6e-7f8a-9b0c-1d2e3f4a5b6c',
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    expect(mockUpdate.mock.calls[0][0]).toBe(
+      '3f2a1b4c-5d6e-7f8a-9b0c-1d2e3f4a5b6c',
     );
-    const payload = mockPatch.mock.calls[0][1] as Record<string, unknown>;
+    const payload = mockUpdate.mock.calls[0][1] as Record<string, unknown>;
     expect(payload.name).toBe('Active Subscribers');
   });
 
@@ -151,7 +151,7 @@ describe('segments update command', () => {
       ),
     );
 
-    expect(mockPatch).not.toHaveBeenCalled();
+    expect(mockUpdate).not.toHaveBeenCalled();
   });
 
   it('errors with auth_error when no API key', async () => {
@@ -178,7 +178,7 @@ describe('segments update command', () => {
 
   it('errors with update_error when SDK returns an error', async () => {
     setNonInteractive();
-    mockPatch.mockResolvedValueOnce(
+    mockUpdate.mockResolvedValueOnce(
       mockSdkError('Segment not found', 'not_found'),
     );
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/tests/commands/segments/update.test.ts
+++ b/tests/commands/segments/update.test.ts
@@ -22,7 +22,6 @@ const mockPatch = vi.fn(async () => ({
   data: {
     object: 'segment' as const,
     id: '3f2a1b4c-5d6e-7f8a-9b0c-1d2e3f4a5b6c',
-    name: 'Active Subscribers',
   },
   error: null,
 }));
@@ -90,7 +89,6 @@ describe('segments update command', () => {
     const parsed = JSON.parse(output);
     expect(parsed.object).toBe('segment');
     expect(parsed.id).toBe('3f2a1b4c-5d6e-7f8a-9b0c-1d2e3f4a5b6c');
-    expect(parsed.name).toBe('Active Subscribers');
   });
 
   it('errors with missing_name when --name absent in non-interactive mode', async () => {

--- a/tests/commands/segments/update.test.ts
+++ b/tests/commands/segments/update.test.ts
@@ -139,6 +139,45 @@ describe('segments update command', () => {
     expect(output).toContain('missing_name');
   });
 
+  it('errors with missing_name when --name is an empty string, even in TTY', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: true,
+      writable: true,
+    });
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: true,
+      writable: true,
+    });
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = mockExitThrow();
+
+    const program = new Command()
+      .option('--profile <name>')
+      .option('--team <name>')
+      .option('--json')
+      .option('--api-key <key>')
+      .option('-q, --quiet')
+      .addCommand(updateSegmentCommand);
+    commandRef = updateSegmentCommand as unknown as { parent: unknown };
+
+    await expectExit1(() =>
+      program.parseAsync(
+        [
+          'update',
+          '3f2a1b4c-5d6e-7f8a-9b0c-1d2e3f4a5b6c',
+          '--name',
+          '',
+          '--json',
+        ],
+        { from: 'user' },
+      ),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('missing_name');
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
   it('does not call SDK when missing_name error is raised', async () => {
     setNonInteractive();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});


### PR DESCRIPTION
Adds \`resend segments update <id>\` for \`PATCH /segments/:id\`.

## Usage

\`\`\`
resend segments update 78261eea-8f8b-4381-83c6-79fa7120f1cf --name "Active Subscribers"
\`\`\`

## Flags

| Flag | Type | Required | Description |
|------|------|----------|-------------|
| \`--name <name>\` | string | Yes (non-interactive) | New segment name |

## Output

\`\`\`
{"object":"segment","id":"<uuid>"}
\`\`\`