### PR TITLE
chore: bump to v2.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-cli",
-  "version": "2.19.1",
+  "version": "2.20.0",
   "description": "The official CLI for Resend",
   "license": "MIT",
   "repository": {

--- a/skills/resend-cli/SKILL.md
+++ b/skills/resend-cli/SKILL.md
@@ -13,7 +13,7 @@ metadata:
   author: resend
   # Skill version is independent from the CLI/package.json version —
   # bump it on skill content changes, not CLI releases.
-  version: "2.11.0"
+  version: "2.12.0"
   homepage: https://resend.com/docs/cli-agents
   source: https://github.com/resend/resend-cli
   openclaw:


### PR DESCRIPTION
Release bump for the `webhooks rotate-signing-secret` command from #385. The skill version moves to 2.12.0 as well, since #385 changed its command table and webhooks reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)