### PR TITLE
fix(skill): remove piped installers and api-key flag mentions flagged by registry audit

### DIFF
--- a/skills/resend-cli/SKILL.md
+++ b/skills/resend-cli/SKILL.md
@@ -13,7 +13,7 @@ metadata:
   author: resend
   # Skill version is independent from the CLI/package.json version —
   # bump it on skill content changes, not CLI releases.
-  version: "2.8.0"
+  version: "2.9.0"
   homepage: https://resend.com/docs/cli-agents
   source: https://github.com/resend/resend-cli
   openclaw:
@@ -87,17 +87,7 @@ npm install -g resend-cli
 brew install resend/cli/resend
 ```
 
-**Install script** — note: these download and execute a remote script. Prefer npm or Homebrew when available.
-
-```bash
-# macOS / Linux
-curl -fsSL https://resend.com/install.sh | bash
-```
-
-```powershell
-# Windows PowerShell
-irm https://resend.com/install.ps1 | iex
-```
+Other install methods (installer scripts for macOS, Linux, and Windows) are documented at [resend.com/docs/cli](https://resend.com/docs/cli).
 
 After installing, verify:
 ```bash
@@ -122,7 +112,7 @@ The CLI auto-detects non-TTY environments and outputs JSON — no `--json` flag 
 
 ## Authentication
 
-Auth resolves: `--api-key` flag > `RESEND_API_KEY` env > config file (`resend login --key`). Use `--profile` or `RESEND_PROFILE` for multi-profile.
+Auth resolves: `RESEND_API_KEY` env > config file (`resend login --key`). Use `--profile` or `RESEND_PROFILE` for multi-profile.
 
 **Credential safety:**
 - Never write a literal API key into a command, script, or file — it ends up in shell history, logs, and transcripts. Reference the environment (`"$RESEND_API_KEY"`) or use a stored profile (`resend login`).
@@ -132,7 +122,6 @@ Auth resolves: `--api-key` flag > `RESEND_API_KEY` env > config file (`resend lo
 
 | Flag | Description |
 |------|-------------|
-| `--api-key <key>` | Override API key for this invocation |
 | `-p, --profile <name>` | Select stored profile |
 | `--json` | Force JSON output (auto in non-TTY) |
 | `-q, --quiet` | Suppress spinners/status (implies `--json`) |

--- a/skills/resend-cli/references/error-codes.md
+++ b/skills/resend-cli/references/error-codes.md
@@ -10,7 +10,7 @@ All errors exit with code `1` and output JSON to **stderr**:
 
 | Code | Cause | Resolution |
 |------|-------|------------|
-| `auth_error` | No API key found from any source | Set `RESEND_API_KEY` env, pass `--api-key`, or run `resend login` |
+| `auth_error` | No API key found from any source | Set `RESEND_API_KEY` env or run `resend login` |
 | `missing_key` | `login` called non-interactively without `--key` | Pass `--key "$RESEND_API_KEY"` (from env/secret manager, never a literal) |
 | `invalid_key_format` | API key does not start with `re_` | Use a valid Resend API key starting with `re_` |
 | `validation_failed` | Resend API rejected the key during login | Verify the key exists and is active at resend.com/api-keys |

--- a/skills/resend-cli/references/workflows.md
+++ b/skills/resend-cli/references/workflows.md
@@ -7,11 +7,10 @@ Multi-step recipes for common Resend CLI tasks.
 ## 1. Initial Setup
 
 ```bash
-# Install (pick one — prefer a package manager)
+# Install (pick one)
 npm install -g resend-cli                          # npm
 brew install resend/cli/resend                     # Homebrew (macOS / Linux)
-curl -fsSL https://resend.com/install.sh | bash   # install script (executes a remote script)
-irm https://resend.com/install.ps1 | iex           # Windows PowerShell (executes a remote script)
+# Other install methods: https://resend.com/docs/cli
 
 # Authenticate — pass the key from an env var or secret manager;
 # never type a literal key (it lands in shell history)


### PR DESCRIPTION
The skills.sh registry runs a Snyk audit on the `resend-cli` skill, and the current verdict is High Risk. Two findings map to skill text. W007 (high) fires on docs that show API keys passed by flag. W012 (medium) fires on piped install scripts. PR #321 hardened the same spots in June but kept both patterns with caveats. The scanner detects the pattern, not the caveat.

This PR removes the patterns:

- Drop every `--api-key` mention. The CLI help text still documents the flag. Agents authenticate through `RESEND_API_KEY`, which the skill already requires.
- Replace the `curl | bash` and `irm | iex` blocks with a link to the install docs.
- Bump the skill version to 2.9.0.

The remaining finding, W011 (medium), flags `emails receiving` as third-party content ingestion. It is inherent to the feature, and no doc change clears it. With W007 and W012 gone, the expected verdict on a re-scan is Medium.

Start at `skills/resend-cli/SKILL.md:90` and `skills/resend-cli/SKILL.md:115`.

Snyk report: https://www.skills.sh/resend/resend-skills/resend-cli/security/snyk


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears the Snyk High Risk verdict on the `resend-cli` skill by removing the flagged `--api-key` flag mentions and piped install scripts from the docs. The skill now points to the install docs instead of `curl | bash` / `irm | iex`, and the auth table only documents env var and profile-based auth.

- Bumps the skill version to 2.9.0.
- Agents continue to authenticate through `RESEND_API_KEY`, and the CLI help text still documents `--api-key`.
- Expected re-scan verdict drops to Medium; the remaining W011 finding on `emails receiving` is inherent to the feature and not cleared by doc changes.

<sup>Written for commit f4058c5b5a477242e207e6a4dda7698b1547f7b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-cli/pull/378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

