### PR TITLE
feat: prompt yes/no for boolean careers application fields

### DIFF
--- a/skills/resend-cli/references/careers.md
+++ b/skills/resend-cli/references/careers.md
@@ -40,6 +40,7 @@ Interactive mode walks through every question in the job's application form; fla
 **Notes:**
 - Applying twice with the same email fails with `apply_error` ("An application has already been submitted...").
 - The resume is required by the API for every position.
+- Yes/no questions (`Boolean` fields on the job posting) take `true` or `false` via `--field`; interactive mode prompts with a Yes/No select.
 
 **Example (non-interactive):**
 ```bash

--- a/src/commands/careers/apply.ts
+++ b/src/commands/careers/apply.ts
@@ -308,7 +308,13 @@ async function confirmSubmission(
     const field = fieldByPath.get(path);
     const label = field?.title ?? path;
     const display =
-      field?.type === 'Boolean' ? (value === 'true' ? 'Yes' : 'No') : value;
+      field?.type === 'Boolean'
+        ? value === 'true'
+          ? 'Yes'
+          : value === 'false'
+            ? 'No'
+            : value
+        : value;
     return `${label}: ${truncate(display, 80)}`;
   });
   lines.push(`Resume: ${basename(resumePath)}`);

--- a/src/commands/careers/apply.ts
+++ b/src/commands/careers/apply.ts
@@ -234,6 +234,19 @@ async function promptField(field: CareerField): Promise<string | undefined> {
     return result === SKIP_OPTION ? undefined : result;
   }
 
+  if (field.type === 'Boolean') {
+    const options = [
+      ...(field.required ? [] : [{ value: SKIP_OPTION, label: 'Skip' }]),
+      { value: 'true', label: 'Yes' },
+      { value: 'false', label: 'No' },
+    ];
+    const result = await p.select({ message, options });
+    if (p.isCancel(result)) {
+      cancelAndExit('Application cancelled.');
+    }
+    return result === SKIP_OPTION ? undefined : result;
+  }
+
   const result = await p.text({
     message,
     ...(field.description ? { placeholder: field.description } : {}),
@@ -290,12 +303,13 @@ async function confirmSubmission(
   answers: Map<string, string>,
   resumePath: string,
 ): Promise<void> {
-  const titleByPath = new Map(
-    job.fields.map((field) => [field.path, field.title]),
-  );
+  const fieldByPath = new Map(job.fields.map((field) => [field.path, field]));
   const lines = [...answers.entries()].map(([path, value]) => {
-    const label = titleByPath.get(path) ?? path;
-    return `${label}: ${truncate(value, 80)}`;
+    const field = fieldByPath.get(path);
+    const label = field?.title ?? path;
+    const display =
+      field?.type === 'Boolean' ? (value === 'true' ? 'Yes' : 'No') : value;
+    return `${label}: ${truncate(display, 80)}`;
   });
   lines.push(`Resume: ${basename(resumePath)}`);
 


### PR DESCRIPTION
## Summary

Ashby job applications are getting a new Boolean field type (rendered as Yes/No on the careers page, see resend/resend-monorepo#9190). The interactive `careers apply` flow had no handling for it, so boolean questions fell through to the free-text prompt and any typed answer was submitted verbatim.

- `promptField` now renders a Yes/No select for `Boolean` fields (with a Skip option when the question is optional), storing `true`/`false`
- The confirmation summary displays boolean answers as Yes/No instead of raw `true`/`false`
- Documented in the skill reference that boolean questions take `true`/`false` via `--field`

Non-interactive mode is unchanged: `--field <uuid>=true` already worked since everything is a string on the wire.

## Testing

- `pnpm typecheck`, `biome check`, and the careers test suite pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Yes/No prompts for boolean fields in the interactive `careers apply` command, and displays boolean answers as Yes/No in the confirmation summary. Non-interactive mode remains unchanged, since `--field` already accepts `true`/`false` as strings.

- Optional boolean fields now offer a Skip option.
- Pre-filled boolean answers that aren't lowercase `'true'` (e.g., `TRUE`, `yes`, `1`) now show their raw value in the summary instead of being mislabeled as "No".
- Updated the skill reference to document boolean field values.

<sup>Written for commit 1e3657cf0f111448ff076133322736972a390ad7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-cli/pull/375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

