### PR TITLE
feat(webhooks): add event listing commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,11 +438,13 @@ Use `all` with `--events` to subscribe to every event.
 - `update`
 - `delete`
 - `listen`
+- `events` (`list`, `get`, `attempts`)
 
 #### Aliases
 
 - `webhooks ls` → `list`
 - `webhooks rm` → `delete`
+- `webhooks events ls` → `webhooks events list`
 
 ---
 
@@ -560,6 +562,32 @@ ngrok http 4318
 resend webhooks listen --url https://xxxx.ngrok-free.app
 resend webhooks listen --url https://xxxx.ngrok-free.app --forward-to localhost:3000/api/webhooks/resend
 resend webhooks listen --url https://xxxx.ngrok-free.app --port 8080 --events email.sent email.bounced
+```
+
+#### **`resend webhooks events`**
+
+Inspects what Resend already delivered to a webhook. Use it to debug an endpoint that is missing events:
+
+1. `resend webhooks events list <webhook-id>` — find the event
+2. `resend webhooks events get <webhook-id> <event-id>` — see the payload we sent
+3. `resend webhooks events attempts <webhook-id> <event-id>` — see what your endpoint returned
+
+Running `resend webhooks events <webhook-id>` with no subcommand runs `list`.
+
+Both list subcommands paginate forward only — there is no `--before`.
+
+| Flag               | Description                                              |
+| ------------------ | -------------------------------------------------------- |
+| `--limit <n>`      | Max results to return (`1`–`100`, default `10`)          |
+| `--after <cursor>` | Return results after this ID (next page)                 |
+
+`events list` reports each event's `type`, `status` (`pending`, `attempting`, `success`, `failed`), and `created_at`. `events get` adds `next_attempt_at` and the payload that was sent. `events attempts` reports the `http_status_code` and response body your endpoint returned for each try.
+
+```bash
+resend webhooks events list wh_abc123
+resend webhooks events list wh_abc123 --limit 50 --json
+resend webhooks events get wh_abc123 msg_1srOrx2ZWZBpBUvZwXKQmoEYga2
+resend webhooks events attempts wh_abc123 msg_1srOrx2ZWZBpBUvZwXKQmoEYga2
 ```
 
 ---

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "esbuild": "0.28.1",
     "esbuild-wasm": "0.28.0",
     "picocolors": "1.1.1",
-    "resend": "6.23.0"
+    "resend": "6.25.0"
   },
   "pkg": {
     "scripts": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-cli",
-  "version": "2.17.1",
+  "version": "2.18.0",
   "description": "The official CLI for Resend",
   "license": "MIT",
   "repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: 1.1.1
         version: 1.1.1
       resend:
-        specifier: 6.23.0
-        version: 6.23.0
+        specifier: 6.25.0
+        version: 6.25.0
     devDependencies:
       '@biomejs/biome':
         specifier: 2.4.11
@@ -1226,8 +1226,8 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
-  resend@6.23.0:
-    resolution: {integrity: sha512-Yzdq6egQDmhkHzkYOiD0e0zj2m8TUxAPH6vzhF+KQWUhcK1BYgoUjr1dcazLu41+I4A2YLDEY3b0Df25wCVwiA==}
+  resend@6.25.0:
+    resolution: {integrity: sha512-iptUEycs+6Hu+W8mExK708LrDiMYOuGgnCP+wTD5L4Zrqqd2B86h1oyAmNe0khZWQw0ccI7jz8OgAaplEsyaIA==}
     engines: {node: '>=20'}
     peerDependencies:
       '@react-email/render': '*'
@@ -2431,7 +2431,7 @@ snapshots:
 
   require-directory@2.1.1: {}
 
-  resend@6.23.0:
+  resend@6.25.0:
     dependencies:
       postal-mime: 2.7.5
       standardwebhooks: 1.0.0

--- a/skills/resend-cli/SKILL.md
+++ b/skills/resend-cli/SKILL.md
@@ -13,7 +13,7 @@ metadata:
   author: resend
   # Skill version is independent from the CLI/package.json version —
   # bump it on skill content changes, not CLI releases.
-  version: "2.9.0"
+  version: "2.10.0"
   homepage: https://resend.com/docs/cli-agents
   source: https://github.com/resend/resend-cli
   openclaw:
@@ -145,7 +145,7 @@ Auth resolves: `RESEND_API_KEY` env > config file (`resend login --key`). Use `-
 | `segments` | create, get, list, update, delete, contacts |
 | `templates` | create, publish, duplicate, delete, list |
 | `topics` | create, update, delete, list |
-| `webhooks` | create, update, listen, delete, list |
+| `webhooks` | create, update, listen, delete, list, events (list, get, attempts) |
 | `auth` | login, logout, switch, rename, remove |
 | `whoami` / `doctor` / `update` / `open` / `commands` | Utility commands |
 

--- a/skills/resend-cli/references/webhooks.md
+++ b/skills/resend-cli/references/webhooks.md
@@ -73,7 +73,7 @@ Lists the events Resend delivered to a webhook, most recent first.
 
 **No `--before`.** These endpoints paginate forward only.
 
-**`status` values:** `pending` (queued), `attempting` (a retry is scheduled), `success`, `failed` (retries exhausted).
+**`status` values:** `pending`, `attempting`, `success`, `failed`.
 
 ---
 

--- a/skills/resend-cli/references/webhooks.md
+++ b/skills/resend-cli/references/webhooks.md
@@ -60,6 +60,51 @@ Detailed flag specifications for `resend webhooks` commands.
 
 ---
 
+## webhooks events list
+
+Lists the events Resend delivered to a webhook, most recent first.
+
+**Argument:** `[webhookId]` — Webhook ID
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--limit <n>` | number | 10 | Max results (1-100) |
+| `--after <cursor>` | string | — | Forward pagination (an event ID) |
+
+**No `--before`.** These endpoints paginate forward only.
+
+**`status` values:** `pending` (queued), `attempting` (a retry is scheduled), `success`, `failed` (retries exhausted).
+
+---
+
+## webhooks events get
+
+**Arguments:** `[webhookId]` `[eventId]`
+
+Returns the event with `next_attempt_at` and the `payload` that was sent to your endpoint.
+`next_attempt_at` is `null` once the event reaches `success` or `failed`.
+
+---
+
+## webhooks events attempts
+
+Lists the delivery attempts for one event, most recent first. Each attempt records the
+`http_status_code` and `response` body your endpoint returned.
+
+**Arguments:** `[webhookId]` `[eventId]`
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--limit <n>` | number | 10 | Max results (1-100) |
+| `--after <cursor>` | string | — | Forward pagination (an attempt ID) |
+
+**Debugging a failed delivery:**
+1. `resend webhooks events list <webhook-id>` — find the event
+2. `resend webhooks events get <webhook-id> <event-id>` — see what we sent
+3. `resend webhooks events attempts <webhook-id> <event-id>` — see what your endpoint returned
+
+---
+
 ## webhooks listen
 
 Start a local server that receives Resend webhook events in real time via a public tunnel URL.

--- a/src/commands/webhooks/events/attempts.ts
+++ b/src/commands/webhooks/events/attempts.ts
@@ -1,0 +1,87 @@
+import { Command } from '@commander-js/extra-typings';
+import { runList } from '../../../lib/actions';
+import type { GlobalOpts } from '../../../lib/client';
+import { buildHelpText } from '../../../lib/help-text';
+import {
+  buildPaginationOpts,
+  parseLimitOpt,
+  printPaginationHint,
+} from '../../../lib/pagination';
+import { pickId } from '../../../lib/prompts';
+import { webhookPickerConfig } from '../utils';
+import {
+  renderWebhookEventAttemptsTable,
+  webhookEventPickerConfig,
+} from './utils';
+
+export const listWebhookEventAttemptsCommand = new Command('attempts')
+  .description(
+    'List the delivery attempts for a webhook event, most recent first',
+  )
+  .argument('[webhookId]', 'Webhook ID')
+  .argument('[eventId]', 'Webhook event ID')
+  .option('--limit <n>', 'Maximum number of attempts to return (1-100)', '10')
+  .option(
+    '--after <cursor>',
+    'Return attempts after this attempt ID (next page)',
+  )
+  .addHelpText(
+    'after',
+    buildHelpText({
+      context: `Each attempt records what your endpoint returned: http_status_code and the
+response body. Use this to debug why an event ended up in the failed status.
+
+This endpoint paginates forward only — there is no --before cursor.`,
+      output: `  {"object":"list","has_more":false,"data":[{"id":"atmpt_...","http_status_code":500,"response":"Internal Server Error","sent_at":"..."}]}`,
+      errorCodes: ['auth_error', 'invalid_limit', 'list_error'],
+      examples: [
+        'resend webhooks events attempts 4dd369bc-aa82-4ff3-97de-514ae3000ee0 msg_1srOrx2ZWZBpBUvZwXKQmoEYga2',
+        'resend webhooks events attempts 4dd369bc-aa82-4ff3-97de-514ae3000ee0 msg_1srOrx2ZWZBpBUvZwXKQmoEYga2 --json',
+      ],
+    }),
+  )
+  .action(async (webhookIdArg, eventIdArg, opts, cmd) => {
+    const globalOpts = cmd.optsWithGlobals() as GlobalOpts;
+    const webhookId = await pickId(
+      webhookIdArg,
+      webhookPickerConfig,
+      globalOpts,
+    );
+    const eventId = await pickId(
+      eventIdArg,
+      webhookEventPickerConfig(webhookId),
+      globalOpts,
+    );
+    const limit = parseLimitOpt(opts.limit, globalOpts);
+    const paginationOpts = buildPaginationOpts(
+      limit,
+      opts.after,
+      undefined,
+      globalOpts,
+    );
+
+    await runList(
+      {
+        loading: 'Fetching delivery attempts...',
+        sdkCall: (resend) =>
+          resend.webhooks.events.attempts.list({
+            webhookId,
+            eventId,
+            ...paginationOpts,
+          }),
+        onInteractive: (list) => {
+          console.log(renderWebhookEventAttemptsTable(list.data));
+          printPaginationHint(
+            list,
+            `webhooks events attempts ${webhookId} ${eventId}`,
+            {
+              limit,
+              apiKey: globalOpts.apiKey,
+              profile: globalOpts.profile,
+            },
+          );
+        },
+      },
+      globalOpts,
+    );
+  });

--- a/src/commands/webhooks/events/attempts.ts
+++ b/src/commands/webhooks/events/attempts.ts
@@ -2,11 +2,7 @@ import { Command } from '@commander-js/extra-typings';
 import { runList } from '../../../lib/actions';
 import type { GlobalOpts } from '../../../lib/client';
 import { buildHelpText } from '../../../lib/help-text';
-import {
-  buildPaginationOpts,
-  parseLimitOpt,
-  printPaginationHint,
-} from '../../../lib/pagination';
+import { parseLimitOpt, printPaginationHint } from '../../../lib/pagination';
 import { pickId } from '../../../lib/prompts';
 import { webhookPickerConfig } from '../utils';
 import {
@@ -53,12 +49,6 @@ This endpoint paginates forward only — there is no --before cursor.`,
       globalOpts,
     );
     const limit = parseLimitOpt(opts.limit, globalOpts);
-    const paginationOpts = buildPaginationOpts(
-      limit,
-      opts.after,
-      undefined,
-      globalOpts,
-    );
 
     await runList(
       {
@@ -67,7 +57,8 @@ This endpoint paginates forward only — there is no --before cursor.`,
           resend.webhooks.events.attempts.list({
             webhookId,
             eventId,
-            ...paginationOpts,
+            limit,
+            ...(opts.after && { after: opts.after }),
           }),
         onInteractive: (list) => {
           console.log(renderWebhookEventAttemptsTable(list.data));

--- a/src/commands/webhooks/events/attempts.ts
+++ b/src/commands/webhooks/events/attempts.ts
@@ -58,7 +58,7 @@ This endpoint paginates forward only — there is no --before cursor.`,
             webhookId,
             eventId,
             limit,
-            ...(opts.after && { after: opts.after }),
+            ...(opts.after !== undefined && { after: opts.after }),
           }),
         onInteractive: (list) => {
           console.log(renderWebhookEventAttemptsTable(list.data));

--- a/src/commands/webhooks/events/get.ts
+++ b/src/commands/webhooks/events/get.ts
@@ -46,7 +46,9 @@ payload is the JSON body that was sent to your endpoint.`,
           console.log(`${event.type} - ${event.status}`);
           console.log(`ID:           ${event.id}`);
           console.log(`Created:      ${event.created_at}`);
-          console.log(`Next attempt: ${event.next_attempt_at ?? '(none)'}`);
+          console.log(
+            `Next attempt: ${event.next_attempt_at ?? 'none scheduled'}`,
+          );
           console.log(`\nPayload:\n${JSON.stringify(event.payload, null, 2)}`);
         },
       },

--- a/src/commands/webhooks/events/get.ts
+++ b/src/commands/webhooks/events/get.ts
@@ -47,7 +47,7 @@ payload is the JSON body that was sent to your endpoint.`,
           console.log(`ID:           ${event.id}`);
           console.log(`Created:      ${event.created_at}`);
           console.log(`Next attempt: ${event.next_attempt_at ?? '(none)'}`);
-          console.log(`Payload:      ${JSON.stringify(event.payload)}`);
+          console.log(`\nPayload:\n${JSON.stringify(event.payload, null, 2)}`);
         },
       },
       globalOpts,

--- a/src/commands/webhooks/events/get.ts
+++ b/src/commands/webhooks/events/get.ts
@@ -1,0 +1,55 @@
+import { Command } from '@commander-js/extra-typings';
+import { runGet } from '../../../lib/actions';
+import type { GlobalOpts } from '../../../lib/client';
+import { buildHelpText } from '../../../lib/help-text';
+import { pickId } from '../../../lib/prompts';
+import { webhookPickerConfig } from '../utils';
+import { webhookEventPickerConfig } from './utils';
+
+export const getWebhookEventCommand = new Command('get')
+  .description('Retrieve a single event delivered to a webhook')
+  .argument('[webhookId]', 'Webhook ID')
+  .argument('[eventId]', 'Webhook event ID')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      context: `next_attempt_at is when the next delivery attempt is scheduled. It is null
+once the event reaches success or failed.
+
+payload is the JSON body that was sent to your endpoint.`,
+      output: `  {"object":"webhook_event","id":"msg_...","type":"email.sent","created_at":"...","status":"attempting","next_attempt_at":"...","payload":{...}}`,
+      errorCodes: ['auth_error', 'fetch_error'],
+      examples: [
+        'resend webhooks events get 4dd369bc-aa82-4ff3-97de-514ae3000ee0 msg_1srOrx2ZWZBpBUvZwXKQmoEYga2',
+        'resend webhooks events get 4dd369bc-aa82-4ff3-97de-514ae3000ee0 msg_1srOrx2ZWZBpBUvZwXKQmoEYga2 --json',
+      ],
+    }),
+  )
+  .action(async (webhookIdArg, eventIdArg, _opts, cmd) => {
+    const globalOpts = cmd.optsWithGlobals() as GlobalOpts;
+    const webhookId = await pickId(
+      webhookIdArg,
+      webhookPickerConfig,
+      globalOpts,
+    );
+    const eventId = await pickId(
+      eventIdArg,
+      webhookEventPickerConfig(webhookId),
+      globalOpts,
+    );
+
+    await runGet(
+      {
+        loading: 'Fetching webhook event...',
+        sdkCall: (resend) => resend.webhooks.events.get({ webhookId, eventId }),
+        onInteractive: (event) => {
+          console.log(`${event.type} - ${event.status}`);
+          console.log(`ID:           ${event.id}`);
+          console.log(`Created:      ${event.created_at}`);
+          console.log(`Next attempt: ${event.next_attempt_at ?? '(none)'}`);
+          console.log(`Payload:      ${JSON.stringify(event.payload)}`);
+        },
+      },
+      globalOpts,
+    );
+  });

--- a/src/commands/webhooks/events/index.ts
+++ b/src/commands/webhooks/events/index.ts
@@ -1,0 +1,28 @@
+import { Command } from '@commander-js/extra-typings';
+import { buildHelpText } from '../../../lib/help-text';
+import { listWebhookEventAttemptsCommand } from './attempts';
+import { getWebhookEventCommand } from './get';
+import { listWebhookEventsCommand } from './list';
+
+export const webhookEventsCommand = new Command('events')
+  .description('Inspect the events Resend delivered to a webhook')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      context: `Debugging a webhook that is missing deliveries:
+  1. resend webhooks events list <webhook-id>                  (find the event)
+  2. resend webhooks events get <webhook-id> <event-id>        (see the payload we sent)
+  3. resend webhooks events attempts <webhook-id> <event-id>   (see what your endpoint returned)
+
+Events are retained per webhook and listed most recent first. Both list commands
+paginate forward only, with --after.`,
+      examples: [
+        'resend webhooks events list 4dd369bc-aa82-4ff3-97de-514ae3000ee0',
+        'resend webhooks events get 4dd369bc-aa82-4ff3-97de-514ae3000ee0 msg_1srOrx2ZWZBpBUvZwXKQmoEYga2',
+        'resend webhooks events attempts 4dd369bc-aa82-4ff3-97de-514ae3000ee0 msg_1srOrx2ZWZBpBUvZwXKQmoEYga2',
+      ],
+    }),
+  )
+  .addCommand(listWebhookEventsCommand, { isDefault: true })
+  .addCommand(getWebhookEventCommand)
+  .addCommand(listWebhookEventAttemptsCommand);

--- a/src/commands/webhooks/events/index.ts
+++ b/src/commands/webhooks/events/index.ts
@@ -14,8 +14,8 @@ export const webhookEventsCommand = new Command('events')
   2. resend webhooks events get <webhook-id> <event-id>        (see the payload we sent)
   3. resend webhooks events attempts <webhook-id> <event-id>   (see what your endpoint returned)
 
-Events are retained per webhook and listed most recent first. Both list commands
-paginate forward only, with --after.`,
+Events are listed most recent first. Both list commands paginate forward only,
+with --after.`,
       examples: [
         'resend webhooks events list 4dd369bc-aa82-4ff3-97de-514ae3000ee0',
         'resend webhooks events get 4dd369bc-aa82-4ff3-97de-514ae3000ee0 msg_1srOrx2ZWZBpBUvZwXKQmoEYga2',

--- a/src/commands/webhooks/events/list.ts
+++ b/src/commands/webhooks/events/list.ts
@@ -46,7 +46,7 @@ This endpoint paginates forward only — there is no --before cursor.`,
           resend.webhooks.events.list({
             webhookId,
             limit,
-            ...(opts.after && { after: opts.after }),
+            ...(opts.after !== undefined && { after: opts.after }),
           }),
         onInteractive: (list) => {
           console.log(renderWebhookEventsTable(list.data));

--- a/src/commands/webhooks/events/list.ts
+++ b/src/commands/webhooks/events/list.ts
@@ -2,16 +2,13 @@ import { Command } from '@commander-js/extra-typings';
 import { runList } from '../../../lib/actions';
 import type { GlobalOpts } from '../../../lib/client';
 import { buildHelpText } from '../../../lib/help-text';
-import {
-  buildPaginationOpts,
-  parseLimitOpt,
-  printPaginationHint,
-} from '../../../lib/pagination';
+import { parseLimitOpt, printPaginationHint } from '../../../lib/pagination';
 import { pickId } from '../../../lib/prompts';
 import { webhookPickerConfig } from '../utils';
 import { renderWebhookEventsTable } from './utils';
 
 export const listWebhookEventsCommand = new Command('list')
+  .alias('ls')
   .description('List the events delivered to a webhook, most recent first')
   .argument('[webhookId]', 'Webhook ID')
   .option('--limit <n>', 'Maximum number of events to return (1-100)', '10')
@@ -20,10 +17,7 @@ export const listWebhookEventsCommand = new Command('list')
     'after',
     buildHelpText({
       context: `status is the delivery status of the event to this webhook:
-  pending     queued, not attempted yet
-  attempting  at least one attempt failed, a retry is scheduled
-  success     the endpoint accepted the delivery
-  failed      every retry was exhausted
+pending, attempting, success, or failed.
 
 This endpoint paginates forward only — there is no --before cursor.`,
       output: `  {"object":"list","has_more":false,"data":[{"id":"msg_...","type":"email.sent","created_at":"...","status":"success"}]}`,
@@ -44,18 +38,16 @@ This endpoint paginates forward only — there is no --before cursor.`,
       globalOpts,
     );
     const limit = parseLimitOpt(opts.limit, globalOpts);
-    const paginationOpts = buildPaginationOpts(
-      limit,
-      opts.after,
-      undefined,
-      globalOpts,
-    );
 
     await runList(
       {
         loading: 'Fetching webhook events...',
         sdkCall: (resend) =>
-          resend.webhooks.events.list({ webhookId, ...paginationOpts }),
+          resend.webhooks.events.list({
+            webhookId,
+            limit,
+            ...(opts.after && { after: opts.after }),
+          }),
         onInteractive: (list) => {
           console.log(renderWebhookEventsTable(list.data));
           printPaginationHint(list, `webhooks events list ${webhookId}`, {

--- a/src/commands/webhooks/events/list.ts
+++ b/src/commands/webhooks/events/list.ts
@@ -1,0 +1,70 @@
+import { Command } from '@commander-js/extra-typings';
+import { runList } from '../../../lib/actions';
+import type { GlobalOpts } from '../../../lib/client';
+import { buildHelpText } from '../../../lib/help-text';
+import {
+  buildPaginationOpts,
+  parseLimitOpt,
+  printPaginationHint,
+} from '../../../lib/pagination';
+import { pickId } from '../../../lib/prompts';
+import { webhookPickerConfig } from '../utils';
+import { renderWebhookEventsTable } from './utils';
+
+export const listWebhookEventsCommand = new Command('list')
+  .description('List the events delivered to a webhook, most recent first')
+  .argument('[webhookId]', 'Webhook ID')
+  .option('--limit <n>', 'Maximum number of events to return (1-100)', '10')
+  .option('--after <cursor>', 'Return events after this event ID (next page)')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      context: `status is the delivery status of the event to this webhook:
+  pending     queued, not attempted yet
+  attempting  at least one attempt failed, a retry is scheduled
+  success     the endpoint accepted the delivery
+  failed      every retry was exhausted
+
+This endpoint paginates forward only — there is no --before cursor.`,
+      output: `  {"object":"list","has_more":false,"data":[{"id":"msg_...","type":"email.sent","created_at":"...","status":"success"}]}`,
+      errorCodes: ['auth_error', 'invalid_limit', 'list_error'],
+      examples: [
+        'resend webhooks events list 4dd369bc-aa82-4ff3-97de-514ae3000ee0',
+        'resend webhooks events list 4dd369bc-aa82-4ff3-97de-514ae3000ee0 --limit 50',
+        'resend webhooks events list 4dd369bc-aa82-4ff3-97de-514ae3000ee0 --after msg_1srOrx2ZWZBpBUvZwXKQmoEYga2',
+        'resend webhooks events list 4dd369bc-aa82-4ff3-97de-514ae3000ee0 --json',
+      ],
+    }),
+  )
+  .action(async (webhookIdArg, opts, cmd) => {
+    const globalOpts = cmd.optsWithGlobals() as GlobalOpts;
+    const webhookId = await pickId(
+      webhookIdArg,
+      webhookPickerConfig,
+      globalOpts,
+    );
+    const limit = parseLimitOpt(opts.limit, globalOpts);
+    const paginationOpts = buildPaginationOpts(
+      limit,
+      opts.after,
+      undefined,
+      globalOpts,
+    );
+
+    await runList(
+      {
+        loading: 'Fetching webhook events...',
+        sdkCall: (resend) =>
+          resend.webhooks.events.list({ webhookId, ...paginationOpts }),
+        onInteractive: (list) => {
+          console.log(renderWebhookEventsTable(list.data));
+          printPaginationHint(list, `webhooks events list ${webhookId}`, {
+            limit,
+            apiKey: globalOpts.apiKey,
+            profile: globalOpts.profile,
+          });
+        },
+      },
+      globalOpts,
+    );
+  });

--- a/src/commands/webhooks/events/utils.ts
+++ b/src/commands/webhooks/events/utils.ts
@@ -36,8 +36,6 @@ export function renderWebhookEventAttemptsTable(
   attempts: ListWebhookEventAttemptsResponseSuccess['data'],
 ): string {
   const rows = attempts.map((a) => {
-    // The response is whatever the customer's endpoint returned — often a
-    // multi-line HTML error page. Newlines would break the table box.
     const response = a.response.replace(/\s+/g, ' ').trim();
     return [
       String(a.http_status_code),

--- a/src/commands/webhooks/events/utils.ts
+++ b/src/commands/webhooks/events/utils.ts
@@ -45,7 +45,7 @@ export function renderWebhookEventAttemptsTable(
     ];
   });
   return renderTable(
-    ['Status', 'Sent', 'Response', 'ID'],
+    ['HTTP', 'Sent', 'Response', 'ID'],
     rows,
     '(no delivery attempts)',
   );

--- a/src/commands/webhooks/events/utils.ts
+++ b/src/commands/webhooks/events/utils.ts
@@ -1,0 +1,49 @@
+import type {
+  ListWebhookEventAttemptsResponseSuccess,
+  ListWebhookEventsResponseSuccess,
+} from 'resend';
+import type { PickerConfig } from '../../../lib/prompts';
+import { renderTable } from '../../../lib/table';
+
+export function webhookEventPickerConfig(
+  webhookId: string,
+): PickerConfig<{ id: string; type: string; status: string }> {
+  return {
+    resource: 'webhook event',
+    resourcePlural: 'webhook events',
+    fetchItems: (resend, { limit, after }) =>
+      resend.webhooks.events.list({
+        webhookId,
+        limit,
+        ...(after && { after }),
+      }),
+    display: (e) => ({ label: `${e.type} (${e.status})`, hint: e.id }),
+  };
+}
+
+export function renderWebhookEventsTable(
+  events: ListWebhookEventsResponseSuccess['data'],
+): string {
+  const rows = events.map((e) => [e.type, e.status, e.created_at, e.id]);
+  return renderTable(
+    ['Type', 'Status', 'Created', 'ID'],
+    rows,
+    '(no webhook events)',
+  );
+}
+
+export function renderWebhookEventAttemptsTable(
+  attempts: ListWebhookEventAttemptsResponseSuccess['data'],
+): string {
+  const rows = attempts.map((a) => [
+    String(a.http_status_code),
+    a.sent_at,
+    a.response.length > 60 ? `${a.response.slice(0, 57)}...` : a.response,
+    a.id,
+  ]);
+  return renderTable(
+    ['Status', 'Sent', 'Response', 'ID'],
+    rows,
+    '(no delivery attempts)',
+  );
+}

--- a/src/commands/webhooks/events/utils.ts
+++ b/src/commands/webhooks/events/utils.ts
@@ -35,12 +35,17 @@ export function renderWebhookEventsTable(
 export function renderWebhookEventAttemptsTable(
   attempts: ListWebhookEventAttemptsResponseSuccess['data'],
 ): string {
-  const rows = attempts.map((a) => [
-    String(a.http_status_code),
-    a.sent_at,
-    a.response.length > 60 ? `${a.response.slice(0, 57)}...` : a.response,
-    a.id,
-  ]);
+  const rows = attempts.map((a) => {
+    // The response is whatever the customer's endpoint returned — often a
+    // multi-line HTML error page. Newlines would break the table box.
+    const response = a.response.replace(/\s+/g, ' ').trim();
+    return [
+      String(a.http_status_code),
+      a.sent_at,
+      response.length > 60 ? `${response.slice(0, 57)}...` : response,
+      a.id,
+    ];
+  });
   return renderTable(
     ['Status', 'Sent', 'Response', 'ID'],
     rows,

--- a/src/commands/webhooks/index.ts
+++ b/src/commands/webhooks/index.ts
@@ -2,6 +2,7 @@ import { Command } from '@commander-js/extra-typings';
 import { buildHelpText } from '../../lib/help-text';
 import { createWebhookCommand } from './create';
 import { deleteWebhookCommand } from './delete';
+import { webhookEventsCommand } from './events';
 import { getWebhookCommand } from './get';
 import { listWebhooksCommand } from './list';
 import { listenWebhookCommand } from './listen';
@@ -25,18 +26,23 @@ Event categories (19 total):
 
 Signature verification (Svix):
   Each delivery includes headers: svix-id, svix-timestamp, svix-signature
-  Verify payloads in your application using: resend.webhooks.verify({ payload, headers, webhookSecret })`,
+  Verify payloads in your application using: resend.webhooks.verify({ payload, headers, webhookSecret })
+
+Delivery history:
+  Inspect what Resend sent and what your endpoint returned with "resend webhooks events".`,
       examples: [
         'resend webhooks list',
         'resend webhooks create --endpoint https://app.example.com/hooks/resend --events all',
         'resend webhooks get wh_abc123',
         'resend webhooks update wh_abc123 --status disabled',
         'resend webhooks delete wh_abc123 --yes',
+        'resend webhooks events list wh_abc123',
       ],
     }),
   )
   .addCommand(createWebhookCommand)
   .addCommand(getWebhookCommand)
+  .addCommand(webhookEventsCommand)
   .addCommand(listenWebhookCommand)
   .addCommand(listWebhooksCommand, { isDefault: true })
   .addCommand(updateWebhookCommand)

--- a/tests/commands/webhooks/events/attempts.test.ts
+++ b/tests/commands/webhooks/events/attempts.test.ts
@@ -1,0 +1,130 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from 'vitest';
+import { listWebhookEventAttemptsCommand } from '../../../../src/commands/webhooks/events/attempts';
+import {
+  captureTestEnv,
+  expectExit1,
+  mockExitThrow,
+  mockSdkError,
+  setNonInteractive,
+  setupOutputSpies,
+} from '../../../helpers';
+
+const WEBHOOK_ID = '4dd369bc-aa82-4ff3-97de-514ae3000ee0';
+const EVENT_ID = 'msg_1srOrx2ZWZBpBUvZwXKQmoEYga2';
+
+const mockListAttempts = vi.fn(async () => ({
+  data: {
+    object: 'list' as const,
+    has_more: false,
+    data: [
+      {
+        id: 'atmpt_2ZbUCwvGmIT4mLIN6d3Yz0Ainbd',
+        http_status_code: 500,
+        response: 'Internal Server Error',
+        sent_at: '2026-08-22T15:28:05.000Z',
+      },
+    ],
+  },
+  error: null,
+}));
+
+vi.mock('resend', () => ({
+  Resend: class MockResend {
+    constructor(public key: string) {}
+    webhooks = { events: { attempts: { list: mockListAttempts } } };
+  },
+}));
+
+describe('webhooks events attempts command', () => {
+  const restoreEnv = captureTestEnv();
+  let spies: ReturnType<typeof setupOutputSpies> | undefined;
+  let errorSpy: MockInstance | undefined;
+  let stderrSpy: MockInstance | undefined;
+  let exitSpy: MockInstance | undefined;
+
+  beforeEach(() => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    mockListAttempts.mockClear();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    errorSpy?.mockRestore();
+    stderrSpy?.mockRestore();
+    exitSpy?.mockRestore();
+    spies = undefined;
+    errorSpy = undefined;
+    stderrSpy = undefined;
+    exitSpy = undefined;
+  });
+
+  it('maps the two positional args to webhookId and eventId in that order', async () => {
+    spies = setupOutputSpies();
+
+    await listWebhookEventAttemptsCommand.parseAsync([WEBHOOK_ID, EVENT_ID], {
+      from: 'user',
+    });
+
+    expect(mockListAttempts).toHaveBeenCalledTimes(1);
+    const opts = mockListAttempts.mock.calls[0][0] as Record<string, unknown>;
+    expect(opts.webhookId).toBe(WEBHOOK_ID);
+    expect(opts.eventId).toBe(EVENT_ID);
+  });
+
+  it('outputs JSON list when non-interactive', async () => {
+    spies = setupOutputSpies();
+
+    await listWebhookEventAttemptsCommand.parseAsync([WEBHOOK_ID, EVENT_ID], {
+      from: 'user',
+    });
+
+    const output = spies.logSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output);
+    expect(parsed.data[0].http_status_code).toBe(500);
+  });
+
+  it('passes --limit and --after to the SDK', async () => {
+    spies = setupOutputSpies();
+
+    await listWebhookEventAttemptsCommand.parseAsync(
+      [WEBHOOK_ID, EVENT_ID, '--limit', '5', '--after', 'atmpt_abc'],
+      { from: 'user' },
+    );
+
+    const opts = mockListAttempts.mock.calls[0][0] as Record<string, unknown>;
+    expect(opts.limit).toBe(5);
+    expect(opts.after).toBe('atmpt_abc');
+  });
+
+  it('errors with list_error when the SDK returns an error', async () => {
+    setNonInteractive();
+    mockListAttempts.mockResolvedValueOnce(
+      mockSdkError(
+        'The resource you are looking for is not available',
+        'not_found',
+      ),
+    );
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    exitSpy = mockExitThrow();
+
+    await expectExit1(() =>
+      listWebhookEventAttemptsCommand.parseAsync([WEBHOOK_ID, EVENT_ID], {
+        from: 'user',
+      }),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('list_error');
+  });
+});

--- a/tests/commands/webhooks/events/get.test.ts
+++ b/tests/commands/webhooks/events/get.test.ts
@@ -1,0 +1,115 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from 'vitest';
+import { getWebhookEventCommand } from '../../../../src/commands/webhooks/events/get';
+import {
+  captureTestEnv,
+  expectExit1,
+  mockExitThrow,
+  mockSdkError,
+  setNonInteractive,
+  setupOutputSpies,
+} from '../../../helpers';
+
+const WEBHOOK_ID = '4dd369bc-aa82-4ff3-97de-514ae3000ee0';
+const EVENT_ID = 'msg_1srOrx2ZWZBpBUvZwXKQmoEYga2';
+
+const mockGetEvent = vi.fn(async () => ({
+  data: {
+    object: 'webhook_event' as const,
+    id: EVENT_ID,
+    type: 'email.sent',
+    created_at: '2026-08-22T15:28:00.000Z',
+    status: 'attempting',
+    next_attempt_at: '2026-08-22T15:33:00.000Z',
+    payload: { type: 'email.sent' },
+  },
+  error: null,
+}));
+
+vi.mock('resend', () => ({
+  Resend: class MockResend {
+    constructor(public key: string) {}
+    webhooks = { events: { get: mockGetEvent } };
+  },
+}));
+
+describe('webhooks events get command', () => {
+  const restoreEnv = captureTestEnv();
+  let spies: ReturnType<typeof setupOutputSpies> | undefined;
+  let errorSpy: MockInstance | undefined;
+  let stderrSpy: MockInstance | undefined;
+  let exitSpy: MockInstance | undefined;
+
+  beforeEach(() => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    mockGetEvent.mockClear();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    errorSpy?.mockRestore();
+    stderrSpy?.mockRestore();
+    exitSpy?.mockRestore();
+    spies = undefined;
+    errorSpy = undefined;
+    stderrSpy = undefined;
+    exitSpy = undefined;
+  });
+
+  it('maps the two positional args to webhookId and eventId in that order', async () => {
+    spies = setupOutputSpies();
+
+    await getWebhookEventCommand.parseAsync([WEBHOOK_ID, EVENT_ID], {
+      from: 'user',
+    });
+
+    expect(mockGetEvent).toHaveBeenCalledTimes(1);
+    const opts = mockGetEvent.mock.calls[0][0] as Record<string, unknown>;
+    expect(opts.webhookId).toBe(WEBHOOK_ID);
+    expect(opts.eventId).toBe(EVENT_ID);
+  });
+
+  it('outputs the event as JSON when non-interactive', async () => {
+    spies = setupOutputSpies();
+
+    await getWebhookEventCommand.parseAsync([WEBHOOK_ID, EVENT_ID], {
+      from: 'user',
+    });
+
+    const output = spies.logSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output);
+    expect(parsed.object).toBe('webhook_event');
+    expect(parsed.next_attempt_at).toBe('2026-08-22T15:33:00.000Z');
+  });
+
+  it('errors with fetch_error when the SDK returns an error', async () => {
+    setNonInteractive();
+    mockGetEvent.mockResolvedValueOnce(
+      mockSdkError(
+        'The resource you are looking for is not available',
+        'not_found',
+      ),
+    );
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    exitSpy = mockExitThrow();
+
+    await expectExit1(() =>
+      getWebhookEventCommand.parseAsync([WEBHOOK_ID, EVENT_ID], {
+        from: 'user',
+      }),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('fetch_error');
+  });
+});

--- a/tests/commands/webhooks/events/list.test.ts
+++ b/tests/commands/webhooks/events/list.test.ts
@@ -1,0 +1,144 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from 'vitest';
+import { listWebhookEventsCommand } from '../../../../src/commands/webhooks/events/list';
+import {
+  captureTestEnv,
+  expectExit1,
+  mockExitThrow,
+  mockSdkError,
+  setNonInteractive,
+  setupOutputSpies,
+} from '../../../helpers';
+
+const WEBHOOK_ID = '4dd369bc-aa82-4ff3-97de-514ae3000ee0';
+
+const mockListEvents = vi.fn(async () => ({
+  data: {
+    object: 'list' as const,
+    has_more: false,
+    data: [
+      {
+        id: 'msg_1srOrx2ZWZBpBUvZwXKQmoEYga2',
+        type: 'email.sent',
+        created_at: '2026-08-22T15:27:42.000Z',
+        status: 'success',
+      },
+    ],
+  },
+  error: null,
+}));
+
+vi.mock('resend', () => ({
+  Resend: class MockResend {
+    constructor(public key: string) {}
+    webhooks = { events: { list: mockListEvents } };
+  },
+}));
+
+describe('webhooks events list command', () => {
+  const restoreEnv = captureTestEnv();
+  let spies: ReturnType<typeof setupOutputSpies> | undefined;
+  let errorSpy: MockInstance | undefined;
+  let stderrSpy: MockInstance | undefined;
+  let exitSpy: MockInstance | undefined;
+
+  beforeEach(() => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    mockListEvents.mockClear();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    errorSpy?.mockRestore();
+    stderrSpy?.mockRestore();
+    exitSpy?.mockRestore();
+    spies = undefined;
+    errorSpy = undefined;
+    stderrSpy = undefined;
+    exitSpy = undefined;
+  });
+
+  it('passes the webhook id through as webhookId, not a positional arg', async () => {
+    spies = setupOutputSpies();
+
+    await listWebhookEventsCommand.parseAsync([WEBHOOK_ID], { from: 'user' });
+
+    expect(mockListEvents).toHaveBeenCalledTimes(1);
+    const opts = mockListEvents.mock.calls[0][0] as Record<string, unknown>;
+    expect(opts.webhookId).toBe(WEBHOOK_ID);
+  });
+
+  it('outputs JSON list when non-interactive', async () => {
+    spies = setupOutputSpies();
+
+    await listWebhookEventsCommand.parseAsync([WEBHOOK_ID], { from: 'user' });
+
+    const output = spies.logSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output);
+    expect(parsed.object).toBe('list');
+    expect(parsed.data[0].type).toBe('email.sent');
+  });
+
+  it('passes --limit and --after to the SDK', async () => {
+    spies = setupOutputSpies();
+
+    await listWebhookEventsCommand.parseAsync(
+      [
+        WEBHOOK_ID,
+        '--limit',
+        '50',
+        '--after',
+        'msg_1srOrx2ZWZBpBUvZwXKQmoEYga2',
+      ],
+      { from: 'user' },
+    );
+
+    const opts = mockListEvents.mock.calls[0][0] as Record<string, unknown>;
+    expect(opts.limit).toBe(50);
+    expect(opts.after).toBe('msg_1srOrx2ZWZBpBUvZwXKQmoEYga2');
+  });
+
+  it('errors with invalid_limit when --limit is out of range', async () => {
+    setNonInteractive();
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    exitSpy = mockExitThrow();
+
+    await expectExit1(() =>
+      listWebhookEventsCommand.parseAsync([WEBHOOK_ID, '--limit', '999'], {
+        from: 'user',
+      }),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('invalid_limit');
+  });
+
+  it('errors with list_error when the SDK returns an error', async () => {
+    setNonInteractive();
+    mockListEvents.mockResolvedValueOnce(
+      mockSdkError('Webhook endpoint not found', 'not_found'),
+    );
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    exitSpy = mockExitThrow();
+
+    await expectExit1(() =>
+      listWebhookEventsCommand.parseAsync([WEBHOOK_ID], { from: 'user' }),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('list_error');
+  });
+});

--- a/tests/commands/webhooks/events/utils.test.ts
+++ b/tests/commands/webhooks/events/utils.test.ts
@@ -13,10 +13,8 @@ describe('renderWebhookEventAttemptsTable', () => {
       },
     ]);
 
-    const rows = table
-      .split('\n')
-      .filter((line) => line.includes('atmpt_2ZbUCwvGmIT4mLIN6d3Yz0Ainbd'));
-    expect(rows).toHaveLength(1);
-    expect(rows[0]).toContain('<html> <body> Internal Server Error');
+    expect(table).toContain(
+      '<html> <body> Internal Server Error </body> </html>',
+    );
   });
 });

--- a/tests/commands/webhooks/events/utils.test.ts
+++ b/tests/commands/webhooks/events/utils.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { renderWebhookEventAttemptsTable } from '../../../../src/commands/webhooks/events/utils';
+
+describe('renderWebhookEventAttemptsTable', () => {
+  it('keeps a multi-line endpoint response on one row', () => {
+    const table = renderWebhookEventAttemptsTable([
+      {
+        id: 'atmpt_2ZbUCwvGmIT4mLIN6d3Yz0Ainbd',
+        http_status_code: 500,
+        response:
+          '<html>\n  <body>\n    Internal Server Error\n  </body>\n</html>',
+        sent_at: '2026-08-22T15:28:05.000Z',
+      },
+    ]);
+
+    const rows = table
+      .split('\n')
+      .filter((line) => line.includes('atmpt_2ZbUCwvGmIT4mLIN6d3Yz0Ainbd'));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toContain('<html> <body> Internal Server Error');
+
+    const widths = new Set(table.split('\n').map((line) => line.length));
+    expect(widths.size).toBe(1);
+  });
+});

--- a/tests/commands/webhooks/events/utils.test.ts
+++ b/tests/commands/webhooks/events/utils.test.ts
@@ -18,8 +18,5 @@ describe('renderWebhookEventAttemptsTable', () => {
       .filter((line) => line.includes('atmpt_2ZbUCwvGmIT4mLIN6d3Yz0Ainbd'));
     expect(rows).toHaveLength(1);
     expect(rows[0]).toContain('<html> <body> Internal Server Error');
-
-    const widths = new Set(table.split('\n').map((line) => line.length));
-    expect(widths.size).toBe(1);
   });
 });


### PR DESCRIPTION
Adds `resend webhooks events list|get|attempts` for the three webhook event endpoints that went GA.

Linear: https://linear.app/resend/issue/DEV-1931

```
resend webhooks events list <webhook-id>
resend webhooks events get <webhook-id> <event-id>
resend webhooks events attempts <webhook-id> <event-id>
```

Nested as a group under `webhooks`, following the `contacts imports` precedent, since the SDK nests them the same way (`resend.webhooks.events.attempts.list`). Flattened, they would have had to be `events` / `event` / `event-attempts`. `list` is the group default and carries the usual `ls` alias.

## Notes

- These endpoints paginate forward only, so the commands expose `--after` and no `--before`. A well-formed `?before=` returns 422 "The `before` parameter is not supported for this endpoint."
- Bumps `resend` 6.23.0 to 6.25.0 — `webhooks.events` became stable in 6.24.0 — and the package to 2.18.0 so a release can be cut off the merge.
- Interactive pickers work at both levels: `webhookPickerConfig` for the webhook, and an event picker scoped to it, following `attachmentPickerConfig(emailId)`.
- Updates the README webhooks section and the agent skill (`references/webhooks.md`, the `SKILL.md` command table, skill version 2.10.0).

## Checks

`pnpm typecheck`, `pnpm lint`, `pnpm build` clean. Full suite: 136 files, 1149 passed.

Smoke-ran all three against production, plus the `ls` alias and the bare `resend webhooks events <id>` default.

`tests/commands/webhooks/events/utils.test.ts` pins the one piece of real rendering logic. An attempt's `response` is whatever the customer's endpoint returned, and `safeTerminalText` passes `\n` through by design, so a multi-line HTML error page — the exact case this command exists to show — shattered the table box. The test fails without the fix.

**The data path is unverified against a live response.** Every live call returned an empty page or a 404: this account records no webhook events. I sent one email to try to generate one; it reached `delivered`, but none appeared on any enabled webhook after three minutes. The help text states the status enum without claiming what each value means.