### PR TITLE
feat(webhooks): add rotate-signing-secret command

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,7 +539,7 @@ To pause delivery temporarily, prefer `resend webhooks update <id> --status disa
 
 #### **`resend webhooks rotate-signing-secret`**
 
-Generates a new signing secret for the webhook and returns it. Payloads delivered after the rotation are signed with the new secret. Like `create`, the `signing_secret` is shown once — save it immediately.
+Generates a new signing secret for the webhook and returns it. For 24 hours, payloads are signed with both the new and the previous secret, so either one verifies them. After that, only the new secret does. Like `create`, the `signing_secret` is shown once — save it immediately.
 
 Omit the ID in a terminal to pick from a list.
 

--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@ Use `all` with `--events` to subscribe to every event.
 - `get`
 - `update`
 - `delete`
+- `rotate-signing-secret`
 - `listen`
 - `events` (`list`, `get`, `attempts`, `replay`)
 
@@ -498,7 +499,7 @@ resend webhooks get wh_abc123
 resend webhooks get wh_abc123 --json
 ```
 
-The signing secret is not returned from `get`. To rotate secrets, delete the webhook and create a new one.
+The signing secret is not returned from `get`. Use `resend webhooks rotate-signing-secret <id>` to get a new one.
 
 #### **`resend webhooks update`**
 
@@ -535,6 +536,17 @@ resend webhooks delete wh_abc123 --yes
 ```
 
 To pause delivery temporarily, prefer `resend webhooks update <id> --status disabled`.
+
+#### **`resend webhooks rotate-signing-secret`**
+
+Generates a new signing secret for the webhook and returns it. Payloads delivered after the rotation are signed with the new secret. Like `create`, the `signing_secret` is shown once — save it immediately.
+
+Omit the ID in a terminal to pick from a list.
+
+```bash
+resend webhooks rotate-signing-secret wh_abc123
+resend webhooks rotate-signing-secret wh_abc123 --json
+```
 
 #### **`resend webhooks listen`**
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "esbuild": "0.28.1",
     "esbuild-wasm": "0.28.0",
     "picocolors": "1.1.1",
-    "resend": "6.26.0"
+    "resend": "6.27.0"
   },
   "pkg": {
     "scripts": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: 1.1.1
         version: 1.1.1
       resend:
-        specifier: 6.26.0
-        version: 6.26.0
+        specifier: 6.27.0
+        version: 6.27.0
     devDependencies:
       '@biomejs/biome':
         specifier: 2.4.11
@@ -1226,8 +1226,8 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
-  resend@6.26.0:
-    resolution: {integrity: sha512-vkrULozV5nGF8o7tyun/t0+qFgtPpn+cyRhVqeorhOsPUNDiSc/9p/pn8AprdHqJpYaTvftpnQgWurW++FkCdw==}
+  resend@6.27.0:
+    resolution: {integrity: sha512-5Auh9GWkmKteeEM7rG45j7JRQVsKaQG0Okk4Ev0Pekh+1qfclRsmd4alZ3Kx0AqEosnZjEe/kCXf9jxfGaPZtg==}
     engines: {node: '>=20'}
     peerDependencies:
       '@react-email/render': '*'
@@ -2431,7 +2431,7 @@ snapshots:
 
   require-directory@2.1.1: {}
 
-  resend@6.26.0:
+  resend@6.27.0:
     dependencies:
       postal-mime: 2.7.5
       standardwebhooks: 1.0.0

--- a/skills/resend-cli/SKILL.md
+++ b/skills/resend-cli/SKILL.md
@@ -145,7 +145,7 @@ Auth resolves: `RESEND_API_KEY` env > config file (`resend login --key`). Use `-
 | `segments` | create, get, list, update, delete, contacts |
 | `templates` | create, publish, duplicate, delete, list |
 | `topics` | create, update, delete, list |
-| `webhooks` | create, update, listen, delete, list, events (list, get, attempts, replay) |
+| `webhooks` | create, update, rotate-signing-secret, listen, delete, list, events (list, get, attempts, replay) |
 | `auth` | login, logout, switch, rename, remove |
 | `whoami` / `doctor` / `update` / `open` / `commands` | Utility commands |
 

--- a/skills/resend-cli/references/webhooks.md
+++ b/skills/resend-cli/references/webhooks.md
@@ -64,8 +64,9 @@ Detailed flag specifications for `resend webhooks` commands.
 
 **Argument:** `<id>` — Webhook ID
 
-Generates a new signing secret. Payloads delivered after the rotation are signed
-with the new secret.
+Generates a new signing secret. For 24 hours, payloads are signed with both the
+new and the previous secret, so either one verifies them. After that, only the
+new secret does.
 
 Returns `{"object":"webhook","id":"<uuid>","signing_secret":"whsec_..."}` —
 **shown once only**, save immediately.

--- a/skills/resend-cli/references/webhooks.md
+++ b/skills/resend-cli/references/webhooks.md
@@ -34,7 +34,7 @@ Detailed flag specifications for `resend webhooks` commands.
 
 **Argument:** `<id>` — Webhook ID
 
-**Note:** `signing_secret` is NOT returned by get (only at creation).
+**Note:** `signing_secret` is NOT returned by get (only at creation or rotation).
 
 ---
 
@@ -57,6 +57,18 @@ Detailed flag specifications for `resend webhooks` commands.
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
 | `--yes` | boolean | Yes (non-interactive) | Skip confirmation |
+
+---
+
+## webhooks rotate-signing-secret
+
+**Argument:** `<id>` — Webhook ID
+
+Generates a new signing secret. Payloads delivered after the rotation are signed
+with the new secret.
+
+Returns `{"object":"webhook","id":"<uuid>","signing_secret":"whsec_..."}` —
+**shown once only**, save immediately.
 
 ---
 

--- a/src/commands/webhooks/index.ts
+++ b/src/commands/webhooks/index.ts
@@ -6,6 +6,7 @@ import { webhookEventsCommand } from './events';
 import { getWebhookCommand } from './get';
 import { listWebhooksCommand } from './list';
 import { listenWebhookCommand } from './listen';
+import { rotateWebhookSigningSecretCommand } from './rotate-signing-secret';
 import { updateWebhookCommand } from './update';
 
 export const webhooksCommand = new Command('webhooks')
@@ -27,6 +28,7 @@ Event categories (19 total):
 Signature verification (Svix):
   Each delivery includes headers: svix-id, svix-timestamp, svix-signature
   Verify payloads in your application using: resend.webhooks.verify({ payload, headers, webhookSecret })
+  Rotate a secret with "resend webhooks rotate-signing-secret <id>"; the new one is shown once.
 
 Delivery history:
   Inspect what Resend sent and what your endpoint returned with "resend webhooks events".`,
@@ -35,6 +37,7 @@ Delivery history:
         'resend webhooks create --endpoint https://app.example.com/hooks/resend --events all',
         'resend webhooks get wh_abc123',
         'resend webhooks update wh_abc123 --status disabled',
+        'resend webhooks rotate-signing-secret wh_abc123',
         'resend webhooks delete wh_abc123 --yes',
         'resend webhooks events list wh_abc123',
       ],
@@ -46,4 +49,5 @@ Delivery history:
   .addCommand(listenWebhookCommand)
   .addCommand(listWebhooksCommand, { isDefault: true })
   .addCommand(updateWebhookCommand)
+  .addCommand(rotateWebhookSigningSecretCommand)
   .addCommand(deleteWebhookCommand);

--- a/src/commands/webhooks/rotate-signing-secret.ts
+++ b/src/commands/webhooks/rotate-signing-secret.ts
@@ -14,8 +14,9 @@ export const rotateWebhookSigningSecretCommand = new Command(
   .addHelpText(
     'after',
     buildHelpText({
-      context: `Generates a new signing secret and returns it. Payloads delivered after the
-rotation are signed with the new secret, so update your verification code with it.
+      context: `Generates a new signing secret and returns it. For 24 hours, payloads are
+signed with both the new and the previous secret, so either one verifies them.
+After that, only the new secret does. Update your verification code within that window.
 
 The signing_secret in the response is shown ONCE — save it immediately.`,
       output: `  {"object":"webhook","id":"<uuid>","signing_secret":"<whsec_...>"}`,

--- a/src/commands/webhooks/rotate-signing-secret.ts
+++ b/src/commands/webhooks/rotate-signing-secret.ts
@@ -1,0 +1,53 @@
+import { Command } from '@commander-js/extra-typings';
+import type { CreateWebhookResponse } from 'resend';
+import { runCreate } from '../../lib/actions';
+import type { GlobalOpts } from '../../lib/client';
+import { buildHelpText } from '../../lib/help-text';
+import { pickId } from '../../lib/prompts';
+import { webhookPickerConfig } from './utils';
+
+export const rotateWebhookSigningSecretCommand = new Command(
+  'rotate-signing-secret',
+)
+  .description('Generate a new signing secret for a webhook')
+  .argument('[id]', 'Webhook UUID')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      context: `Generates a new signing secret and returns it. Payloads delivered after the
+rotation are signed with the new secret, so update your verification code with it.
+
+The signing_secret in the response is shown ONCE — save it immediately.`,
+      output: `  {"object":"webhook","id":"<uuid>","signing_secret":"<whsec_...>"}`,
+      errorCodes: ['auth_error', 'create_error'],
+      examples: [
+        'resend webhooks rotate-signing-secret 4dd369bc-aa82-4ff3-97de-514ae3000ee0',
+        'resend webhooks rotate-signing-secret 4dd369bc-aa82-4ff3-97de-514ae3000ee0 --json',
+      ],
+    }),
+  )
+  .action(async (idArg, _opts, cmd) => {
+    const globalOpts = cmd.optsWithGlobals() as GlobalOpts;
+    const id = await pickId(idArg, webhookPickerConfig, globalOpts);
+
+    await runCreate(
+      {
+        loading: 'Rotating webhook signing secret...',
+        sdkCall: (resend) =>
+          (
+            resend.webhooks as unknown as {
+              rotateSigningSecret: (
+                id: string,
+              ) => Promise<CreateWebhookResponse>;
+            }
+          ).rotateSigningSecret(id),
+        onInteractive: (d) => {
+          console.log(`Webhook signing secret rotated`);
+          console.log(`ID:             ${d.id}`);
+          console.log(`Signing Secret: ${d.signing_secret}`);
+          console.log(`Save the signing secret — it is only shown once.`);
+        },
+      },
+      globalOpts,
+    );
+  });

--- a/src/commands/webhooks/rotate-signing-secret.ts
+++ b/src/commands/webhooks/rotate-signing-secret.ts
@@ -1,5 +1,4 @@
 import { Command } from '@commander-js/extra-typings';
-import type { CreateWebhookResponse } from 'resend';
 import { runCreate } from '../../lib/actions';
 import type { GlobalOpts } from '../../lib/client';
 import { buildHelpText } from '../../lib/help-text';
@@ -34,14 +33,7 @@ The signing_secret in the response is shown ONCE — save it immediately.`,
     await runCreate(
       {
         loading: 'Rotating webhook signing secret...',
-        sdkCall: (resend) =>
-          (
-            resend.webhooks as unknown as {
-              rotateSigningSecret: (
-                id: string,
-              ) => Promise<CreateWebhookResponse>;
-            }
-          ).rotateSigningSecret(id),
+        sdkCall: (resend) => resend.webhooks.rotateSigningSecret(id),
         onInteractive: (d) => {
           console.log(`Webhook signing secret rotated`);
           console.log(`ID:             ${d.id}`);

--- a/tests/commands/webhooks/rotate-signing-secret.test.ts
+++ b/tests/commands/webhooks/rotate-signing-secret.test.ts
@@ -1,0 +1,95 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from 'vitest';
+import { rotateWebhookSigningSecretCommand } from '../../../src/commands/webhooks/rotate-signing-secret';
+import {
+  captureTestEnv,
+  expectExit1,
+  mockExitThrow,
+  mockSdkError,
+  setNonInteractive,
+  setupOutputSpies,
+} from '../../helpers';
+
+const WEBHOOK_ID = '4dd369bc-aa82-4ff3-97de-514ae3000ee0';
+
+const mockRotateSigningSecret = vi.fn(async () => ({
+  data: {
+    object: 'webhook' as const,
+    id: WEBHOOK_ID,
+    signing_secret: 'whsec_new_secret',
+  },
+  error: null,
+}));
+
+vi.mock('resend', () => ({
+  Resend: class MockResend {
+    constructor(public key: string) {}
+    webhooks = { rotateSigningSecret: mockRotateSigningSecret };
+  },
+}));
+
+describe('webhooks rotate-signing-secret command', () => {
+  const restoreEnv = captureTestEnv();
+  let spies: ReturnType<typeof setupOutputSpies> | undefined;
+  let errorSpy: MockInstance | undefined;
+  let stderrSpy: MockInstance | undefined;
+  let exitSpy: MockInstance | undefined;
+
+  beforeEach(() => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    mockRotateSigningSecret.mockClear();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    errorSpy?.mockRestore();
+    stderrSpy?.mockRestore();
+    exitSpy?.mockRestore();
+    spies = undefined;
+    errorSpy = undefined;
+    stderrSpy = undefined;
+    exitSpy = undefined;
+  });
+
+  it('rotates the secret for the given webhook and outputs it as JSON when non-interactive', async () => {
+    spies = setupOutputSpies();
+
+    await rotateWebhookSigningSecretCommand.parseAsync([WEBHOOK_ID], {
+      from: 'user',
+    });
+
+    expect(mockRotateSigningSecret).toHaveBeenCalledWith(WEBHOOK_ID);
+    const parsed = JSON.parse(spies.logSpy.mock.calls[0][0] as string);
+    expect(parsed.object).toBe('webhook');
+    expect(parsed.id).toBe(WEBHOOK_ID);
+    expect(parsed.signing_secret).toBe('whsec_new_secret');
+  });
+
+  it('errors with create_error when the SDK returns an error', async () => {
+    setNonInteractive();
+    mockRotateSigningSecret.mockResolvedValueOnce(
+      mockSdkError('Webhook not found', 'not_found'),
+    );
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    exitSpy = mockExitThrow();
+
+    await expectExit1(() =>
+      rotateWebhookSigningSecretCommand.parseAsync([WEBHOOK_ID], {
+        from: 'user',
+      }),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('create_error');
+  });
+});


### PR DESCRIPTION
Adds `resend webhooks rotate-signing-secret <id>`, calling `resend.webhooks.rotateSigningSecret(id)` for the new `POST /webhooks/{id}/signing-secret/rotate` endpoint (spec: https://github.com/resend/resend-openapi/pull/113). It behaves like `webhooks create`: interactively it prints the id and the new `signing_secret` with the shown-once warning, piped or with `--json` it prints the response as is. README, skill table, and the webhooks skill reference gain the command, and the README's "delete and recreate to rotate" note now points here. The `resend` pin moves to 6.27.0, the release that ships the method. Linear: https://linear.app/resend/issue/DEV-2080

🤖 Generated with [Claude Code](https://claude.com/claude-code)