### PR TITLE
feat(webhooks): add event replay command

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ Use `all` with `--events` to subscribe to every event.
 - `update`
 - `delete`
 - `listen`
-- `events` (`list`, `get`, `attempts`)
+- `events` (`list`, `get`, `attempts`, `replay`)
 
 #### Aliases
 
@@ -571,6 +571,7 @@ Inspects what Resend already delivered to a webhook. Use it to debug an endpoint
 1. `resend webhooks events list <webhook-id>` — find the event
 2. `resend webhooks events get <webhook-id> <event-id>` — see the payload we sent
 3. `resend webhooks events attempts <webhook-id> <event-id>` — see what your endpoint returned
+4. `resend webhooks events replay <webhook-id> <event-id>` — queue another delivery
 
 Running `resend webhooks events <webhook-id>` with no subcommand runs `list`.
 
@@ -581,13 +582,14 @@ Both list subcommands paginate forward only — there is no `--before`.
 | `--limit <n>`      | Max results to return (`1`–`100`, default `10`)          |
 | `--after <cursor>` | Return results after this ID (next page)                 |
 
-`events list` reports each event's `type`, `status` (`pending`, `attempting`, `success`, `failed`), and `created_at`. `events get` adds `next_attempt_at` and the payload that was sent. `events attempts` reports the `http_status_code` and response body your endpoint returned for each try.
+`events list` reports each event's `type`, `status` (`pending`, `attempting`, `success`, `failed`), and `created_at`. `events get` adds `next_attempt_at` and the payload that was sent. `events attempts` reports the `http_status_code` and response body your endpoint returned for each try. `events replay` queues one more delivery attempt and returns `{"object":"webhook_event","id":"<event-id>"}`; it does not schedule automatic retries.
 
 ```bash
 resend webhooks events list wh_abc123
 resend webhooks events list wh_abc123 --limit 50 --json
 resend webhooks events get wh_abc123 msg_1srOrx2ZWZBpBUvZwXKQmoEYga2
 resend webhooks events attempts wh_abc123 msg_1srOrx2ZWZBpBUvZwXKQmoEYga2
+resend webhooks events replay wh_abc123 msg_1srOrx2ZWZBpBUvZwXKQmoEYga2
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -582,7 +582,7 @@ Both list subcommands paginate forward only — there is no `--before`.
 | `--limit <n>`      | Max results to return (`1`–`100`, default `10`)          |
 | `--after <cursor>` | Return results after this ID (next page)                 |
 
-`events list` reports each event's `type`, `status` (`pending`, `attempting`, `success`, `failed`), and `created_at`. `events get` adds `next_attempt_at` and the payload that was sent. `events attempts` reports the `http_status_code` and response body your endpoint returned for each try. `events replay` queues one more delivery attempt and returns `{"object":"webhook_event","id":"<event-id>"}`; it does not schedule automatic retries.
+`events list` reports each event's `type`, `status` (`pending`, `attempting`, `success`, `failed`), and `created_at`. `events get` adds `next_attempt_at` and the payload that was sent. `events attempts` reports the `http_status_code` and response body your endpoint returned for each try. `events replay` queues one more delivery attempt and returns `{"object":"webhook_event","id":"<event-id>"}`; it does not schedule automatic retries, and the webhook must be enabled (`resend webhooks update <id> --status enabled`) or it returns `validation_error`.
 
 ```bash
 resend webhooks events list wh_abc123

--- a/README.md
+++ b/README.md
@@ -582,7 +582,7 @@ Both list subcommands paginate forward only — there is no `--before`.
 | `--limit <n>`      | Max results to return (`1`–`100`, default `10`)          |
 | `--after <cursor>` | Return results after this ID (next page)                 |
 
-`events list` reports each event's `type`, `status` (`pending`, `attempting`, `success`, `failed`), and `created_at`. `events get` adds `next_attempt_at` and the payload that was sent. `events attempts` reports the `http_status_code` and response body your endpoint returned for each try. `events replay` queues one more delivery attempt and returns `{"object":"webhook_event","id":"<event-id>"}`; it does not schedule automatic retries, and the webhook must be enabled (`resend webhooks update <id> --status enabled`) or it returns `validation_error`.
+`events list` reports each event's `type`, `status` (`pending`, `attempting`, `success`, `failed`), and `created_at`. `events get` adds `next_attempt_at` and the payload that was sent. `events attempts` reports the `http_status_code` and response body your endpoint returned for each try. `events replay` queues one more delivery attempt and returns `{"object":"webhook_event","id":"<event-id>"}`; it does not schedule automatic retries.
 
 ```bash
 resend webhooks events list wh_abc123

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "esbuild": "0.28.1",
     "esbuild-wasm": "0.28.0",
     "picocolors": "1.1.1",
-    "resend": "6.25.0"
+    "resend": "6.26.0"
   },
   "pkg": {
     "scripts": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-cli",
-  "version": "2.18.0",
+  "version": "2.19.0",
   "description": "The official CLI for Resend",
   "license": "MIT",
   "repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: 1.1.1
         version: 1.1.1
       resend:
-        specifier: 6.25.0
-        version: 6.25.0
+        specifier: 6.26.0
+        version: 6.26.0
     devDependencies:
       '@biomejs/biome':
         specifier: 2.4.11
@@ -1226,8 +1226,8 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
-  resend@6.25.0:
-    resolution: {integrity: sha512-iptUEycs+6Hu+W8mExK708LrDiMYOuGgnCP+wTD5L4Zrqqd2B86h1oyAmNe0khZWQw0ccI7jz8OgAaplEsyaIA==}
+  resend@6.26.0:
+    resolution: {integrity: sha512-vkrULozV5nGF8o7tyun/t0+qFgtPpn+cyRhVqeorhOsPUNDiSc/9p/pn8AprdHqJpYaTvftpnQgWurW++FkCdw==}
     engines: {node: '>=20'}
     peerDependencies:
       '@react-email/render': '*'
@@ -2431,7 +2431,7 @@ snapshots:
 
   require-directory@2.1.1: {}
 
-  resend@6.25.0:
+  resend@6.26.0:
     dependencies:
       postal-mime: 2.7.5
       standardwebhooks: 1.0.0

--- a/skills/resend-cli/SKILL.md
+++ b/skills/resend-cli/SKILL.md
@@ -13,7 +13,7 @@ metadata:
   author: resend
   # Skill version is independent from the CLI/package.json version —
   # bump it on skill content changes, not CLI releases.
-  version: "2.10.0"
+  version: "2.11.0"
   homepage: https://resend.com/docs/cli-agents
   source: https://github.com/resend/resend-cli
   openclaw:
@@ -145,7 +145,7 @@ Auth resolves: `RESEND_API_KEY` env > config file (`resend login --key`). Use `-
 | `segments` | create, get, list, update, delete, contacts |
 | `templates` | create, publish, duplicate, delete, list |
 | `topics` | create, update, delete, list |
-| `webhooks` | create, update, listen, delete, list, events (list, get, attempts) |
+| `webhooks` | create, update, listen, delete, list, events (list, get, attempts, replay) |
 | `auth` | login, logout, switch, rename, remove |
 | `whoami` / `doctor` / `update` / `open` / `commands` | Utility commands |
 

--- a/skills/resend-cli/references/webhooks.md
+++ b/skills/resend-cli/references/webhooks.md
@@ -102,6 +102,22 @@ Lists the delivery attempts for one event, most recent first. Each attempt recor
 1. `resend webhooks events list <webhook-id>` — find the event
 2. `resend webhooks events get <webhook-id> <event-id>` — see what we sent
 3. `resend webhooks events attempts <webhook-id> <event-id>` — see what your endpoint returned
+4. `resend webhooks events replay <webhook-id> <event-id>` — queue another delivery
+
+---
+
+## webhooks events replay
+
+Queues one more delivery of the event to the webhook — the same action as the
+dashboard's Replay button.
+
+**Arguments:** `[webhookId]` `[eventId]`
+
+**Manual replays do not schedule automatic retries.** Run replay again if the
+endpoint fails again.
+
+Returns `{"object":"webhook_event","id":"<event-id>"}` — no `type`, `status`,
+or `payload` (use `events get` for those).
 
 ---
 

--- a/skills/resend-cli/references/webhooks.md
+++ b/skills/resend-cli/references/webhooks.md
@@ -116,8 +116,8 @@ dashboard's Replay button.
 **Manual replays do not schedule automatic retries.** Run replay again if the
 endpoint fails again.
 
-**The webhook must be enabled.** A disabled webhook returns `validation_error`
-("Webhook is disabled") — re-enable it first with
+**The webhook must be enabled.** Replaying a disabled webhook's event fails
+with `replay_error` ("Webhook is disabled") — re-enable it first with
 `resend webhooks update <webhook-id> --status enabled`.
 
 Returns `{"object":"webhook_event","id":"<event-id>"}` — no `type`, `status`,

--- a/skills/resend-cli/references/webhooks.md
+++ b/skills/resend-cli/references/webhooks.md
@@ -116,8 +116,7 @@ dashboard's Replay button.
 **Manual replays do not schedule automatic retries.** Run replay again if the
 endpoint fails again.
 
-**The webhook must be enabled.** Replaying a disabled webhook's event fails
-with `replay_error` ("Webhook is disabled") — re-enable it first with
+**The webhook must be enabled.** Re-enable it first with
 `resend webhooks update <webhook-id> --status enabled`.
 
 Returns `{"object":"webhook_event","id":"<event-id>"}` — no `type`, `status`,

--- a/skills/resend-cli/references/webhooks.md
+++ b/skills/resend-cli/references/webhooks.md
@@ -108,15 +108,11 @@ Lists the delivery attempts for one event, most recent first. Each attempt recor
 
 ## webhooks events replay
 
-Queues one more delivery of the event to the webhook — the same action as the
-dashboard's Replay button.
+Queues one more delivery of the event. Does not schedule automatic retries.
 
 **Arguments:** `[webhookId]` `[eventId]`
 
-**Manual replays do not schedule automatic retries.** Run replay again if the
-endpoint fails again.
-
-**The webhook must be enabled.** Re-enable it first with
+The webhook must be enabled — re-enable it first with
 `resend webhooks update <webhook-id> --status enabled`.
 
 Returns `{"object":"webhook_event","id":"<event-id>"}` — no `type`, `status`,

--- a/skills/resend-cli/references/webhooks.md
+++ b/skills/resend-cli/references/webhooks.md
@@ -116,6 +116,10 @@ dashboard's Replay button.
 **Manual replays do not schedule automatic retries.** Run replay again if the
 endpoint fails again.
 
+**The webhook must be enabled.** A disabled webhook returns `validation_error`
+("Webhook is disabled") — re-enable it first with
+`resend webhooks update <webhook-id> --status enabled`.
+
 Returns `{"object":"webhook_event","id":"<event-id>"}` — no `type`, `status`,
 or `payload` (use `events get` for those).
 

--- a/src/commands/webhooks/events/index.ts
+++ b/src/commands/webhooks/events/index.ts
@@ -3,6 +3,7 @@ import { buildHelpText } from '../../../lib/help-text';
 import { listWebhookEventAttemptsCommand } from './attempts';
 import { getWebhookEventCommand } from './get';
 import { listWebhookEventsCommand } from './list';
+import { replayWebhookEventCommand } from './replay';
 
 export const webhookEventsCommand = new Command('events')
   .description('Inspect the events Resend delivered to a webhook')
@@ -13,6 +14,7 @@ export const webhookEventsCommand = new Command('events')
   1. resend webhooks events list <webhook-id>                  (find the event)
   2. resend webhooks events get <webhook-id> <event-id>        (see the payload we sent)
   3. resend webhooks events attempts <webhook-id> <event-id>   (see what your endpoint returned)
+  4. resend webhooks events replay <webhook-id> <event-id>     (queue another delivery)
 
 Events are listed most recent first. Both list commands paginate forward only,
 with --after.`,
@@ -20,9 +22,11 @@ with --after.`,
         'resend webhooks events list 4dd369bc-aa82-4ff3-97de-514ae3000ee0',
         'resend webhooks events get 4dd369bc-aa82-4ff3-97de-514ae3000ee0 msg_1srOrx2ZWZBpBUvZwXKQmoEYga2',
         'resend webhooks events attempts 4dd369bc-aa82-4ff3-97de-514ae3000ee0 msg_1srOrx2ZWZBpBUvZwXKQmoEYga2',
+        'resend webhooks events replay 4dd369bc-aa82-4ff3-97de-514ae3000ee0 msg_1srOrx2ZWZBpBUvZwXKQmoEYga2',
       ],
     }),
   )
   .addCommand(listWebhookEventsCommand, { isDefault: true })
   .addCommand(getWebhookEventCommand)
-  .addCommand(listWebhookEventAttemptsCommand);
+  .addCommand(listWebhookEventAttemptsCommand)
+  .addCommand(replayWebhookEventCommand);

--- a/src/commands/webhooks/events/index.ts
+++ b/src/commands/webhooks/events/index.ts
@@ -6,7 +6,7 @@ import { listWebhookEventsCommand } from './list';
 import { replayWebhookEventCommand } from './replay';
 
 export const webhookEventsCommand = new Command('events')
-  .description('Inspect the events Resend delivered to a webhook')
+  .description('Inspect or replay the events Resend delivered to a webhook')
   .addHelpText(
     'after',
     buildHelpText({

--- a/src/commands/webhooks/events/replay.ts
+++ b/src/commands/webhooks/events/replay.ts
@@ -13,14 +13,8 @@ export const replayWebhookEventCommand = new Command('replay')
   .addHelpText(
     'after',
     buildHelpText({
-      context: `Queues one more delivery of the event to the webhook — the same action as
-the Replay button in the dashboard.
-
-Manual replays do not schedule automatic retries. If the endpoint fails again,
-run replay again.
-
-The webhook must be enabled to replay events to it. Re-enable it first with:
-resend webhooks update <webhook-id> --status enabled`,
+      context: `Queues one more delivery of the event. Does not schedule automatic retries.
+The webhook must be enabled — re-enable it first with: resend webhooks update <webhook-id> --status enabled`,
       output: `  {"object":"webhook_event","id":"msg_..."}`,
       errorCodes: ['auth_error', 'replay_error'],
       examples: [

--- a/src/commands/webhooks/events/replay.ts
+++ b/src/commands/webhooks/events/replay.ts
@@ -19,8 +19,9 @@ the Replay button in the dashboard.
 Manual replays do not schedule automatic retries. If the endpoint fails again,
 run replay again.
 
-The webhook must be enabled. A disabled webhook returns validation_error;
-re-enable it first with: resend webhooks update <id> --status enabled`,
+The webhook must be enabled. Replaying a disabled webhook's event fails with
+replay_error ("Webhook is disabled"); re-enable it first with:
+resend webhooks update <webhook-id> --status enabled`,
       output: `  {"object":"webhook_event","id":"msg_..."}`,
       errorCodes: ['auth_error', 'replay_error'],
       examples: [

--- a/src/commands/webhooks/events/replay.ts
+++ b/src/commands/webhooks/events/replay.ts
@@ -17,7 +17,10 @@ export const replayWebhookEventCommand = new Command('replay')
 the Replay button in the dashboard.
 
 Manual replays do not schedule automatic retries. If the endpoint fails again,
-run replay again.`,
+run replay again.
+
+The webhook must be enabled. A disabled webhook returns validation_error;
+re-enable it first with: resend webhooks update <id> --status enabled`,
       output: `  {"object":"webhook_event","id":"msg_..."}`,
       errorCodes: ['auth_error', 'replay_error'],
       examples: [

--- a/src/commands/webhooks/events/replay.ts
+++ b/src/commands/webhooks/events/replay.ts
@@ -19,8 +19,7 @@ the Replay button in the dashboard.
 Manual replays do not schedule automatic retries. If the endpoint fails again,
 run replay again.
 
-The webhook must be enabled. Replaying a disabled webhook's event fails with
-replay_error ("Webhook is disabled"); re-enable it first with:
+The webhook must be enabled to replay events to it. Re-enable it first with:
 resend webhooks update <webhook-id> --status enabled`,
       output: `  {"object":"webhook_event","id":"msg_..."}`,
       errorCodes: ['auth_error', 'replay_error'],

--- a/src/commands/webhooks/events/replay.ts
+++ b/src/commands/webhooks/events/replay.ts
@@ -1,0 +1,52 @@
+import { Command } from '@commander-js/extra-typings';
+import { runWrite } from '../../../lib/actions';
+import type { GlobalOpts } from '../../../lib/client';
+import { buildHelpText } from '../../../lib/help-text';
+import { pickId } from '../../../lib/prompts';
+import { webhookPickerConfig } from '../utils';
+import { webhookEventPickerConfig } from './utils';
+
+export const replayWebhookEventCommand = new Command('replay')
+  .description('Queue another delivery attempt for a webhook event')
+  .argument('[webhookId]', 'Webhook ID')
+  .argument('[eventId]', 'Webhook event ID')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      context: `Queues one more delivery of the event to the webhook — the same action as
+the Replay button in the dashboard.
+
+Manual replays do not schedule automatic retries. If the endpoint fails again,
+run replay again.`,
+      output: `  {"object":"webhook_event","id":"msg_..."}`,
+      errorCodes: ['auth_error', 'replay_error'],
+      examples: [
+        'resend webhooks events replay 4dd369bc-aa82-4ff3-97de-514ae3000ee0 msg_1srOrx2ZWZBpBUvZwXKQmoEYga2',
+        'resend webhooks events replay 4dd369bc-aa82-4ff3-97de-514ae3000ee0 msg_1srOrx2ZWZBpBUvZwXKQmoEYga2 --json',
+      ],
+    }),
+  )
+  .action(async (webhookIdArg, eventIdArg, _opts, cmd) => {
+    const globalOpts = cmd.optsWithGlobals() as GlobalOpts;
+    const webhookId = await pickId(
+      webhookIdArg,
+      webhookPickerConfig,
+      globalOpts,
+    );
+    const eventId = await pickId(
+      eventIdArg,
+      webhookEventPickerConfig(webhookId),
+      globalOpts,
+    );
+
+    await runWrite(
+      {
+        loading: 'Replaying webhook event...',
+        sdkCall: (resend) =>
+          resend.webhooks.events.replay({ webhookId, eventId }),
+        errorCode: 'replay_error',
+        successMsg: `Webhook event replay queued: ${eventId}`,
+      },
+      globalOpts,
+    );
+  });

--- a/tests/commands/webhooks/events/replay.test.ts
+++ b/tests/commands/webhooks/events/replay.test.ts
@@ -103,6 +103,5 @@ describe('webhooks events replay command', () => {
 
     const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
     expect(output).toContain('replay_error');
-    expect(output).toContain('Webhook is disabled');
   });
 });

--- a/tests/commands/webhooks/events/replay.test.ts
+++ b/tests/commands/webhooks/events/replay.test.ts
@@ -103,5 +103,6 @@ describe('webhooks events replay command', () => {
 
     const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
     expect(output).toContain('replay_error');
+    expect(output).toContain('Webhook is disabled');
   });
 });

--- a/tests/commands/webhooks/events/replay.test.ts
+++ b/tests/commands/webhooks/events/replay.test.ts
@@ -1,0 +1,107 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from 'vitest';
+import { replayWebhookEventCommand } from '../../../../src/commands/webhooks/events/replay';
+import {
+  captureTestEnv,
+  expectExit1,
+  mockExitThrow,
+  mockSdkError,
+  setNonInteractive,
+  setupOutputSpies,
+} from '../../../helpers';
+
+const WEBHOOK_ID = '4dd369bc-aa82-4ff3-97de-514ae3000ee0';
+const EVENT_ID = 'msg_1srOrx2ZWZBpBUvZwXKQmoEYga2';
+
+const mockReplay = vi.fn(async () => ({
+  data: {
+    object: 'webhook_event' as const,
+    id: EVENT_ID,
+  },
+  error: null,
+}));
+
+vi.mock('resend', () => ({
+  Resend: class MockResend {
+    constructor(public key: string) {}
+    webhooks = { events: { replay: mockReplay } };
+  },
+}));
+
+describe('webhooks events replay command', () => {
+  const restoreEnv = captureTestEnv();
+  let spies: ReturnType<typeof setupOutputSpies> | undefined;
+  let errorSpy: MockInstance | undefined;
+  let stderrSpy: MockInstance | undefined;
+  let exitSpy: MockInstance | undefined;
+
+  beforeEach(() => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    mockReplay.mockClear();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    errorSpy?.mockRestore();
+    stderrSpy?.mockRestore();
+    exitSpy?.mockRestore();
+    spies = undefined;
+    errorSpy = undefined;
+    stderrSpy = undefined;
+    exitSpy = undefined;
+  });
+
+  it('maps the two positional args to webhookId and eventId in that order', async () => {
+    spies = setupOutputSpies();
+
+    await replayWebhookEventCommand.parseAsync([WEBHOOK_ID, EVENT_ID], {
+      from: 'user',
+    });
+
+    expect(mockReplay).toHaveBeenCalledTimes(1);
+    const opts = mockReplay.mock.calls[0][0] as Record<string, unknown>;
+    expect(opts.webhookId).toBe(WEBHOOK_ID);
+    expect(opts.eventId).toBe(EVENT_ID);
+  });
+
+  it('outputs the replayed event as JSON when non-interactive', async () => {
+    spies = setupOutputSpies();
+
+    await replayWebhookEventCommand.parseAsync([WEBHOOK_ID, EVENT_ID], {
+      from: 'user',
+    });
+
+    const output = spies.logSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output);
+    expect(parsed.object).toBe('webhook_event');
+    expect(parsed.id).toBe(EVENT_ID);
+  });
+
+  it('errors with replay_error when the SDK returns an error', async () => {
+    setNonInteractive();
+    mockReplay.mockResolvedValueOnce(
+      mockSdkError('Webhook is disabled', 'validation_error'),
+    );
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    exitSpy = mockExitThrow();
+
+    await expectExit1(() =>
+      replayWebhookEventCommand.parseAsync([WEBHOOK_ID, EVENT_ID], {
+        from: 'user',
+      }),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('replay_error');
+  });
+});


### PR DESCRIPTION
## What

Adds `resend webhooks events replay <webhookId> <eventId>`, mirroring `webhooks events get`'s argument parsing, prompts, and help text. Queues one more delivery of a webhook event — the same action as the dashboard's Replay button.

```bash
resend webhooks events replay 4dd369bc-aa82-4ff3-97de-514ae3000ee0 msg_1srOrx2ZWZBpBUvZwXKQmoEYga2
```

```json
{"object":"webhook_event","id":"msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"}
```

(response shape per the spec — no live call was made; see below)

## Blocked on resend-node 6.26.0 publish

`replay()` ships in resend/resend-node#1087, open and not yet published to npm. `package.json` is bumped to `resend@6.26.0` anyway to match convention, so:

- `pnpm install --frozen-lockfile` will fail in CI (404 fetching `resend@6.26.0`) until that version is published.
- The `pnpm-lock.yaml` integrity hash for `resend@6.26.0` is computed from a local build of the resend-node PR branch, not the real npm tarball — it must be regenerated (`pnpm install`, unfrozen) once 6.26.0 actually publishes.
- Tested locally by linking against that local build instead: `pnpm lint`, `pnpm typecheck`, `pnpm test` (137 files, all passing), and `pnpm build` all pass against it.

Keeping this in draft until resend-node 6.26.0 is published, at which point the lockfile needs a refresh before merging.

resend/resend-node#1087, resend/resend-openapi#112, resend/resend-monorepo#9535

Part of DEV-2005.

Linear: https://linear.app/resend/issue/DEV-2017
