### PR TITLE
feat(broadcasts): add duplicate command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend-cli",
-  "version": "2.20.1",
+  "version": "2.21.0",
   "description": "The official CLI for Resend",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "esbuild": "0.28.1",
     "esbuild-wasm": "0.28.0",
     "picocolors": "1.1.1",
-    "resend": "6.27.0"
+    "resend": "6.28.0"
   },
   "pkg": {
     "scripts": [

--- a/skills/resend-cli/SKILL.md
+++ b/skills/resend-cli/SKILL.md
@@ -13,7 +13,7 @@ metadata:
   author: resend
   # Skill version is independent from the CLI/package.json version —
   # bump it on skill content changes, not CLI releases.
-  version: "2.12.1"
+  version: "2.13.0"
   homepage: https://resend.com/docs/cli-agents
   source: https://github.com/resend/resend-cli
   openclaw:

--- a/skills/resend-cli/SKILL.md
+++ b/skills/resend-cli/SKILL.md
@@ -139,7 +139,7 @@ Auth resolves: `RESEND_API_KEY` env > config file (`resend login --key`). Use `-
 | `api-keys` | create, list, update, delete |
 | `automations` | create, get, list, update, delete, duplicate, stop, open, runs |
 | `events` | create, get, list, update, delete, send, open |
-| `broadcasts` | create, send, get, update, delete, list, cancel, open, clicked-links, recipients |
+| `broadcasts` | create, send, get, update, delete, list, cancel, duplicate, open, clicked-links, recipients |
 | `contacts` | create, update, delete, segments, topics, imports |
 | `contact-properties` | create, update, delete, list |
 | `segments` | create, get, list, update, delete, contacts |

--- a/skills/resend-cli/references/broadcasts.md
+++ b/skills/resend-cli/references/broadcasts.md
@@ -102,6 +102,14 @@ Cancelling a queued broadcast stops it mid-send — emails already sent are not 
 
 ---
 
+## broadcasts duplicate
+
+**Argument:** `<id>` — Broadcast ID
+
+The copy is a draft named `<name> (copy)`, truncated to 70 characters, with the same segment, topic, from, subject, reply-to, preview text, and content. Any broadcast can be duplicated, including sent ones.
+
+---
+
 ## broadcasts delete
 
 **Argument:** `<id>` — Broadcast ID

--- a/src/commands/broadcasts/duplicate.ts
+++ b/src/commands/broadcasts/duplicate.ts
@@ -1,0 +1,38 @@
+import { Command } from '@commander-js/extra-typings';
+import { runCreate } from '../../lib/actions';
+import type { GlobalOpts } from '../../lib/client';
+import { buildHelpText } from '../../lib/help-text';
+import { pickId } from '../../lib/prompts';
+import { broadcastPickerConfig } from './utils';
+
+export const duplicateBroadcastCommand = new Command('duplicate')
+  .description('Duplicate a broadcast')
+  .argument('[id]', 'Broadcast ID')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      context: `Creates a copy of an existing broadcast and returns the new broadcast ID.
+The copy is a draft named after the original with " (copy)" appended, truncated to 70 characters.
+Segment, topic, from, subject, reply-to, preview text, and content are copied. Any broadcast can be duplicated, including sent ones.`,
+      output: `  {"object":"broadcast","id":"<new-broadcast-id>"}`,
+      errorCodes: ['auth_error', 'create_error'],
+      examples: [
+        'resend broadcasts duplicate d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6',
+        'resend broadcasts duplicate d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6 --json',
+      ],
+    }),
+  )
+  .action(async (idArg, _opts, cmd) => {
+    const globalOpts = cmd.optsWithGlobals() as GlobalOpts;
+    const id = await pickId(idArg, broadcastPickerConfig, globalOpts);
+    await runCreate(
+      {
+        loading: 'Duplicating broadcast...',
+        sdkCall: (resend) => resend.broadcasts.duplicate(id),
+        onInteractive: (d) => {
+          console.log(`Broadcast duplicated: ${d.id}`);
+        },
+      },
+      globalOpts,
+    );
+  });

--- a/src/commands/broadcasts/index.ts
+++ b/src/commands/broadcasts/index.ts
@@ -4,6 +4,7 @@ import { cancelBroadcastCommand } from './cancel';
 import { clickedLinksBroadcastCommand } from './clicked-links';
 import { createBroadcastCommand } from './create';
 import { deleteBroadcastCommand } from './delete';
+import { duplicateBroadcastCommand } from './duplicate';
 import { getBroadcastCommand } from './get';
 import { listBroadcastsCommand } from './list';
 import { openBroadcastCommand } from './open';
@@ -40,6 +41,7 @@ Scheduling:
         'resend broadcasts recipients d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6 --type opened',
         'resend broadcasts update d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6 --subject "Updated Subject"',
         'resend broadcasts cancel d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6',
+        'resend broadcasts duplicate d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6',
         'resend broadcasts delete d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6 --yes',
         'resend broadcasts open',
         'resend broadcasts open d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6',
@@ -55,5 +57,6 @@ Scheduling:
   .addCommand(recipientsBroadcastCommand)
   .addCommand(updateBroadcastCommand)
   .addCommand(cancelBroadcastCommand)
+  .addCommand(duplicateBroadcastCommand)
   .addCommand(deleteBroadcastCommand)
   .addCommand(clickedLinksBroadcastCommand);

--- a/tests/commands/broadcasts/duplicate.test.ts
+++ b/tests/commands/broadcasts/duplicate.test.ts
@@ -1,0 +1,113 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from 'vitest';
+import { duplicateBroadcastCommand } from '../../../src/commands/broadcasts/duplicate';
+import {
+  captureTestEnv,
+  expectExit1,
+  mockExitThrow,
+  mockSdkError,
+  setNonInteractive,
+  setupOutputSpies,
+} from '../../helpers';
+
+const mockDuplicate = vi.fn(async () => ({
+  data: { object: 'broadcast', id: 'f0e1d2c3-b4a5-6978-8a9b-0c1d2e3f4a5b' },
+  error: null,
+}));
+
+vi.mock('resend', () => ({
+  Resend: class MockResend {
+    constructor(public key: string) {}
+    broadcasts = { duplicate: mockDuplicate };
+  },
+}));
+
+describe('broadcasts duplicate command', () => {
+  const restoreEnv = captureTestEnv();
+  let spies: ReturnType<typeof setupOutputSpies> | undefined;
+  let errorSpy: MockInstance | undefined;
+  let stderrSpy: MockInstance | undefined;
+  let exitSpy: MockInstance | undefined;
+
+  beforeEach(() => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    mockDuplicate.mockClear();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    errorSpy?.mockRestore();
+    stderrSpy?.mockRestore();
+    exitSpy?.mockRestore();
+    spies = undefined;
+    errorSpy = undefined;
+    stderrSpy = undefined;
+    exitSpy = undefined;
+  });
+
+  it('duplicates the given broadcast and prints the new id as JSON', async () => {
+    spies = setupOutputSpies();
+
+    await duplicateBroadcastCommand.parseAsync(
+      ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'],
+      { from: 'user' },
+    );
+
+    expect(mockDuplicate).toHaveBeenCalledTimes(1);
+    expect(mockDuplicate.mock.calls[0][0]).toBe(
+      'd1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6',
+    );
+
+    const output = spies.logSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output);
+    expect(parsed.id).toBe('f0e1d2c3-b4a5-6978-8a9b-0c1d2e3f4a5b');
+    expect(parsed.object).toBe('broadcast');
+  });
+
+  it('errors with auth_error when no API key', async () => {
+    setNonInteractive();
+    delete process.env.RESEND_API_KEY;
+    process.env.XDG_CONFIG_HOME = '/tmp/nonexistent-resend';
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = mockExitThrow();
+
+    await expectExit1(() =>
+      duplicateBroadcastCommand.parseAsync(
+        ['d1c2b3a4-5e6f-7a8b-9c0d-e1f2a3b4c5d6'],
+        { from: 'user' },
+      ),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('auth_error');
+  });
+
+  it('errors with create_error when SDK returns an error', async () => {
+    setNonInteractive();
+    mockDuplicate.mockResolvedValueOnce(
+      mockSdkError('Broadcast not found', 'not_found'),
+    );
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    exitSpy = mockExitThrow();
+
+    await expectExit1(() =>
+      duplicateBroadcastCommand.parseAsync(
+        ['00000000-0000-0000-0000-00000000bad0'],
+        { from: 'user' },
+      ),
+    );
+
+    const output = errorSpy.mock.calls.map((c) => c[0]).join(' ');
+    expect(output).toContain('create_error');
+  });
+});


### PR DESCRIPTION
This adds `resend broadcasts duplicate <id>` on top of `resend.broadcasts.duplicate` (POST `/broadcasts/{id}/duplicate`, spec in https://github.com/resend/resend-openapi/pull/115). The copy is a draft named `<name> (copy)` with the same segment, topic, from, subject, reply-to, preview text, and content; any broadcast can be duplicated, including sent ones. It picks from every broadcast like `get` does and follows `templates duplicate` (runCreate, `create_error`). The CLI releases as 2.21.0.

It depends on resend@6.28.0, which is not on npm yet; the method lands in https://github.com/resend/resend-node/pull/1094. The `resend` pin is already 6.28.0 but the lockfile follows the Node release, so `pnpm install --frozen-lockfile` stays red and this PR stays draft until 6.28.0 is published and the lockfile commit lands here; merging before that breaks install for every contributor and CI. Locally, checks and the live calls ran against a pack of that branch.

Live calls against staging through the built CLI. First a draft source, then a sent one; each copy is inspected and deleted:

```
$ node dist/cli.cjs broadcasts duplicate e6bd3843-3cc7-4c0d-b7fd-e01cbb514a16 --json
{
  "object": "broadcast",
  "id": "cedfd557-a42c-4182-9ee6-b0ec7afcafb2"
}

$ node dist/cli.cjs broadcasts get cedfd557-a42c-4182-9ee6-b0ec7afcafb2 --json | node -e 'const b=JSON.parse(require("fs").readFileSync(0,"utf8")); console.log(JSON.stringify({id:b.id,name:b.name,status:b.status,segment_id:b.segment_id,from:b.from,subject:b.subject,reply_to:b.reply_to,preview_text:b.preview_text,html_length:(b.html||"").length}))'
{"id":"cedfd557-a42c-4182-9ee6-b0ec7afcafb2","name":"Untitled (copy)","status":"draft","segment_id":"7ce6a143-b076-4291-80c3-445042a4b7d9","from":"Test <test@resend.cloud>","subject":"Another day another test","reply_to":null,"preview_text":null,"html_length":1776}

$ node dist/cli.cjs broadcasts delete cedfd557-a42c-4182-9ee6-b0ec7afcafb2 --yes
{
  "object": "broadcast",
  "id": "cedfd557-a42c-4182-9ee6-b0ec7afcafb2",
  "deleted": true
}
```

```
$ node dist/cli.cjs broadcasts get ca3652ea-09be-4e3e-8caa-52da40702c36 --json | jq '{id, name, status, sent_at}'
{
  "id": "ca3652ea-09be-4e3e-8caa-52da40702c36",
  "name": "Untitled",
  "status": "sent",
  "sent_at": "2026-09-10 17:31:08.00087+00"
}

$ node dist/cli.cjs broadcasts duplicate ca3652ea-09be-4e3e-8caa-52da40702c36 --json
{
  "object": "broadcast",
  "id": "6ccb36ec-1833-4df4-8eea-e86a9efc6dd3"
}

$ node dist/cli.cjs broadcasts get 6ccb36ec-1833-4df4-8eea-e86a9efc6dd3 --json | jq '{id, name, status, segment_id, from, subject, reply_to, preview_text, html: (.html | length)}'
{
  "id": "6ccb36ec-1833-4df4-8eea-e86a9efc6dd3",
  "name": "Untitled (copy)",
  "status": "draft",
  "segment_id": "6f31db6f-41f8-4ee9-9ead-c70124822534",
  "from": "Test <test@resend.cloud>",
  "subject": "Why is an unsubscribe link important when sending marketing emails?",
  "reply_to": null,
  "preview_text": null,
  "html": 4722
}

$ node dist/cli.cjs broadcasts delete 6ccb36ec-1833-4df4-8eea-e86a9efc6dd3 --yes
{
  "object": "broadcast",
  "id": "6ccb36ec-1833-4df4-8eea-e86a9efc6dd3",
  "deleted": true
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


